### PR TITLE
KOTOR: Add some features for the KotOR Buttons

### DIFF
--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -57,6 +57,10 @@ void WidgetButton::setPermanentHighlight(bool permanentHighlight) {
 	}
 }
 
+void WidgetButton::setDisableHoverSound(bool disableHoverSound) {
+	_disableHoverSound = disableHoverSound;
+}
+
 void WidgetButton::load(const Aurora::GFF3Struct &gff) {
 	KotORWidget::load(gff);
 	if (getTextHighlightableComponent() != 0) {
@@ -76,17 +80,19 @@ void WidgetButton::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)
 }
 
 void WidgetButton::enter() {
-	_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
+	if (!_disableHoverSound)
+		_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
 
-	if(!_permanentHighlight) {
+	if (!_permanentHighlight) {
 		startHighlight();
 	}
 }
 
 void WidgetButton::leave() {
-	SoundMan.stopChannel(_sound);
+	if (!_disableHoverSound)
+		SoundMan.stopChannel(_sound);
 
-	if(!_permanentHighlight) {
+	if (!_permanentHighlight) {
 		stopHighlight();
 	}
 }

--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -40,10 +40,21 @@ namespace Engines {
 namespace KotOR {
 
 WidgetButton::WidgetButton(::Engines::GUI &gui, const Common::UString &tag) :
-	KotORWidget(gui, tag) {
+	KotORWidget(gui, tag),
+	_permanentHighlight(false) {
 }
 
 WidgetButton::~WidgetButton() {
+}
+
+void WidgetButton::setPermanentHighlight(bool permanentHighlight) {
+	_permanentHighlight = permanentHighlight;
+
+	if (_permanentHighlight) {
+		startHighlight();
+	} else {
+		stopHighlight();
+	}
 }
 
 void WidgetButton::load(const Aurora::GFF3Struct &gff) {
@@ -65,8 +76,24 @@ void WidgetButton::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)
 }
 
 void WidgetButton::enter() {
-	float r, g, b, a;
 	_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
+
+	if(!_permanentHighlight) {
+		startHighlight();
+	}
+}
+
+void WidgetButton::leave() {
+	SoundMan.stopChannel(_sound);
+
+	if(!_permanentHighlight) {
+		stopHighlight();
+	}
+}
+
+void WidgetButton::startHighlight() {
+	float r, g, b, a;
+
 	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
 		_text->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
 		_text->getHighlightedLowerBound(r, g, b, a);
@@ -80,11 +107,9 @@ void WidgetButton::enter() {
 		_quad->setColor(r, g, b, a);
 		getQuadHighlightableComponent()->setHighlighted(true);
 	}
-
 }
 
-void WidgetButton::leave() {
-	SoundMan.stopChannel(_sound);
+void WidgetButton::stopHighlight() {
 	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
 		_text->setHighlighted(false);
 		_text->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);

--- a/src/engines/kotor/gui/widgets/button.h
+++ b/src/engines/kotor/gui/widgets/button.h
@@ -39,6 +39,7 @@ public:
 	~WidgetButton();
 
     void setPermanentHighlight(bool);
+	void setDisableHoverSound(bool);
 
 	virtual void load(const Aurora::GFF3Struct &gff);
 
@@ -53,6 +54,7 @@ private:
 	void stopHighlight();
 
 	bool _permanentHighlight;
+	bool _disableHoverSound;
 
 	void setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable);
 	Sound::ChannelHandle _sound;

--- a/src/engines/kotor/gui/widgets/button.h
+++ b/src/engines/kotor/gui/widgets/button.h
@@ -38,6 +38,8 @@ public:
 	WidgetButton(::Engines::GUI &gui, const Common::UString &tag);
 	~WidgetButton();
 
+    void setPermanentHighlight(bool);
+
 	virtual void load(const Aurora::GFF3Struct &gff);
 
 	void mouseUp(uint8 state, float x, float y);
@@ -47,6 +49,10 @@ public:
 	virtual void leave();
 
 private:
+	void startHighlight();
+	void stopHighlight();
+
+	bool _permanentHighlight;
 
 	void setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable);
 	Sound::ChannelHandle _sound;


### PR DESCRIPTION
when creating a character (either a quick or custom character) in KotOR, the buttons of the steps (like potrait, name ...) behave different then the default button in two ways. They are permanently highlighted, if they are the actual step and have no hovering sound. I added two methods for the KotOR Buttons to enable and disable this features.