### PR TITLE
GRAPHICS: Use new[] instead of malloc()

### DIFF
--- a/src/graphics/indexbuffer.cpp
+++ b/src/graphics/indexbuffer.cpp
@@ -38,7 +38,7 @@ IndexBuffer::IndexBuffer(const IndexBuffer &other) : _data(0), _ibo(0), _hint(GL
 
 IndexBuffer::~IndexBuffer() {
 	destroyGL();
-	std::free(_data);
+	delete[] _data;
 }
 
 IndexBuffer &IndexBuffer::operator=(const IndexBuffer &other) {
@@ -55,11 +55,11 @@ void IndexBuffer::setSize(uint32 indexCount, uint32 indexSize, GLenum indexType)
 	_size  = indexSize;
 	_type  = indexType;
 
-	std::free(_data);
+	delete[] _data;
 	_data = 0;
 
 	if (_count && _size) {
-		_data = (byte *)(std::malloc(_count * _size));  // Ensures correct alignment.
+		_data = new byte[_count * _size];
 	}
 }
 

--- a/src/graphics/vertexbuffer.cpp
+++ b/src/graphics/vertexbuffer.cpp
@@ -38,7 +38,7 @@ VertexBuffer::VertexBuffer(const VertexBuffer &other) : _data(0), _vbo(0) {
 
 VertexBuffer::~VertexBuffer() {
 	destroyGL(); // Dangerous if GL components not already freed and we're not in the GL context thread.
-	std::free(_data);
+	delete[] _data;
 }
 
 VertexBuffer &VertexBuffer::operator=(const VertexBuffer &other) {
@@ -67,11 +67,11 @@ void VertexBuffer::setSize(uint32 vertCount, uint32 vertSize) {
 	_count = vertCount;
 	_size  = vertSize;
 
-	std::free(_data);
+	delete[] _data;
 	_data = 0;
 
 	if (_count && _size) {
-		_data = (byte *)(std::malloc(_count * _size));  // Ensures correct alignment.
+		_data = new byte[_count * _size];
 	}
 }
 


### PR DESCRIPTION
Index and vertex buffers can safely use new[] instead of malloc
and not run into alignment issues.