### PR TITLE
GRAPHICS: Texture base class _textureID

### DIFF
--- a/src/graphics/aurora/texture.cpp
+++ b/src/graphics/aurora/texture.cpp
@@ -49,7 +49,7 @@ namespace Graphics {
 
 namespace Aurora {
 
-Texture::Texture(const Common::UString &name) : _textureID(0),
+Texture::Texture(const Common::UString &name) :
 	_type(::Aurora::kFileTypeNone), _image(0), _txi(0), _width(0), _height(0) {
 
 	_txi = new TXI();
@@ -66,7 +66,7 @@ Texture::Texture(const Common::UString &name) : _textureID(0),
 	addToQueue(kQueueNewTexture);
 }
 
-Texture::Texture(ImageDecoder *image, const TXI *txi) : _textureID(0),
+Texture::Texture(ImageDecoder *image, const TXI *txi) :
 	_type(::Aurora::kFileTypeNone), _image(0), _txi(0), _width(0), _height(0) {
 
 	if (txi)
@@ -95,10 +95,6 @@ Texture::~Texture() {
 
 	delete _txi;
 	delete _image;
-}
-
-TextureID Texture::getID() const {
-	return _textureID;
 }
 
 uint32 Texture::getWidth() const {

--- a/src/graphics/aurora/texture.h
+++ b/src/graphics/aurora/texture.h
@@ -81,8 +81,6 @@ protected:
 private:
 	Common::UString _name;
 
-	TextureID _textureID; ///< OpenGL texture ID.
-
 	::Aurora::FileType _type; ///< The texture's image's file type.
 
 	ImageDecoder *_image; ///< The actual image.
@@ -96,8 +94,6 @@ private:
 
 	void loadTXI(Common::SeekableReadStream *stream);
 	void loadImage();
-
-	TextureID getID() const;
 
 	friend class TextureManager;
 };

--- a/src/graphics/texture.cpp
+++ b/src/graphics/texture.cpp
@@ -31,10 +31,14 @@
 
 namespace Graphics {
 
-Texture::Texture() {
+Texture::Texture() : _textureID(0) {
 }
 
 Texture::~Texture() {
+}
+
+TextureID Texture::getID() const {
+	return _textureID;
 }
 
 } // End of namespace Graphics

--- a/src/graphics/texture.h
+++ b/src/graphics/texture.h
@@ -36,6 +36,11 @@ class Texture : public GLContainer {
 public:
 	Texture();
 	~Texture();
+
+	TextureID getID() const;
+
+protected:
+	TextureID _textureID; ///< OpenGL texture ID.
 };
 
 } // End of namespace Graphics


### PR DESCRIPTION
Interfaces necessary for OpenGL promoted to the texture base class.
The reasoning behind this is to allow shader samplers to reference
a texture directly instead of only relying on the OpenGL handle.
This easily allows the texture to be reloaded without needing to
synchronise any ShaderMaterial that might be using the texture.