### PR TITLE
MAIN: Fail before probing if path is a file

### DIFF
--- a/src/xoreos.cpp
+++ b/src/xoreos.cpp
@@ -147,8 +147,11 @@ int main(int argc, char **argv) {
 		error("Invalid path \"%s\"", dirArg.c_str());
 	}
 
-	if (!Common::FilePath::isDirectory(baseDir) && !Common::FilePath::isRegularFile(baseDir))
-		error("No such file or directory \"%s\"", baseDir.c_str());
+	if (!Common::FilePath::isDirectory(baseDir))
+		if (!Common::FilePath::isRegularFile(baseDir))
+			error("No such file or directory \"%s\"", baseDir.c_str());
+		else
+			error("Target \"%s\" is a file instead of a directory", baseDir.c_str());
 
 	Engines::GameThread *gameThread = new Engines::GameThread;
 	try {


### PR DESCRIPTION
When trying to launch xoreos for the first time, I accidentally pointed the path (in -p) to nwmain.exe instead of the parent folder. The usage function is clear that I should point to the folder, but I didn't immediately notice it and I was confused because of the strange unrelated opengl/audio errors that I got instead.

Now we fail early with a clear error message instead. 
