### PR TITLE
NWN: Fix an uninitialized pointer.

### DIFF
--- a/src/engines/nwn/gui/widgets/tooltip.cpp
+++ b/src/engines/nwn/gui/widgets/tooltip.cpp
@@ -129,7 +129,7 @@ void Tooltip::addLine(const Common::UString &text, float r, float g, float b, fl
 		_lines.back().b    = b;
 		_lines.back().a    = a;
 		_lines.back().line = *l;
-		_lines.back().text = new Graphics::Aurora::Text(FontMan.get(getFontName()), *l);
+		_lines.back().text = new Graphics::Aurora::Text(FontMan.get(getFontName()), *l, r, g, b, a);
 		_lines.back().text->setTag("Tooltip#Text");
 	}
 


### PR DESCRIPTION
The Aurora::Graphics::Text in the tooltip widget of nwn is not initialized properly. 
Even if is initialized afterwards (in redoLayout()), it causes a severe crash on 
an OSX system by losing the tooltip adress.

By the way, it seems that in the structure Line in tooltip.h the UString line is
almost unused and redundant with the Aurora::Graphics::Text which already
contains the string.
