### PR TITLE
DeS3TC cursor fix

### DIFF
--- a/src/aurora/rules.mk
+++ b/src/aurora/rules.mk
@@ -60,6 +60,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nitrofile.h \
     src/aurora/nsbtxfile.h \
     src/aurora/cdpth.h \
+    src/aurora/xwbfile.h
     $(EMPTY)
 
 src_aurora_libaurora_la_SOURCES += \
@@ -97,6 +98,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nitrofile.cpp \
     src/aurora/nsbtxfile.cpp \
     src/aurora/cdpth.cpp \
+    src/aurora/xwbfile.cpp
     $(EMPTY)
 
 src_aurora_libaurora_la_LIBADD = \

--- a/src/aurora/xwbfile.cpp
+++ b/src/aurora/xwbfile.cpp
@@ -1,6 +1,26 @@
-//
-// Created by patrick on 06.05.17.
-//
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**@file
+ * 	for reading xact xwb files, both ascii and binary
+ */
 
 #include "xwbfile.h"
 
@@ -39,13 +59,13 @@ XWBFile::XWBFile(Common::SeekableReadStream *xwb)
 	unsigned int numWaves = atoi(tokens[2].c_str());
 	
 	int tokenoffset = 3;
+	if(tokenoffset + numWaves*8 > tokens.size())
+	{
+		throw Common::Exception("xwb file is too short");
+	}
+	
 	for (unsigned int i = 0; i < numWaves; ++i)
 	{
-		/*if(tokenoffset + i*8 + 1 > tokens.size())
-		{
-			throw Common::Exception("xwb file is too short");
-		}*/
-		
 		Common::UString file = tokens[tokenoffset + i*8 + 1];
 		Common::UString fileid, filesuffix;
 		std::vector<Common::UString> filenameparts;

--- a/src/aurora/xwbfile.cpp
+++ b/src/aurora/xwbfile.cpp
@@ -1,0 +1,89 @@
+//
+// Created by patrick on 06.05.17.
+//
+
+#include "xwbfile.h"
+
+#include "src/common/ustring.h"
+#include "src/common/streamtokenizer.h"
+#include "resman.h"
+
+namespace Aurora
+{
+
+XWBFile::XWBFile(Common::SeekableReadStream *xwb)
+{
+	//divide numbers and strings
+	Common::StreamTokenizer tokenizer;
+	tokenizer.addSeparator(' ');
+	tokenizer.addSeparator('\n');
+	
+	//get the extracted values
+	std::vector<Common::UString> tokens;
+	tokenizer.getTokens(*xwb, tokens);
+	
+	//get the name of the wavebank
+	name = tokens[0];
+	
+	//check if the wavebank should be streamed
+	if (tokens[1] == "STREAMING")
+	{
+		streaming = true;
+	}
+	else
+	{
+		streaming = false;
+	}
+	
+	//get the number of waves inside the file
+	unsigned int numWaves = atoi(tokens[2].c_str());
+	
+	int tokenoffset = 3;
+	for (unsigned int i = 0; i < numWaves; ++i)
+	{
+		/*if(tokenoffset + i*8 + 1 > tokens.size())
+		{
+			throw Common::Exception("xwb file is too short");
+		}*/
+		
+		Common::UString file = tokens[tokenoffset + i*8 + 1];
+		Common::UString fileid, filesuffix;
+		std::vector<Common::UString> filenameparts;
+		Common::UString::iterator iter =  file.findLast('.');
+		file.split(iter, fileid, filesuffix);
+		
+		Resource r;
+		r.name = fileid;
+		r.index = i;
+		
+		fileids.push_back(fileid);
+		_resources.push_back(r);
+	}
+}
+
+XWBFile::~XWBFile()
+{
+
+}
+
+const Archive::ResourceList &XWBFile::getResources() const
+{
+	return _resources;
+}
+
+Common::SeekableReadStream *XWBFile::getResource(uint32 index, bool tryNoCopy) const
+{
+	return ResMan.getResource(fileids[index]);
+}
+
+bool XWBFile::isStreaming() const
+{
+	return streaming;
+}
+
+Common::UString XWBFile::getName() const
+{
+	return name;
+}
+
+}

--- a/src/aurora/xwbfile.h
+++ b/src/aurora/xwbfile.h
@@ -1,0 +1,94 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ * Handling for an XACT Wave Bank file
+ */
+
+#ifndef XOREOS_XWB_H
+#define XOREOS_XWB_H
+
+#include "src/aurora/archive.h"
+
+#include "src/common/ustring.h"
+
+namespace Aurora
+{
+
+/**
+ * Class for loading an XACT wave bank file
+ *
+ * this class is able to load XACT wave bank files
+ * and treats them as archives contining multiple
+ * sound files. it supports two modes: binary and
+ * text
+ *
+ * text
+ * 	the text files assume a folder with the name
+ * 	of the text file excluding the _xwb.txt suffix,
+ * binary
+ * 	TODO
+ */
+class XWBFile : public Archive
+{
+public:
+	XWBFile(Common::SeekableReadStream *);
+	~XWBFile();
+	
+	const ResourceList &getResources() const;
+	
+	Common::SeekableReadStream *getResource(uint32, bool = false) const;
+	
+	// --- xwb specific functions
+	/**
+	 * check if this wavebank should be
+	 * streamed
+	 *
+	 * @return
+	 * 	if this is a streaming wavebank
+	 */
+	bool isStreaming() const;
+	
+	/**
+	 * get the name of the wavebank
+	 *
+	 * @return
+	 * 	the name of the wavebank
+	 */
+	Common::UString getName() const;
+
+private:
+	/** External list of resource names and types. */
+	ResourceList _resources;
+	
+	/** list of all file ids in this bank */
+	std::vector<Common::UString> fileids;
+	
+	/** name of this wave bank */
+	Common::UString name;
+	
+	/** if this is a streaming wavebank */
+	bool streaming;
+};
+
+}
+
+#endif //XOREOS_XWB_H

--- a/src/graphics/aurora/cursor.cpp
+++ b/src/graphics/aurora/cursor.cpp
@@ -30,6 +30,8 @@
 #include "src/aurora/types.h"
 #include "src/aurora/resman.h"
 
+#include "src/graphics/graphics.h"
+
 #include "src/graphics/images/decoder.h"
 #include "src/graphics/images/txi.h"
 #include "src/graphics/images/tga.h"
@@ -112,6 +114,12 @@ void Cursor::load() {
 
 	TXI *txi = new TXI();
 	txi->getFeatures().filter = false;
+	
+	//if we need DeS3TC, we decompress the cursor image
+	if(GfxMan.needManualDeS3TC())
+	{
+		image->decompress();
+	}
 
 	_texture = TextureMan.add(Texture::create(image.release(), type, txi), _name);
 

--- a/tests/aurora/rules.mk
+++ b/tests/aurora/rules.mk
@@ -140,3 +140,8 @@ check_PROGRAMS                    += tests/aurora/test_dlgfile
 tests_aurora_test_dlgfile_SOURCES  = tests/aurora/dlgfile.cpp
 tests_aurora_test_dlgfile_LDADD    = $(aurora_LIBS)
 tests_aurora_test_dlgfile_CXXFLAGS = $(test_CXXFLAGS)
+
+check_PROGRAMS                    += tests/aurora/test_xwbfile
+tests_aurora_test_xwbfile_SOURCES  = tests/aurora/xwbfile.cpp
+tests_aurora_test_xwbfile_LDADD    = $(aurora_LIBS)
+tests_aurora_test_xwbfile_CXXFLAGS = $(test_CXXFLAGS)

--- a/tests/aurora/xwbfile.cpp
+++ b/tests/aurora/xwbfile.cpp
@@ -1,0 +1,75 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ * 	unit tests for the xwb files
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/aurora/xwbfile.h"
+
+static const char* kXWBASCII = {
+		"testbank\n"
+		"STREAMING\n"
+		"9\n"
+		"WMA testbank00.wma 44100 2 4 1000000 0 0\n"
+		"WAV testbank01.wav 44100 2 4 2000000 0 0\n"
+		"WAV testbank02.wav 44100 2 4 1000000 0 0\n"
+		"WMA testbank03.wma 44100 2 4 100 0 0\n"
+		"WMA testbank04.wma 22050 2 4 200 0 0\n"
+		"WMA testbank05.wma 44100 2 4 3453454 0 0\n"
+		"WAV testbank06.wav 44100 2 4 1000000 0 0\n"
+		"WMA testbank07.wma 44100 2 4 1000000 0 0\n"
+		"WMA testbank08.wma 44100 2 4 1000000 0 0\n"
+};
+
+// --- Text xwb files
+
+GTEST_TEST(XWBFileASCII, getHeader)
+{
+	Common::MemoryReadStream stream(kXWBASCII);
+	const Aurora::XWBFile file(&stream);
+	
+	EXPECT_EQ(file.getName(), "testbank");
+	EXPECT_EQ(file.isStreaming(), true);
+}
+
+GTEST_TEST(XWBFileASCII, getResoures)
+{
+	Common::MemoryReadStream stream(kXWBASCII);
+	const Aurora::XWBFile file(&stream);
+	
+	Aurora::XWBFile::ResourceList list = file.getResources();
+	
+	EXPECT_EQ(list.size(), 9);
+	
+	Aurora::XWBFile::ResourceList::iterator iter = list.begin();
+	for (unsigned int i = 0; i < list.size(); ++i)
+	{
+		std::stringstream title;
+		title << "testbank0" << i;
+		EXPECT_EQ(title.str(), std::string((*iter).name.c_str()));
+		EXPECT_EQ(i, (*iter).index);
+		
+		++iter;
+	}
+}


### PR DESCRIPTION
I recognized a bug in the graphics system which caused it to crash when loading a compressed cursor image on a non-s3tc system. I added three lines to make the cursor image decompress on such systems.