### PR TITLE
KOTOR: Fix a bug for widgets with an initially empty text

### DIFF
--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -173,7 +173,7 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 
 	Text text = createText(gff);
 
-	if (!text.text.empty() && !text.font.empty()) {
+	if (!text.font.empty()) {
 		_text.reset(new Graphics::Aurora::HighlightableText(FontMan.get(text.font),
 		            text.text, text.r, text.g, text.b, 1.0f));
 


### PR DESCRIPTION
The KotORWidget class does not generate a text rendering object if the text is initially empty. This caused the program to crash on attempts to change the text of empty labels. I fixed this by removing the condition that the text shouldn't be empty.