### PR TITLE
GRAPHICS: Add an optional opengl scissor test for the quad rendering

### DIFF
--- a/src/graphics/aurora/guiquad.cpp
+++ b/src/graphics/aurora/guiquad.cpp
@@ -40,7 +40,7 @@ GUIQuad::GUIQuad(const Common::UString &texture,
 	_r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f),
 	_x1 (x1) , _y1 (y1) , _x2 (x2) , _y2 (y2) ,
 	_tX1(tX1), _tY1(tY1), _tX2(tX2), _tY2(tY2),
-	_xor(false) {
+	_xor(false), _scissor(false) {
 
 	try {
 
@@ -63,7 +63,7 @@ GUIQuad::GUIQuad(TextureHandle texture,
 	_texture(texture), _r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f),
 	_x1 (x1) , _y1 (y1) , _x2 (x2) , _y2 (y2) ,
 	_tX1(tX1), _tY1(tY1), _tX2(tX2), _tY2(tY2),
-	_xor(false) {
+	_xor(false), _scissor(false) {
 
 	_distance = -FLT_MAX;
 }
@@ -140,6 +140,13 @@ void GUIQuad::setTexture(TextureHandle texture) {
 	unlockFrameIfVisible();
 }
 
+void GUIQuad::setScissor(int x, int y, int width, int height) {
+	_scissorX = x;
+	_scissorY = y;
+	_scissorWidth = width;
+	_scissorHeight = height;
+}
+
 float GUIQuad::getWidth() const {
 	return ABS(_x2 - _x1);
 }
@@ -172,6 +179,14 @@ void GUIQuad::setXOR(bool enabled) {
 	unlockFrameIfVisible();
 }
 
+void GUIQuad::setScissor(bool enabled) {
+	lockFrameIfVisible();
+
+	_scissor = enabled;
+
+	unlockFrameIfVisible();
+}
+
 bool GUIQuad::isIn(float x, float y) const {
 	if ((x < _x1) || (x > _x2))
 		return false;
@@ -199,6 +214,17 @@ void GUIQuad::render(RenderPass pass) {
 		glLogicOp(GL_XOR);
 	}
 
+	if (_scissor) {
+		glEnable(GL_SCISSOR_TEST);
+		GLint viewport[4];
+		glGetIntegerv(GL_VIEWPORT, viewport);
+		glScissor(viewport[2]/2 + _x1 + _scissorX,
+		          viewport[3]/2 + _y1 + _scissorY,
+		          _scissorWidth,
+		          _scissorHeight
+		);
+	}
+
 	glBegin(GL_QUADS);
 		glTexCoord2f(_tX1, _tY1);
 		glVertex2f(_x1, _y1);
@@ -209,6 +235,9 @@ void GUIQuad::render(RenderPass pass) {
 		glTexCoord2f(_tX1, _tY2);
 		glVertex2f(_x1, _y2);
 	glEnd();
+
+	if (_scissor)
+		glDisable(GL_SCISSOR_TEST);
 
 	if (_xor)
 		glDisable(GL_COLOR_LOGIC_OP);

--- a/src/graphics/aurora/guiquad.h
+++ b/src/graphics/aurora/guiquad.h
@@ -63,6 +63,9 @@ public:
 	/** Set the current texture of the quad. */
 	void setTexture(TextureHandle texture);
 
+	/** Set the scissor test parameters. */
+	void setScissor(int x, int y, int width, int height);
+
 	float getWidth () const; ///< Return the quad's width.
 	float getHeight() const; ///< Return the quad's height.
 
@@ -70,6 +73,8 @@ public:
 	void setHeight(float h); ///< Set the quad's height.
 
 	void setXOR(bool enabled); ///< Enable/Disable XOR mode.
+
+	void setScissor(bool enabled); ///< Enable/Disable Scissor Test.
 
 	/** Is the point within the quad? */
 	bool isIn(float x, float y) const;
@@ -96,7 +101,13 @@ private:
 	float _tX2;
 	float _tY2;
 
+	int _scissorX;
+	int _scissorY;
+	int _scissorWidth;
+	int _scissorHeight;
+
 	bool _xor;
+	bool _scissor;
 };
 
 } // End of namespace Aurora


### PR DESCRIPTION
While working on the KotOR GUI, I recognized, that some textures were too large for placing them exactly like the original game does. The Problem was that they have borders equal with the background, but they overlap with other elements. I added the possiblity to remove this borders while rendering using the scissor test. I will add the gui specific stuff later.