### PR TITLE
Fix include guard define in "fps.h"

### DIFF
--- a/src/graphics/aurora/fps.h
+++ b/src/graphics/aurora/fps.h
@@ -28,7 +28,7 @@
  */
 
 #ifndef GRAPHICS_AURORA_FPS_H
-#define GRAPHICS_AURORA_FPST_H
+#define GRAPHICS_AURORA_FPS_H
 
 #include "events/notifyable.h"
 


### PR DESCRIPTION
Guess this was a typo.
