### PR TITLE
Warnings cleanup

### DIFF
--- a/src/aurora/erffile.cpp
+++ b/src/aurora/erffile.cpp
@@ -86,7 +86,7 @@ void ERFFile::load() {
 
 			if (!_noResources)
 				readResources(erf, erfHeader);
-		} catch (Common::Exception &e) {
+		} catch (Common::Exception &/*e*/) {
 			delete[] erfHeader.stringTable;
 			throw;
 		}
@@ -419,7 +419,7 @@ Common::SeekableReadStream *ERFFile::decompressBiowareZlib(byte *compressedData,
 		Common::SeekableReadStream *stream = decompressZlib(compressedData + 1, packedSize - 1, unpackedSize, *compressedData >> 4);
 		delete[] compressedData;
 		return stream;
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		delete[] compressedData;
 		throw;
 	}
@@ -430,7 +430,7 @@ Common::SeekableReadStream *ERFFile::decompressHeaderlessZlib(byte *compressedDa
 		Common::SeekableReadStream *stream = decompressZlib(compressedData, packedSize, unpackedSize, MAX_WBITS);
 		delete[] compressedData;
 		return stream;
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		delete[] compressedData;
 		throw;
 	}

--- a/src/aurora/gff4file.cpp
+++ b/src/aurora/gff4file.cpp
@@ -256,11 +256,11 @@ GFF4Struct::Field::Field() : label(0), type(kIFieldTypeNone), offset(0xFFFFFFFF)
 }
 
 GFF4Struct::Field::Field(uint32 l, uint16 t, uint16 f, uint32 o) : label(l), offset(o) {
-	isList      = f & 0x8000;
-	isReference = f & 0x2000;
+	isList      = (f & 0x8000) != 0;
+	isReference = (f & 0x2000) != 0;
 
 	// Map the struct flag to the struct type and index, if necessary
-	const bool isStruct = f & 0x4000;
+	const bool isStruct = (f & 0x4000) != 0;
 	if (isStruct) {
 		type        = kIFieldTypeStruct;
 		structIndex = t;

--- a/src/aurora/nwscript/ncsfile.cpp
+++ b/src/aurora/nwscript/ncsfile.cpp
@@ -396,7 +396,7 @@ bool NCSFile::executeStep() {
 
 	try {
 		(this->*(_opcodes[opcode].proc))((InstructionType)type);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 
@@ -590,7 +590,7 @@ void NCSFile::o_logand(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg1 && arg2);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -603,7 +603,7 @@ void NCSFile::o_logor(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg1 || arg2);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -616,7 +616,7 @@ void NCSFile::o_incor(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg1 | arg2);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -629,7 +629,7 @@ void NCSFile::o_excor(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg1 ^ arg2);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -642,7 +642,7 @@ void NCSFile::o_booland(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg1 && arg2);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -674,7 +674,7 @@ void NCSFile::o_geq(InstructionType type) {
 				int32 arg1 = _stack.pop().getInt();
 				int32 arg2 = _stack.pop().getInt();
 				_stack.push(arg2 >= arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -684,7 +684,7 @@ void NCSFile::o_geq(InstructionType type) {
 				float arg1 = _stack.pop().getFloat();
 				float arg2 = _stack.pop().getFloat();
 				_stack.push(arg2 >= arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -701,7 +701,7 @@ void NCSFile::o_gt(InstructionType type) {
 				int32 arg1 = _stack.pop().getInt();
 				int32 arg2 = _stack.pop().getInt();
 				_stack.push(arg2 > arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -711,7 +711,7 @@ void NCSFile::o_gt(InstructionType type) {
 				float arg1 = _stack.pop().getFloat();
 				float arg2 = _stack.pop().getFloat();
 				_stack.push(arg2 > arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -728,7 +728,7 @@ void NCSFile::o_lt(InstructionType type) {
 				int32 arg1 = _stack.pop().getInt();
 				int32 arg2 = _stack.pop().getInt();
 				_stack.push(arg2 < arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -738,7 +738,7 @@ void NCSFile::o_lt(InstructionType type) {
 				float arg1 = _stack.pop().getFloat();
 				float arg2 = _stack.pop().getFloat();
 				_stack.push(arg2 < arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -755,7 +755,7 @@ void NCSFile::o_leq(InstructionType type) {
 				int32 arg1 = _stack.pop().getInt();
 				int32 arg2 = _stack.pop().getInt();
 				_stack.push(arg2 <= arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -765,7 +765,7 @@ void NCSFile::o_leq(InstructionType type) {
 				float arg1 = _stack.pop().getFloat();
 				float arg2 = _stack.pop().getFloat();
 				_stack.push(arg2 <= arg1);
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -783,7 +783,7 @@ void NCSFile::o_shleft(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg2 << arg1);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -796,7 +796,7 @@ void NCSFile::o_shright(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg2 >> arg1);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -811,7 +811,7 @@ void NCSFile::o_ushright(InstructionType type) {
 		int32 arg1 = _stack.pop().getInt();
 		int32 arg2 = _stack.pop().getInt();
 		_stack.push(arg2 >> arg1);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -830,7 +830,7 @@ void NCSFile::o_mod(InstructionType type) {
 			throw Common::Exception("NCSFile::o_mod(): Modulus by negative number (%d %% %d)", arg2, arg1);
 
 		_stack.push(arg2 % arg1);
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }
@@ -840,7 +840,7 @@ void NCSFile::o_neg(InstructionType type) {
 		case kInstTypeInt:
 			try {
 				_stack.push(-_stack.pop().getInt());
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -848,7 +848,7 @@ void NCSFile::o_neg(InstructionType type) {
 		case kInstTypeFloat:
 			try {
 				_stack.push(-_stack.pop().getFloat());
-			} catch (Common::Exception &e) {
+			} catch (Common::Exception &/*e*/) {
 				throw;
 			}
 			break;
@@ -864,7 +864,7 @@ void NCSFile::o_comp(InstructionType type) {
 
 	try {
 		_stack.push(~_stack.pop().getInt());
-	} catch (Common::Exception &e) {
+	} catch (Common::Exception &/*e*/) {
 		throw;
 	}
 }

--- a/src/common/foxpro.cpp
+++ b/src/common/foxpro.cpp
@@ -94,7 +94,7 @@ void FoxPro::loadHeader(SeekableReadStream &dbf, uint32 &recordSize, uint32 &rec
 	byte flags = dbf.readByte();
 
 	_hasIndex = flags & 0x01;
-	_hasMemo  = flags & 0x02;
+	_hasMemo  = (flags & 0x02) != 0;
 
 	if (flags & 0x04)
 		throw Exception("DBC unsupported");

--- a/src/common/system.h
+++ b/src/common/system.h
@@ -84,6 +84,8 @@
 		#define WIN32
 	#endif
 
+	#define IGNORE_UNUSED_VARIABLES __pragma(warning(disable : 4101))
+
 #elif defined(__MINGW32__)
 
 	#define XOREOS_LITTLE_ENDIAN

--- a/src/engines/nwn/gui/chargen/charalignment.cpp
+++ b/src/engines/nwn/gui/chargen/charalignment.cpp
@@ -139,7 +139,7 @@ void CharAlignment::setRestrict() {
 	const Aurora::TwoDARow &row = twodaClasses.getRow(_choices->getClass());
 
 	uint alignRestrict = row.getInt("AlignRestrict");
-	bool invertRestrict = row.getInt("InvertRestrict");
+	bool invertRestrict = row.getInt("InvertRestrict") != 0;
 
 	// Build restriction axis.
 	uint axisRestrict[5] = { 0x01, 0x02, 0x04, 0x08, 0x10 };

--- a/src/engines/nwn/script/functions_300.cpp
+++ b/src/engines/nwn/script/functions_300.cpp
@@ -845,9 +845,9 @@ void ScriptFunctions::addJournalQuestEntry(Aurora::NWScript::FunctionContext &ct
 
 	Creature *pc = convertPC(ctx.getParams()[2].getObject());
 
-	bool allPartyMembers = ctx.getParams()[3].getInt();
-	bool allPlayers      = ctx.getParams()[4].getInt();
-	bool allowOverride   = ctx.getParams()[5].getInt();
+	bool allPartyMembers = ctx.getParams()[3].getInt() != 0;
+	bool allPlayers      = ctx.getParams()[4].getInt() != 0;
+	bool allowOverride   = ctx.getParams()[5].getInt() != 0;
 
 	warning("TODO: AddJournalQuestEntry: %s: \"%s\" to %d (%d, %d, %d)", gTag(pc).c_str(),
 	        plot.c_str(), state, allPartyMembers, allPlayers, allowOverride);

--- a/src/engines/witcher/campaign.cpp
+++ b/src/engines/witcher/campaign.cpp
@@ -146,7 +146,7 @@ void Campaign::loadCampaignFile(const CampaignDescription &desc) {
 
 			file = new Common::File(desc.file);
 			gff  = new Aurora::GFF3File(file, MKTAG('M', 'M', 'D', ' '));
-		} catch (Common::Exception &e) {
+		} catch (Common::Exception &/*e*/) {
 			delete file;
 			throw;
 		}

--- a/src/graphics/aurora/model_jade.cpp
+++ b/src/graphics/aurora/model_jade.cpp
@@ -334,10 +334,10 @@ void ModelNode_Jade::readMesh(Model_Jade::ParserContext &ctx) {
 	uint32 transparencyHint = ctx.mdl->readUint32LE();
 	uint16 flags            = ctx.mdl->readUint16LE();
 
-	_shadow = ctx.mdl->readUint16LE();
+	_shadow = ctx.mdl->readUint16LE() != 0;
 
-	_render  = flags & kNodeFlagsRender;
-	_beaming = flags & kNodeFlagsBeaming;
+	_render  = (flags & kNodeFlagsRender) != 0;
+	_beaming = (flags & kNodeFlagsBeaming) != 0;
 
 	_hasTransparencyHint = true;
 	_transparencyHint    = (transparencyHint == 1);

--- a/src/sound/decoders/asf.cpp
+++ b/src/sound/decoders/asf.cpp
@@ -53,7 +53,7 @@ public:
 	}
 
 	bool operator!=(const ASFGUID &g) const {
-		return memcmp(g.id, id, 16);
+		return memcmp(g.id, id, 16) != 0;
 	}
 
 	Common::UString toString() const {

--- a/src/sound/decoders/wma.cpp
+++ b/src/sound/decoders/wma.cpp
@@ -730,7 +730,7 @@ int WMACodec::decodeBlock(Common::BitStream &bits) {
 
 	bool msStereo = false;
 	if (_channels == 2)
-		msStereo = bits.getBit();
+		msStereo = bits.getBit() != 0;
 
 	// Which channels are encoded?
 
@@ -740,7 +740,7 @@ int WMACodec::decodeBlock(Common::BitStream &bits) {
 		hasChannel[i] = false;
 
 	for (int i = 0; i < _channels; i++) {
-		hasChannel[i] = bits.getBit();
+		hasChannel[i] = bits.getBit() != 0;
 		if (hasChannel[i])
 			hasChannels = true;
 	}

--- a/src/sound/sound.cpp
+++ b/src/sound/sound.cpp
@@ -83,7 +83,7 @@ void SoundManager::init() {
 		if (!_ctx)
 			throw Common::Exception("Could not create OpenAL context");
 
-		_hasMultiChannel = alIsExtensionPresent("AL_EXT_MCFORMATS");
+		_hasMultiChannel = alIsExtensionPresent("AL_EXT_MCFORMATS") != 0;
 		_format51        = alGetEnumValue("AL_FORMAT_51CHN16");
 	}
 

--- a/src/video/bink.cpp
+++ b/src/video/bink.cpp
@@ -571,7 +571,7 @@ void Bink::load() {
 
 	_frames[frameCount - 1].size = _bink->size() - _frames[frameCount - 1].offset;
 
-	_hasAlpha   = _videoFlags & kVideoFlagAlpha;
+	_hasAlpha   = (_videoFlags & kVideoFlagAlpha) != 0;
 	_swapPlanes = (_id == kBIKhID) || (_id == kBIKiID); // BIKh and BIKi swap the chroma planes
 
 	// Give the planes a bit extra space

--- a/src/video/codecs/xmvwmv2.cpp
+++ b/src/video/codecs/xmvwmv2.cpp
@@ -66,7 +66,7 @@ bool XMVWMV2Codec::CBP::empty() const {
 bool XMVWMV2Codec::CBP::isSet(int block) const {
 	assert((block >= 0) && (block < 6));
 
-	return _cbp & (1 << (5 - block));
+	return (_cbp & (1 << (5 - block))) != 0;
 }
 
 void XMVWMV2Codec::CBP::set(int block, bool coded) {
@@ -634,7 +634,7 @@ void XMVWMV2Codec::decodeIBlock(DecodeContext &ctx, BlockContext &block) {
 			} else {
 				// Escape + 00: run and level directly encoded
 
-				done = ctx.bits.getBit();
+				done = ctx.bits.getBit() != 0;
 
 				if (ctx.acRLERunLength == 0) {
 


### PR DESCRIPTION
I am not sure whether you preferred this style (commit 320b772) or instead add IGNORE_UNUSED_VARIABLES macro to these files as well.

The removal suppression of the warnings on MSVC build for all files will be submitted once the CMakefiles are sorted out.

> I would very much appreciate if you could fix these all, i.e. change them all to use != 0 (without #ifdef'ing), and submit a pull request for them, if you don't mind that extra work.

Commit  8acfab5

> if the disabling of these warning is in any way applicable to MSVC, could you maybe add a #define for IGNORE_UNUSED_VARIABLES for MSVC in there?

Commit 9c9dffc