### PR TITLE
Rewrite manpage to use semantic -mdoc macros.

### DIFF
--- a/man/xoreos.6
+++ b/man/xoreos.6
@@ -1,95 +1,89 @@
-.de URL
-\\$2 \(laURL: \\$1 \(ra\\$3
-..
-.if \n[.g] .mso www.tmac
-
-.hw xoreos
-.hw $XDG\_CONFIG\_HOME-/-xoreos-/-xoreos.conf
-.hw $XDG\_CONFIG\_HOME
-.hw $HOME-/-.config/
-.hw $HOME-/-Library-/-Preferences-/-xoreos-/-xoreos.conf
-.hw xoreos.conf
-.hw $APPDATA
-.hw $USERPROFILE
-
-.TH xoreos 6 2015-07-24 xoreos
-.SH NAME
-xoreos - A reimplementation of BioWare's Aurora engine
-.SH SYNOPSIS
-xoreos [<options>] [<target>]
-.SH DESCRIPTION
-.PP
-.B xoreos
+.Dd July 24, 2015
+.Dt XOREOS 6
+.Os
+.Sh NAME
+.Nm xoreos
+.Nd reimplementation of BioWare's Aurora engine
+.Sh SYNOPSIS
+xoreos
+.Op Ar options
+.Op Ar target
+.Sh DESCRIPTION
+.Nm xoreos
 is an open source implementation of BioWare's Aurora engine and its
 derivatives, licensed under the terms of the GNU General Public
-License version 3 (or later). The goal is to have all games using
-this engines working in a portable manner.
-.PP
-.B The following games are valid targets for xoreos:
-.PD 0
-.IP - 2
+License version 3 (or later).
+The goal is to have all games using this engine working in a portable manner.
+.Pp
+.Sy The following games are valid targets for xoreos:
+.Bl -bullet -compact
+.It
 Neverwinter Nights
-.IP - 2
+.It
 Neverwinter Nights 2
-.IP - 2
+.It
 Knights of the Old Republic
-.IP - 2
+.It
 Knights of the Old Republic II: The Sith Lords
-.IP - 2
+.It
 Jade Empire
-.IP - 2
+.It
 Sonic Chronicles: The Dark Brotherhood
-.IP - 2
+.It
 The Witcher
-.IP - 2
+.It
 Dragon Age: Origins
-.IP - 2
+.It
 Dragon Age II
-.PD
-.SS Running xoreos
+.El
+.Ss Running xoreos
 First, you need to fully install and/or copy the game you want to play
 with
-.B xoreos
-onto your hard disk. How you do this depends on the game, your
-operating system and where/how you have bought the game.
-.PP
-.B xoreos
-does not yet have a launcher GUI or anything like this. You need
-to start it from the command line. Run xoreos with the command line
-option "--help" (without the quotes) to get a help text about further
-command line options.
-.PP
-The quickest way to start a game in path /path/to/game/ would be to call
-.IP "" 4
-.nf
-xoreos -p/path/to/game/
-.fi
-.PP
-If you're on Windows and the path is, say, D:\\Path\\To\\Game\\, call
-.IP "" 4
-.nf
-xoreos -pD:\\Path\\To\\Game\\
-.fi
-.SS Config file
+.Nm
+onto your hard disk.
+How you do this depends on the game,
+your operating system and where/how you have bought the game.
+.Pp
+.Nm
+does not yet have a launcher GUI or anything like this.
+You need to start it from the command line.
+Run xoreos with the command line option
+.Fl Fl help
+to get a help text about further command line options.
+.Pp
+The quickest way to start a game in path
+.Pa /path/to/game/
+would be to call:
+.Pp
+.Dl $ xoreos -p/path/to/game/
+.Pp
+If you're on Windows and the path is, say,
+.Pa D:\ePath\eTo\eGame\e , call :
+.Pp
+.Dl $ xoreos -pD:\ePath\eTo\eGame\e
+.Ss Config file
 In general,
-.B xoreos
+.Nm
 can read the configuration which game to run from either the command
-line, a config file or both. Additionally, when you first specify a
-new game on the command line,
-.B xoreos
+line, a config file or both.
+Additionally, when you first specify a new game on the command line,
+.Nm
 will add a related entry in the config file (creating it first, if
 necessary).
-.PP
+.Pp
 To accurately identify a specific instance of an installed game,
-.B xoreos
-uses the concept of a "target". Each target has a separate section in
-the config file, and each of their options apply only to that target.
-The special target "xoreos" is a global section applying to all games,
+.Nm
+uses the concept of a
+.Dq target .
+Each target has a separate section in the config file,
+and each of their options apply only to that target.
+The special target
+.Dq xoreos
+is a global section applying to all games,
 although the same option in a game target overrides the global option.
-.PP
-.B For example:
-.IP "" 4
-.nf
+.Pp
+.Sy For example:
+.Bd -literal -offset Ds
 [xoreos]
 width=1024
 height=768
@@ -101,220 +95,197 @@ fullscreen=true
 volume_music=0.500000
 volume_sfx=0.850000
 volume_voice=0.850000
-.fi
-.PP
-You can then start the game with the target "nwn" with
-.IP "" 4
-.nf
-xoreos nwn
-.fi
-.PP
+.Ed
+.Pp
+You can then start the game with the target
+.Dq nwn
+with
+.Pp
+.Dl $ xoreos nwn
+.Pp
 and
-.BR xoreos
-will do the rest. This will start the game in the path
-/home/drmccoy/games/nwn/, running it in fullscreen at 1024x768.
-.PP
+.Nm
+will do the rest.
+This will start the game in the path
+.Pa /home/drmccoy/games/nwn/ ,
+running it in fullscreen at 1024\(mu768.
+.Pp
 As you can see with the volume options,
-.BR xoreos
+.Nm
 also saves settings you made in the game' actual GUI into the
 target's section of the config file.
-.PP
+.Pp
 The place where
-.BR xoreos
+.Nm
 expects the config file depends on your operating system:
-.PD 0
-.IP - 2
-On GNU/Linux, the place is $XDG\_CONFIG\_HOME/xoreos/xoreos.conf.
-$XDG\_CONFIG\_HOME defaults to $HOME/.config/
-.IP - 2
-On Mac OS X, the place is $HOME/Library/Preferences/xoreos/xoreos.conf
-.IP - 2
-On Windows, xoreos.conf is in the subdirectory xoreos in either
-$APPDATA or $USERPROFILE, depending on your Windows version
-.PD
-.SH OPTIONS
-.TP 4
-.B --help
+.Bl -bullet -compact
+.It
+On GNU/Linux, the place is
+.Pa $XDG_CONFIG_HOME/xoreos/xoreos.conf .
+.Ev XDG_CONFIG_HOME
+defaults to
+.Pa $HOME/.config/ .
+.It
+On Mac OS X, the place is
+.Pa $HOME/Library/Preferences/xoreos/xoreos.conf .
+.It
+On Windows,
+.Pa xoreos.conf
+is in the subdirectory
+.Pa xoreos
+in either
+.Ev $APPDATA
+or
+.Ev $USERPROFILE ,
+depending on your Windows version.
+.El
+.Sh OPTIONS
+.Bl -tag -width Ds -compact
+.It Fl Fl help
 Show a help text and exit.
-.TP 4
-.B --version
+.It Fl Fl version
 Show version information and exit.
-.TP 4
-.BR -c FILE
-.PD 0
-.TP 4
-.BR --config= FILE
-Load the config from file FILE.
-.PD
-
-
-
-.TP 4
-.BR -p DIR
-.PD 0
-.TP 4
-.BR --path= DIR
-Override the game path with DIR.
-.PD
-.TP 4
-.BR -w SIZE
-.PD 0
-.TP 4
-.BR --width= SIZE
-Set the window's width to SIZE.
-.PD
-.TP 4
-.BR -h SIZE
-.PD 0
-.TP 4
-.BR --height= SIZE
-Set the window's height to SIZE.
-.PD
-.TP 4
-.BR -f BOOL
-.PD 0
-.TP 4
-.BR --fullscreen= BOOL
+.It Fl c Ar file
+.It Fl Fl config= Ns Ar file
+Load the config from file
+.Ar file .
+.It Fl p Ar dir
+.It Fl Fl path= Ns Ar dir
+Override the game path with
+.Ar dir .
+.It Fl w Ar size
+.It Fl Fl width= Ns Ar size
+Set the window's width to
+.Ar size .
+.It Fl h Ar size
+.It Fl Fl height= Ns Ar size
+Set the window's height to
+.Ar size .
+.It Fl f Ar bool
+.It Fl Fl fullscreen= Ns Ar bool
 Switch fullscreen on/off.
-.PD
-.TP 4
-.BR -k BOOL
-.PD 0
-.TP 4
-.BR --skipvideos= BOOL
+.It Fl k Ar bool
+.It Fl Fl skipvideos= Ns Ar bool
 Disable videos on/off.
-.PD
-.TP 4
-.BR -v VOL
-.PD 0
-.TP 4
-.BR --volume= VOL
-Set global volume to VOL.
-.PD
-.TP 4
-.BR -m VOL
-.PD 0
-.TP 4
-.BR --volume_music= VOL
-Set music volume to VOL.
-.PD
-.TP 4
-.BR -s VOL
-.PD 0
-.TP 4
-.BR --volume_sfx= VOL
-Set SFX volume to VOL.
-.PD
-.TP 4
-.BR -o VOL
-.PD 0
-.TP 4
-.BR --volume_voice= VOL
-Set voice volume to VOL.
-.PD
-.TP 4
-.BR -i VOL
-.PD 0
-.TP 4
-.BR --volume_video= VOL
-Set video volume to VOL.
-.PD
-.TP 4
-.BR -q LANG
-.PD 0
-.TP 4
-.BR --lang= LANG
+.It Fl v Ar vol
+.It Fl Fl volume= Ns Ar vol
+Set global volume to
+.Ar vol .
+.It Fl m Ar vol
+.It Fl Fl volume_music= Ns Ar vol
+Set music volume to
+.Ar vol .
+.It Fl s Ar vol
+.It Fl Fl volume_sfx= Ns Ar vol
+Set SFX volume to
+.Ar vol .
+.It Fl o Ar vol
+.It Fl Fl volume_voice= Ns Ar vol
+Set voice volume to
+.Ar vol .
+.It Fl i Ar vol
+.It Fl Fl volume_video= Ns Ar vol
+Set video volume to
+.Ar vol .
+.It Fl q Ar lang
+.It Fl Fl lang= Ns Ar lang
 Set the game's language.
-.PD
-.TP 4
-.BR --langtext= LANG
+.It Fl Fl langtext= Ns Ar lang
 Set the game's text language.
-.TP 4
-.BR --langvoice= LANG
+.It Fl Fl langvoice= Ns Ar lang
 Set the game's voice language.
-.TP 4
-.BR -d LVL
-.PD 0
-.TP 4
-.BR --debuglevel= LVL
-Set the debug level to LVL.
-.PD
-.TP 4
-.BR --debugchannel= CHAN
-Set the enabled debug channel(s) to CHAN.
-.TP 4
-.BR --listdebug
+.It Fl d Ar lvl
+.It Fl Fl debuglevel= Ns Ar lvl
+Set the debug level to
+.Ar lvl .
+.It Fl Fl debugchannel= Ns Ar chan
+Set the enabled debug channel(s) to
+.Ar chan .
+.It Fl Fl listdebug
 List all available debug channels.
-.TP 4
-.BR --listlangs
+.It Fl Fl listlangs
 List all available languages for this target.
-.TP 4
-.BR --logfile= FILE
+.It Fl Fl logfile= Ns Ar file
 Write all debug output into this file too.
-.TP 4
-.BR --nologfile= BOOL
+.It Fl Fl nologfile= Ns Ar bool
 Don't write a log file.
-.TP 4
-.BR --consolelog= FILE
+.It Fl Fl consolelog= Ns Ar file
 Write all debug console output into this file too.
-.TP 4
-.BR --noconsolelog= BOOL
+.It Fl Fl noconsolelog= Ns Ar bool
 Don't write a debug console log file.
-.PP
-.PD 0
-.IP "FILE:" 6
+.El
+.Bl -tag -width Ds
+.It Ar file
 Absolute or relative path to a file.
-.PP
-.IP "FILE:" 6
-Absolute or relative path to a file.
-.IP "DIR:" 6
+.It Ar dir
 Absolute or relative path to a directory.
-.IP "SIZE:" 6
+.It Ar size
 A positive integer.
-.IP "BOOL:" 6
-"true", "yes", "y", "on" and "1" are true, everything else is false.
-.IP "VOL:" 6
-A double ranging from 0.0 (min) - 1.0 (max).
-.IP "LANG:" 6
-A language identifier. Full name, ISO 639-1 or ISO 639-2 language
-code; or IETF language tag with ISO 639-1 and ISO 3166-1 country code.
+.It Ar bool
+.Dq true ,
+.Dq yes ,
+.Dq y ,
+.Dq on ,
+and
+.Dq 1
+are true, everything else is false.
+.It Ar vol
+A double ranging from 0.0 (min) \(en 1.0 (max).
+.It Ar lang
+A language identifier.
+Full name, ISO 639-1 or ISO 639-2 language code;
+or IETF language tag with ISO 639-1 and ISO 3166-1 country code.
 Examples: en, de_de, hun, Czech, zh-tw, zh_cn, zh-cht, zh-chs.
-.IP "LVL:" 6
+.It Ar lvl
 A positive integer.
-.IP "CHAN:" 6
-A comma-separated list of debug channels. Use "All" to enable all
-debug channels.
-.PD
-.PP
-Long-form command line option, like --skipvideos, map directly to
-config options. Options given on the command line will override any
-options found in the config file for this session, but will not save
-back to that config file.
-.SH EXAMPLES
-.TP 4
-xoreos -p/path/to/nwn/
-.BR xoreos
-will start the game in /path/to/nwn/. Should a target with this path
-not yet exist in the config file,
-.BR xoreos
-will create one named "nwn".
-.TP 4
-xoreos -p/path/to/nwn/ foobar
-.BR xoreos
-will start the game in /path/to/nwn/. If a target "foobar" does not
-yet exist in the config file,
-.BR xoreos
+.It Ar chan
+A comma-separated list of debug channels. Use
+.Dq All
+to enable all debug channels.
+.El
+.Pp
+Long-form command line option, like
+.Fl Fl skipvideos ,
+map directly to config options.
+Options given on the command line will override any
+options found in the config file for this session,
+but will not save back to that config file.
+.Sh EXAMPLES
+.Dl $ xoreos -p/path/to/nwn/
+.Pp
+.Nm
+will start the game in
+.Pa /path/to/nwn/ .
+Should a target with this path not yet exist in the config file,
+.Nm
+will create one named
+.Dq nwn .
+.Pp
+.Dl $ xoreos -p/path/to/nwn/ foobar
+.Pp
+.Nm
+will start the game in
+.Pa /path/to/nwn/ .
+If a target
+.Dq foobar
+does not yet exist in the config file,
+.Nm
 will create it.
-.TP 4
-xoreos nwn
-.BR xoreos
-will start the game specified by target "nwn", which must exit in the
-config file already.
-
-.SH "SEE ALSO"
+.Pp
+.Dl $ xoreos nwn
+.Pp
+.Nm
+will start the game specified by target
+.Dq nwn ,
+which must exist in the config file already.
+.Sh SEE ALSO
 More information about the xoreos project can be found on
-.URL "https://xoreos.org/" "its website" " and"
-.URL "https://wiki.xoreos.org/" "its wiki" .
-.SH AUTHORS
+.Lk https://xoreos.org/ "its website"
+and
+.Lk https://wiki.xoreos.org/ "its wiki" .
+.Sh AUTHORS
 This program is part of the xoreos projects, and was written by
-the xoreos team. Please see the AUTHORS file for details.
+the xoreos team.
+Please see the
+.Pa AUTHORS
+file for details.


### PR DESCRIPTION
This updates the macros in the manpage to the semantic -mdoc macros.

-mdoc is a drop‐in replacement for -man. It is supported out of the box by the default manpage formatters in Linux, OpenBSD, FreeBSD, Mac OS X, Illumos, and Minix. No change is necessary when installing the manpage.

-mdoc macros are semantic, and aside from groff (what most Linux distributions use to format manpages) there are several great tools for such manuals, especially the mandoc suite, which supports advanced searching, conversion to semantic HTML, and linting.