### PR TITLE
GRAPHICS: Remove superfluous warning about model tcoords.

### DIFF
--- a/src/graphics/aurora/model_nwn.cpp
+++ b/src/graphics/aurora/model_nwn.cpp
@@ -1098,9 +1098,6 @@ void ModelNode_NWN_ASCII::load(Model_NWN::ParserContext &ctx,
 
 			readVCoords(ctx, mesh);
 		} else if (line[0] == "tverts") {
-			if (mesh.tCount != 0)
-				warning("ModelNode_NWN_ASCII::load(): Multiple texture coordinates!");
-
 			line[1].parse(mesh.tCount);
 
 			readTCoords(ctx, mesh);


### PR DESCRIPTION
Most, if not all, models have got texture coordinates. One could eventually warn about a model having none, as the loading code expects them.
