### PR TITLE
GRAPHICS: ShaderSampler direct texture pointer

### DIFF
--- a/src/graphics/shader/shader.cpp
+++ b/src/graphics/shader/shader.cpp
@@ -170,57 +170,57 @@ void ShaderManager::bindShaderVariable(ShaderObject::ShaderObjectVariable &var, 
 		case SHADER_SAMPLER1D:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_1D, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_1D, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER2D:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_2D, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_2D, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER3D:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_3D, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_3D, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLERCUBE:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_CUBE_MAP, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_CUBE_MAP, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER1DSHADOW:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER2DSHADOW:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_2D, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_2D, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER1DARRAY:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER2DARRAY:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER1DARRAYSHADOW:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_1D_ARRAY, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLER2DARRAYSHADOW:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_SAMPLERBUFFER:
 			glUniform1i(loc, static_cast<const ShaderSampler *>(data)->unit);
 			glActiveTexture(GL_TEXTURE0 + static_cast<const ShaderSampler *>(data)->unit);
-			glBindTexture(GL_TEXTURE_BUFFER, static_cast<const ShaderSampler *>(data)->glid);
+			glBindTexture(GL_TEXTURE_BUFFER, static_cast<const ShaderSampler *>(data)->texture->getID());
 			break;
 		case SHADER_ISAMPLER1D: break;
 		case SHADER_ISAMPLER2D: break;

--- a/src/graphics/shader/shader.h
+++ b/src/graphics/shader/shader.h
@@ -68,6 +68,7 @@
 #include <map>
 
 #include "src/graphics/types.h"
+#include "src/graphics/texture.h"
 
 #include "src/common/types.h"
 #include "src/common/singleton.h"
@@ -179,10 +180,10 @@ struct ShaderUBO {
  *  must specify the unit to use.
  */
 struct ShaderSampler {
-	GLuint glid;
+	Texture *texture;
 	uint32 unit;
-	ShaderSampler() : glid(0), unit(0) {}
-	ShaderSampler(GLuint id, uint32 t) : glid(id), unit(t) {}
+	ShaderSampler() : texture(0), unit(0) {}
+	ShaderSampler(Texture *t, uint32 u) : texture(t), unit(u) {}
 };
 
 

--- a/src/graphics/shader/shadermaterial.cpp
+++ b/src/graphics/shader/shadermaterial.cpp
@@ -165,7 +165,7 @@ void ShaderMaterial::recalcTextureUnits() {
 			case SHADER_SAMPLER3D:
 			case SHADER_SAMPLERCUBE:
 				if (!(_variableData[i].flags & SHADER_MATERIAL_VARIABLE_OWNED)) {
-					unit |= (1 << (static_cast<ShaderMaterial::ShaderMaterialSampler *>(_variableData[i].data)->sampler.unit));
+					unit |= (1 << (static_cast<Shader::ShaderSampler *>(_variableData[i].data)->unit));
 				}
 			break;
 			default: break;
@@ -188,7 +188,7 @@ void ShaderMaterial::recalcTextureUnits() {
 							break;
 						}
 					}
-					static_cast<ShaderMaterialSampler *>(_variableData[i].data)->sampler.unit = textureUnit;
+					static_cast<Shader::ShaderSampler *>(_variableData[i].data)->unit = textureUnit;
 				}
 				break;
 			default: break;
@@ -293,7 +293,7 @@ void *ShaderMaterial::genMaterialVar(uint32 index) {
 		case SHADER_SAMPLER1D:
 		case SHADER_SAMPLER2D:
 		case SHADER_SAMPLER3D:
-		case SHADER_SAMPLERCUBE: rval = new ShaderMaterial::ShaderMaterialSampler(); break;
+		case SHADER_SAMPLERCUBE: rval = new Shader::ShaderSampler(); break;
 		case SHADER_SAMPLER1DSHADOW: break;
 		case SHADER_SAMPLER2DSHADOW: break;
 		case SHADER_SAMPLER1DARRAY:  break;
@@ -358,7 +358,7 @@ void ShaderMaterial::delMaterialVar(uint32 index)
 			// todo: link in texture usage count properly here.
 			//if(static_cast<ShaderMaterial::ShaderMaterialSampler *>(data)->texture != 0)
 			//	static_cast<ShaderMaterial::ShaderMaterialSampler *>(data)->texture->_usageCount--;
-			delete (static_cast<ShaderMaterial::ShaderMaterialSampler *>(data));
+			delete (static_cast<Shader::ShaderSampler *>(data));
 		break;
 		case SHADER_SAMPLER1DSHADOW: break;
 		case SHADER_SAMPLER2DSHADOW: break;

--- a/src/graphics/shader/shadermaterial.h
+++ b/src/graphics/shader/shadermaterial.h
@@ -26,7 +26,6 @@
 #define GRAPHICS_SHADER_SHADERMATERIAL_H
 
 #include "src/graphics/shader/shader.h"
-#include "src/graphics/aurora/textureman.h"
 
 namespace Graphics {
 
@@ -53,14 +52,6 @@ namespace Shader {
 
 class ShaderMaterial {
 public:
-
-	struct ShaderMaterialSampler {
-		Shader::ShaderSampler sampler;
-		Graphics::Aurora::Texture *texture; // Needed for proper resource management, e.g usage count.
-
-		ShaderMaterialSampler() : sampler(), texture(0) {}
-	};
-
 	uint32 _usageCount; // TODO: move this elsewhere please.
 
 	ShaderMaterial(Shader::ShaderObject *fragShader, const Common::UString &name = "unnamed");


### PR DESCRIPTION
ShaderSampler directly points to a texture object, allowing the
GL handler id to be accessed without any kind of synchronisation.

This also means no special "ShaderMaterialSampler" is required.