### PR TITLE
NWN: Fix texturing of non-human parts-based models

### DIFF
--- a/src/engines/nwn/creature.cpp
+++ b/src/engines/nwn/creature.cpp
@@ -295,6 +295,7 @@ void Creature::constructModelName(const Common::UString &type, uint32 id,
 }
 
 // Based on filenames in model2.bif
+// These should be read from MDLNAME, NODENAME in capart.2da (in 2da.bif)
 static const char *kBodyPartModels[] = {
 	"head"  ,
 	"neck"  ,

--- a/src/graphics/aurora/model_nwn.cpp
+++ b/src/graphics/aurora/model_nwn.cpp
@@ -652,9 +652,6 @@ void ModelNode_NWN_Binary::readMesh(Model_NWN::ParserContext &ctx) {
 		textureCount = 4;
 	}
 
-	if ((textureCount > 0) && !ctx.texture.empty())
-		textures[0] = ctx.texture;
-
 	textures.resize(textureCount);
 	loadTextures(textures);
 


### PR DESCRIPTION
For some reason the loading code was overwriting the texture with an invalid value. This fixes that problem.
