### PR TITLE
COMMON: Avoid endianness redefinition

### DIFF
--- a/src/common/system.h
+++ b/src/common/system.h
@@ -89,7 +89,9 @@
 
 #elif defined(__MINGW32__)
 
-	#define XOREOS_LITTLE_ENDIAN
+	#ifndef XOREOS_LITTLE_ENDIAN
+		#define XOREOS_LITTLE_ENDIAN
+	#endif
 
 	#define PLUGIN_EXPORT __declspec(dllexport)
 


### PR DESCRIPTION
The CMake front-end defines XOREOS_LITTLE_ENDIAN already, if
applicable. This prevents warnings about macro redefinitions.