### PR TITLE
KOTOR: enable free look using the right mouse button

### DIFF
--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -315,9 +315,16 @@ void Module::handleEvents() {
 }
 
 bool Module::handleCamera(const Events::Event &e) {
-	if (e.type != Events::kEventKeyDown)
-		return false;
 
+	if (e.type == Events::kEventKeyDown)
+		return handleCameraKeyboardInput(e);
+	else if (e.type == Events::kEventMouseMove)
+		return handleCameraMouseInput(e);
+
+	return false;
+}
+
+bool Module::handleCameraKeyboardInput(const Events::Event &e) {
 	if (e.key.keysym.sym == SDLK_UP)
 		CameraMan.move( 0.5);
 	else if (e.key.keysym.sym == SDLK_DOWN)
@@ -351,6 +358,16 @@ bool Module::handleCamera(const Events::Event &e) {
 
 		CameraMan.setOrientation(0.0, orient[1], orient[2]);
 	} else
+		return false;
+
+	return true;
+}
+
+bool Module::handleCameraMouseInput(const Events::Event &e) {
+	// Holding down the right mouse button enables free look.
+	if (e.motion.state & SDL_BUTTON(3))
+		CameraMan.turn(-0.5 * e.motion.yrel, 0.5 * e.motion.xrel, 0.0);
+	else
 		return false;
 
 	return true;

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -106,6 +106,8 @@ protected:
 
 	void handleEvents();
 	bool handleCamera(const Events::Event &e);
+	bool handleCameraKeyboardInput(const Events::Event &e);
+	bool handleCameraMouseInput(const Events::Event &e);
 
 	virtual Area *createArea() const;
 


### PR DESCRIPTION
Not sure how useful this is for later gaming but flying through the levels is a lot more fun with the mouse :-)
