### PR TITLE
DIST: Add Fedora specific spec file

### DIFF
--- a/dists/fedora/build-from-git.sh
+++ b/dists/fedora/build-from-git.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This is a helper script to update the Release tag of the specfile
+# and then invoke rpmbuild --build-in-place with the correct options
+# to build from the root of the git checkout.
+
+# You need rpmbuild to build the rpm.
+
+# Thanks to StackOverflow:
+# https://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+RPM_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+XOREOS_ROOT=`git rev-parse --show-toplevel`
+SPEC_NAME=${RPM_DIR}/xoreos.spec
+
+# Compute the release snapshot, create a temporary spec. Also redine _rpmdir
+SNAPSHOT=`date +"%Y%m%d"`
+sed "s,\%global snapshot .*,\%global snapshot ${SNAPSHOT}git," < ${SPEC_NAME} > ${SPEC_NAME}.tmp
+sed "1s,^,\%define _rpmdir ${RPM_DIR}\n," -i ${SPEC_NAME}.tmp
+
+# Create a buildroot directory.
+mkdir -p ${RPM_DIR}/buildroot
+
+# Invoke rpmbuild from the root of the git repo (so --build-in-place works).
+# Also set the --buildroot and --
+cd ${XOREOS_ROOT}
+rpmbuild --build-in-place --rmspec --buildroot ${RPM_DIR}/buildroot -bb ${SPEC_NAME}.tmp
+rm -rf ${RPM_DIR}/buildroot

--- a/dists/fedora/xoreos.spec
+++ b/dists/fedora/xoreos.spec
@@ -1,0 +1,85 @@
+# If you want to build the current git checkout, run "build-from-git.sh".
+# If you want to build the last stable release of xoreos instead,
+# build from this specfile directly.
+
+# Note: xoreos depends on packages from rpmfusion-free.
+# So it won't be able to build in e.g. a Fedora Copr
+# (https://copr.fedorainfracloud.org/)
+# Presumaby OBS will handle this properly?
+
+# Globals, overridden by build script.
+%global snapshot 0
+
+Name:           xoreos
+Version:        0.0.4
+
+# This is a bit ugly but it works.
+%if "%{snapshot}" == "0"
+Release:        1%{?dist}
+%else
+Release:        1.%{snapshot}%{?dist}
+%endif
+
+Summary:        A reimplementation of BioWare's Aurora engine (and derivatives)
+
+License:        GPLv3
+URL:            https://xoreos.org/
+
+Source0:        https://github.com/xoreos/xoreos/releases/download/%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  zlib-devel, freetype-devel, openal-soft-devel, libvorbis-devel,
+BuildRequires:  libogg-devel, SDL2-devel, libxml2-devel, lzma-devel, glew-devel
+
+BuildRequires:  libtool, gettext
+
+# Boost dependencies.
+BuildRequires:  boost-devel, boost-system, boost-filesystem, boost-atomic,
+BuildRequires:  boost-regex, boost-locale
+
+# Isolated; these are rpmfusion-free dependencies.
+BuildRequires:  faad2-devel, libmad-devel, xvidcore-devel
+
+#Requires:
+
+%description
+xoreos is an open source implementation of BioWare's Aurora engine and its
+derivatives, licensed under the terms of the GNU General Public License
+version 3 (or later). The goal is to have all games using this engines
+working in a portable manner, starting from Neverwinter Nights and ending
+with Dragon Age II.
+
+Currently, the "foundation" work of managing resources, reading many basic
+file formats, displaying graphics and playing sounds has been done. All
+targeted games show partial ingame graphics, such as the area geometry and
+objects, letting you fly around in a "spectator mode". Some games show partial
+menus, and something resembling a starting point for a script system is there.
+
+No actual "normal" gameplay is implemented yet, though.
+
+%prep
+%setup -q
+
+%build
+./autogen.sh
+%configure
+
+# When building in place we want to do a make clean.
+make clean
+
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+# We'll get the documentation manually.
+rm %{buildroot}%{_pkgdocdir}/*
+
+%files
+%{_bindir}/xoreos
+%{_mandir}/man6/xoreos.6*
+%doc *.md AUTHORS ChangeLog TODO doc/xoreos.conf.example
+%license COPYING*
+
+%changelog
+* Mon Feb 15 2016 Ben Rosser <rosser.bjr@gmail.com> 0.0.4-1
+- Initial package.


### PR DESCRIPTION
So, I made a Fedora-specific spec file for xoreos. 

The BuildRequires are sufficient such that it builds under [mock](https://fedoraproject.org/wiki/Mock) (the Fedora chroot buildsystem for building packages), and I was able to install and run the result. :)

It's also compliant with current Fedora packaging guidelines, but otherwise is pretty similar to the [OBS spec](https://build.opensuse.org/package/view_file/home:DrMcCoy:xoreos/xoreos/xoreos.spec?expand=1) that @DrMcCoy linked me on IRC when I asked about this.

I'd be happy to make Fedora-specific specs for xoreos-tools and phaethon as well.

**rpmfusion dependencies**

There are three dependencies (libmad, faad, and xvidcore) that aren't in the official Fedora repos, but are instead in [rpmfusion-free](http://rpmfusion.org/). rpmfusion-free mostly contains Free Software that Fedora Legal doesn't want to ship due to patent issues (e.g. MP3 support, etc.), so to actually build on a Fedora system you'd need the rpmfusion-free repository.

I assume OBS takes care of that, since the OBS spec builds, but I've never actually used it for Fedora packages.

I'd offer to set up a [copr](https://copr.fedorainfracloud.org/) to build xoreos packages for Fedora in a native Fedora environment, but I can't due to the above, sadly. :(