### PR TITLE
Escape file path when using regex file lookup.

### DIFF
--- a/src/aurora/resman.cpp
+++ b/src/aurora/resman.cpp
@@ -197,7 +197,7 @@ Common::UString ResourceManager::findArchive(const Common::UString &file,
 
 	Common::UString realName;
 	for (DirectoryList::const_iterator dir = dirs.begin(); dir != dirs.end(); ++dir) {
-		Common::UString escapedPath = Common::FilePath::normalize(*dir) + "/" + escapedFile;
+		Common::UString escapedPath = Common::FilePath::escapeStringLiteral(Common::FilePath::normalize(*dir)) + "/" + escapedFile;
 		if (!(realName = nameMatch.findFirst(escapedPath, true)).empty())
 			return realName;
 	}


### PR DESCRIPTION
This is to fix path lookup breakage when the path contains regex tokens.
