### PR TITLE
GRAPHICS: Add callback to GUI for handling hovering

### DIFF
--- a/src/engines/aurora/gui.cpp
+++ b/src/engines/aurora/gui.cpp
@@ -217,6 +217,9 @@ void GUI::callbackRun() {
 void GUI::callbackActive(Widget &UNUSED(widget)) {
 }
 
+void GUI::callbackHover(Widget &UNUSED(widget)) {
+}
+
 
 void GUI::addChild(GUI *gui) {
 	_childGUIs.push_back(gui);
@@ -451,6 +454,16 @@ void GUI::checkWidgetActive(Widget *widget) {
 	widget->setActive(false);
 }
 
+void GUI::checkWidgetHovered(Widget *widget) {
+	if (!widget)
+		return;
+
+	if (widget->isHovered()) {
+		callbackHover(*widget);
+		widget->setHovered(false);
+	}
+}
+
 void GUI::mouseMove(const Events::Event &event) {
 	Widget *widget = getWidgetAt(event.motion.x, event.motion.y);
 
@@ -463,6 +476,8 @@ void GUI::mouseMove(const Events::Event &event) {
 		// Moves without a mouse button can change the current widget
 		if (widget != _currentWidget)
 			changedWidget(widget);
+
+	checkWidgetHovered(_currentWidget);
 }
 
 void GUI::mouseDown(const Events::Event &event) {

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -114,6 +114,8 @@ protected:
 	virtual void callbackRun();
 	/** Callback that's triggered when a widget was activated. */
 	virtual void callbackActive(Widget &widget);
+	/** Callback that's triggered when a widget is hovered or unhovered */
+	virtual void callbackHover(Widget &widget);
 
 	/** Add a child GUI object to this GUI. Ownership of the pointer is not transferred. */
 	void addChild(GUI *gui);
@@ -140,6 +142,7 @@ private:
 
 	void changedWidget(Widget *widget);     ///< The current widget has changed.
 	void checkWidgetActive(Widget *widget); ///< Check if a widget was activated.
+	void checkWidgetHovered(Widget *widget);///< Check if a widget was hovered.
 
 	void mouseMove(const Events::Event &event); ///< Mouse move event triggered.
 	void mouseDown(const Events::Event &event); ///< Mouse down event triggered.

--- a/src/engines/aurora/widget.cpp
+++ b/src/engines/aurora/widget.cpp
@@ -33,7 +33,7 @@ namespace Engines {
 
 Widget::Widget(GUI &gui, const Common::UString &tag) : _gui(&gui), _tag(tag),
 	_parent(0), _owner(0),
-	_active(false), _visible(false), _disabled(false), _invisible(false),
+	_active(false), _visible(false), _disabled(false), _invisible(false), _hovered(false),
 	_x(0.0f), _y(0.0f), _z(0.0f),
 	_lastClickButton(0), _lastClickTime(0), _lastClickX(0.0f), _lastClickY(0.0f) {
 
@@ -66,6 +66,10 @@ bool Widget::isDisabled() const {
 
 bool Widget::isInvisible() const {
 	return _invisible;
+}
+
+bool Widget::isHovered() const {
+	return _hovered;
 }
 
 void Widget::show() {
@@ -276,6 +280,10 @@ void Widget::setActive(bool active) {
 	if (_active)
 		for (std::list<Widget *>::iterator it = _groupMembers.begin(); it != _groupMembers.end(); ++it)
 			(*it)->signalGroupMemberActive();
+}
+
+void Widget::setHovered(bool hovered) {
+	_hovered = hovered;
 }
 
 } // End of namespace Engines

--- a/src/engines/aurora/widget.h
+++ b/src/engines/aurora/widget.h
@@ -51,6 +51,7 @@ public:
 	bool isVisible  () const; ///< Is the widget visible?
 	bool isDisabled () const; ///< Is the widget disabled?
 	bool isInvisible() const; ///< Is the widget invisible (never visible)?
+	bool isHovered  () const; ///< Is the widget hovered?
 
 	virtual void show(); ///< Show the widget.
 	virtual void hide(); ///< Hide the widget.
@@ -119,13 +120,15 @@ protected:
 	/** A fellow group member signaled that it is now active. */
 	virtual void signalGroupMemberActive();
 
-	void setActive(bool active); ///< The widget's active state.
+	void setActive(bool active);       ///< The widget's active state.
+	void setHovered(bool hovered);     ///< The widget's hovered state.
 
 private:
 	bool _active;    ///< Was the widget activated?
 	bool _visible;   ///< Is the widget visible?
 	bool _disabled;  ///< Is the widget disabled?
 	bool _invisible; ///< Is the widget invisible (never visible)?
+	bool _hovered;   ///< Is the widget hovered?
 
 	float _x; ///< The widget X position.
 	float _y; ///< The widget Y position.


### PR DESCRIPTION
While working on the KotOR character creation menus i was missing a possibility to identify widgets when they are hovered (the mouse is over the widget, but does not click). An example for this is the KotOR class selection menu, where you go over the six classes and get information about them in the text box below.