### PR TITLE
AURORA: Add functionality to add child guis to a gui

### DIFF
--- a/src/engines/aurora/gui.cpp
+++ b/src/engines/aurora/gui.cpp
@@ -70,8 +70,7 @@ void GUI::show() {
 			widget.show();
 	}
 
-	std::list<GUI*>::iterator iter;
-	for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
+	for (std::list<GUI *>::iterator iter = _childGUIs.begin(); iter != _childGUIs.end(); ++iter)	{
 		(*iter)->show();
 	}
 
@@ -85,8 +84,7 @@ void GUI::hide() {
 	for (WidgetList::iterator widget = _widgets.begin(); widget != _widgets.end(); ++widget)
 		(*widget)->hide();
 
-	std::list<GUI*>::iterator iter;
-	for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
+	for (std::list<GUI *>::iterator iter = _childGUIs.begin(); iter != _childGUIs.end(); ++iter)	{
 		(*iter)->hide();
 	}
 
@@ -104,12 +102,14 @@ uint32 GUI::run(uint32 startCode) {
 
 	// Run as long as we don't have a return code
 	while (_returnCode == kReturnCodeNone) {
+
+		std::list<GUI *> childGUIs = _childGUIs;
+
 		// Call the periodic run callback
 		callbackRun();
 
-		std::list<GUI*>::iterator iter;
 		// Call the periodic run callback of the children guis
-		for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
+		for (std::list<GUI *>::iterator iter = childGUIs.begin(); iter != childGUIs.end(); ++iter)	{
 			(*iter)->callbackRun();
 		}
 
@@ -124,20 +124,20 @@ uint32 GUI::run(uint32 startCode) {
 		Events::Event event;
 		while (EventMan.pollEvent(event)) {
 			addEvent(event);
-			for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
+			for (std::list<GUI *>::iterator iter = childGUIs.begin(); iter != childGUIs.end(); ++iter)	{
 				(*iter)->addEvent(event);
 			}
 		}
 
 		processEventQueue();
-		for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
+		for (std::list<GUI *>::iterator iter = childGUIs.begin(); iter != childGUIs.end(); ++iter)	{
 			(*iter)->processEventQueue();
 		}
 
 		// If the _returnCode changed of a child gui we propagate it to the
 		// main gui
-		for (iter = _childrenguis.begin(); iter != _childrenguis.end(); iter++)	{
-			if((*iter)->_returnCode != _returnCode) {
+		for (std::list<GUI *>::iterator iter = childGUIs.begin(); iter != childGUIs.end(); ++iter)	{
+			if ((*iter)->_returnCode != _returnCode) {
 				_returnCode = (*iter)->_returnCode;
 			}
 		}
@@ -219,15 +219,14 @@ void GUI::callbackActive(Widget &UNUSED(widget)) {
 }
 
 
-void GUI::addChild(GUI* gui)
-{
-	_childrenguis.push_back(gui);
+void GUI::addChild(GUI *gui) {
+	_childGUIs.push_back(gui);
+	gui->show();
 }
 
-void GUI::removeChild(GUI * gui)
-{
+void GUI::removeChild(GUI *gui) {
 	gui->hide();
-	_childrenguis.remove(gui);
+	_childGUIs.remove(gui);
 }
 
 void GUI::addWidget(Widget *widget) {

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -31,7 +31,6 @@
 #include <boost/noncopyable.hpp>
 
 #include "src/common/ustring.h"
-#include "src/common/scopedptr.h"
 
 #include "src/events/types.h"
 
@@ -75,6 +74,7 @@ protected:
 
 	GUI *_sub; ///< The currently running sub GUI.
 
+
 	/** Add a widget. */
 	void addWidget(Widget *widget);
 	/** Remove a widget. */
@@ -115,13 +115,15 @@ protected:
 	/** Callback that's triggered when a widget was activated. */
 	virtual void callbackActive(Widget &widget);
 
-	void addChild(GUI*);
-	void removeChild(GUI*);
+	/** Add a child GUI object to this GUI. Ownership of the pointer is not transferred */
+	void addChild(GUI *gui);
+	/** Remove a child GUI object from this. Pointer will not deallocated */
+	void removeChild(GUI *gui);
 private:
 	typedef std::list<Widget *> WidgetList;
 	typedef std::map<Common::UString, Widget *> WidgetMap;
 
-	std::list<GUI*> _childrenguis;
+	std::list<GUI *> _childGUIs;
 
 	WidgetList _widgets;   ///< All widgets in the GUI.
 	WidgetMap  _widgetMap; ///< All widgets in the GUI, index by their tag.

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -31,6 +31,7 @@
 #include <boost/noncopyable.hpp>
 
 #include "src/common/ustring.h"
+#include "src/common/scopedptr.h"
 
 #include "src/events/types.h"
 
@@ -74,7 +75,6 @@ protected:
 
 	GUI *_sub; ///< The currently running sub GUI.
 
-
 	/** Add a widget. */
 	void addWidget(Widget *widget);
 	/** Remove a widget. */
@@ -115,9 +115,13 @@ protected:
 	/** Callback that's triggered when a widget was activated. */
 	virtual void callbackActive(Widget &widget);
 
+	void addChild(GUI*);
+	void removeChild(GUI*);
 private:
 	typedef std::list<Widget *> WidgetList;
 	typedef std::map<Common::UString, Widget *> WidgetMap;
+
+	std::list<GUI*> _childrenguis;
 
 	WidgetList _widgets;   ///< All widgets in the GUI.
 	WidgetMap  _widgetMap; ///< All widgets in the GUI, index by their tag.


### PR DESCRIPTION
While I was working on the KotOR menus, i recognized, that KotOR is using combined guis, where the actual interface is consisting of two or more seperated gui files which are independently switched. I added the possibility to do that in the xoreos gui class.