### PR TITLE
KOTOR: Add difficulty setting

### DIFF
--- a/src/engines/kotor/gui/main/options.cpp
+++ b/src/engines/kotor/gui/main/options.cpp
@@ -30,11 +30,12 @@
 #include "engines/aurora/widget.h"
 
 #include "engines/kotor/gui/main/options.h"
-#include <engines/kotor/gui/options/gameplay.h>
-#include <engines/kotor/gui/options/feedback.h>
-#include <engines/kotor/gui/options/autopause.h>
-#include <engines/kotor/gui/options/graphics.h>
-#include <engines/kotor/gui/options/sound.h>
+#include "engines/kotor/gui/options/gameplay.h"
+#include "engines/kotor/gui/options/feedback.h"
+#include "engines/kotor/gui/options/autopause.h"
+#include "engines/kotor/gui/options/graphics.h"
+#include "engines/kotor/gui/options/sound.h"
+#include "gui/widgets/kotorwidget.h"
 
 namespace Engines {
 
@@ -48,6 +49,7 @@ OptionsMenu::OptionsMenu() {
 	_autopause = new OptionsAutoPauseMenu();
 	_graphics = new OptionsGraphicsMenu();
 	_sound = new OptionsSoundMenu();
+	
 }
 
 OptionsMenu::~OptionsMenu() {
@@ -85,10 +87,16 @@ void OptionsMenu::callbackActive(Widget &widget) {
 	}
 
 	if (widget.getTag() == "BTN_BACK") {
+		adoptChanges();
 		_returnCode = 1;
 		return;
 	}
 }
+
+void OptionsMenu::adoptChanges() {
+	dynamic_cast<OptionsGameplayMenu*>(_gameplay)->adoptChanges();
+}
+
 
 } // End of namespace KotOR
 

--- a/src/engines/kotor/gui/main/options.h
+++ b/src/engines/kotor/gui/main/options.h
@@ -32,6 +32,8 @@
 
 #include "engines/kotor/gui/gui.h"
 
+#include "gui/options/gameplay.h"
+
 namespace Engines {
 
 namespace KotOR {
@@ -45,6 +47,8 @@ protected:
 	void callbackActive(Widget &widget);
 
 private:
+	void adoptChanges();
+	
 	GUI *_gameplay;
 	GUI *_feedback;
 	GUI *_autopause;

--- a/src/engines/kotor/gui/options/gameplay.h
+++ b/src/engines/kotor/gui/options/gameplay.h
@@ -30,7 +30,7 @@
 #ifndef OPTIONSGAMEPLAY_H
 #define OPTIONSGAMEPLAY_H
 
-#include <engines/kotor/gui/gui.h>
+#include "engines/kotor/gui/gui.h"
 
 namespace Engines {
 
@@ -40,11 +40,19 @@ class OptionsGameplayMenu : public GUI {
 public:
 	OptionsGameplayMenu();
 	~OptionsGameplayMenu();
+	
 
+	void show();
+	
+	void adoptChanges();
 protected:
 	void callbackActive(Widget &widget);
 
 private:
+  	int _difficulty;
+	
+	void updateDifficulty(int difficulty);
+	
 	GUI *_mousesettings;
 	GUI *_keyboardconfiguration;
 };

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -154,14 +154,14 @@ void KotORWidget::load(const Aurora::GFFStruct &gff) {
 	gff.getVector("COLOR", _r, _g, _b);
 	_a = gff.getDouble("ALPHA", 1.0);
 
-	Extend extend = getExtend(gff);
+	Extend extend = createExtend(gff);
 
 	_width  = extend.w;
 	_height = extend.h;
 
 	Widget::setPosition(extend.x, extend.y, 0.0);
 
-	Border border = getBorder(gff);
+	Border border = createBorder(gff);
 
 	_quad = new Graphics::Aurora::GUIQuad(border.fill, 0.0, 0.0, extend.w, extend.h);
 	_quad->setPosition(extend.x, extend.y, 0.0);
@@ -171,7 +171,7 @@ void KotORWidget::load(const Aurora::GFFStruct &gff) {
 	if (border.fill.empty())
 		_quad->setColor(0.0, 0.0, 0.0, 0.0);
 
-	Text text = getText(gff);
+	Text text = createText(gff);
 
 	if (!text.text.empty() && !text.font.empty()) {
 		_text = new Graphics::Aurora::Text(FontMan.get(text.font), text.text,
@@ -180,6 +180,7 @@ void KotORWidget::load(const Aurora::GFFStruct &gff) {
 		const float hspan = extend.w - _text->getWidth();
 		const float vspan = extend.h - _text->getHeight();
 
+		
 		const float x = extend.x + text.halign * hspan;
 		const float y = extend.y + text.valign * vspan;
 
@@ -189,7 +190,29 @@ void KotORWidget::load(const Aurora::GFFStruct &gff) {
 	}
 }
 
-KotORWidget::Extend KotORWidget::getExtend(const Aurora::GFFStruct &gff) {
+void KotORWidget::setColor(float r, float g, float b, float a) {
+		_quad->setColor(r, g, b, a);
+}
+
+void KotORWidget::setText(const Common::UString &text) {
+  		float extendX, extendY, extendZ, textX, textY, textZ;
+		Widget::getPosition(extendX, extendY, extendZ);
+		_text->getPosition(textX, textY, textZ);
+
+		const float halign = (textX - extendX) / (_width - _text->getWidth());
+		const float valign = (textY - extendY) / (_height - _text->getHeight());
+		 _text->set(text);
+		 
+		const float hspan = _width - _text->getWidth();
+		const float vspan = _height - _text->getHeight();
+
+		const float x = extendX + halign * hspan;
+		const float y = extendY + valign * vspan;
+
+		_text->setPosition(x, y, -1.0);
+}
+
+KotORWidget::Extend KotORWidget::createExtend(const Aurora::GFFStruct &gff) {
 	Extend extend;
 
 	if (gff.hasField("EXTENT")) {
@@ -204,7 +227,7 @@ KotORWidget::Extend KotORWidget::getExtend(const Aurora::GFFStruct &gff) {
 	return extend;
 }
 
-KotORWidget::Border KotORWidget::getBorder(const Aurora::GFFStruct &gff) {
+KotORWidget::Border KotORWidget::createBorder(const Aurora::GFFStruct &gff) {
 	Border border;
 
 	if (gff.hasField("BORDER")) {
@@ -222,11 +245,10 @@ KotORWidget::Border KotORWidget::getBorder(const Aurora::GFFStruct &gff) {
 
 		border.pulsing = b.getBool("PULSING");
 	}
-
 	return border;
 }
 
-KotORWidget::Text KotORWidget::getText(const Aurora::GFFStruct &gff) {
+KotORWidget::Text KotORWidget::createText(const Aurora::GFFStruct &gff) {
 	Text text;
 
 	if (gff.hasField("TEXT")) {

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -61,6 +61,8 @@ public:
 	float getHeight() const;
 
 	void setFill(const Common::UString &fill);
+	void setColor(float r, float g, float b, float a);
+	void setText(const Common::UString &text);
 
 protected:
 	struct Extend {
@@ -87,7 +89,7 @@ protected:
 
 		Border();
 	};
-
+ 
 	struct Text {
 		Common::UString font;
 		Common::UString text;
@@ -115,9 +117,9 @@ protected:
 	Graphics::Aurora::Text    *_text;
 
 
-	Extend getExtend(const Aurora::GFFStruct &gff);
-	Border getBorder(const Aurora::GFFStruct &gff);
-	Text   getText  (const Aurora::GFFStruct &gff);
+	Extend createExtend(const Aurora::GFFStruct &gff);
+	Border createBorder(const Aurora::GFFStruct &gff);
+	Text   createText  (const Aurora::GFFStruct &gff);
 };
 
 } // End of namespace KotOR


### PR DESCRIPTION
This adds a difficulty setting to the gameplay menu. It also loads any existing difficulty setting in .xoreosrc, and will persist the selected difficultly to that file as well. The persistence happens when the user hits "close" from the base options menu, which is also when the real game saves options.
