### PR TITLE
KOTOR: Character generation menu

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -22,6 +22,7 @@
  *  A creature in a Star Wars: Knights of the Old Republic area.
  */
 
+#include "src/common/strutil.h"
 #include "src/common/util.h"
 #include "src/common/maths.h"
 #include "src/common/error.h"
@@ -38,6 +39,7 @@
 #include "src/engines/aurora/model.h"
 
 #include "src/engines/kotor/creature.h"
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
 
 namespace Engines {
 
@@ -246,6 +248,66 @@ void Creature::createFakePC() {
 	_tag  = Common::UString::format("[PC: %s]", _name.c_str());
 
 	_isPC = true;
+}
+
+void Creature::createPC(CharacterGenerationInfo* info)
+{
+	_name = info->getName();
+	_isPC = true;
+
+	PartModels parts;
+
+	parts.body = "p";
+	parts.head = "p";
+
+	switch (info->getGender()) {
+		case kGenderMale:
+			parts.body += "m";
+			parts.head += "m";
+			break;
+		case kGenderFemale:
+			parts.body += "f";
+			parts.head += "f";
+			break;
+		default:
+			throw Common::Exception("unknown gender");
+	}
+
+	parts.body += "bb";
+	parts.head += "h";
+
+	switch (info->getClass()) {
+		case kClassSoldier:
+			parts.body += "l";
+			break;
+		case kClassScout:
+			parts.body += "s";
+			break;
+		default:
+		case kClassScoundrel:
+			parts.body += "m";
+			break;
+	}
+
+	loadBody(parts);
+
+	switch (info->getSkin()) {
+		case kSkinA:
+			parts.head += "a";
+			break;
+		case kSkinB:
+			parts.head += "b";
+			break;
+		default:
+		case kSkinC:
+			parts.head += "c";
+			break;
+	}
+
+	parts.head += "0";
+	parts.head += Common::composeString(info->getFace() + 1);
+
+	loadHead(parts);
 }
 
 void Creature::enter() {

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -39,6 +39,8 @@ namespace Engines {
 
 namespace KotOR {
 
+class CharacterGenerationInfo;
+
 class Creature : public Object {
 public:
 	/** Create a dummy creature instance. Not playable as it is.*/
@@ -49,6 +51,8 @@ public:
 
 	/** Create a fake player character creature for testing purposes. */
 	void createFakePC();
+	/** Create a player character creature from a character info class. */
+	void createPC(CharacterGenerationInfo*);
 
 	// Basic visuals
 

--- a/src/engines/kotor/game.cpp
+++ b/src/engines/kotor/game.cpp
@@ -142,7 +142,7 @@ void Game::stopMusic() {
 }
 
 void Game::mainMenu() {
-	playMenuMusic();
+	//playMenuMusic();
 
 	EventMan.flushEvents();
 
@@ -158,7 +158,7 @@ void Game::mainMenu() {
 	_console->enableCommand("loadmodule");
 	_console->enableCommand("exitmodule");
 
-	stopMenuMusic();
+	//stopMenuMusic();
 }
 
 void Game::getModules(std::vector<Common::UString> &modules) {

--- a/src/engines/kotor/game.cpp
+++ b/src/engines/kotor/game.cpp
@@ -78,11 +78,6 @@ void Game::run() {
 }
 
 void Game::runModule() {
-	Common::ScopedPtr<Creature> fakePC(new Creature);
-	fakePC->createFakePC();
-
-	_module->usePC(fakePC.release());
-
 	if (EventMan.quitRequested() || !_module->isLoaded()) {
 		_module->clear();
 		return;

--- a/src/engines/kotor/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor/gui/chargen/charactergeneration.cpp
@@ -1,0 +1,55 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The primary character generation menu.
+ */
+
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+CharacterGenerationMenu::CharacterGenerationMenu(Module *UNUSED(module), Console *console) : GUI(console) {
+	load("maincg");
+
+	addBackground(kBackgroundTypeMenu);
+
+	getLabel("VIT_ARROW_LBL")->setText("");
+	getLabel("DEF_ARROW_LBL")->setText("");
+
+	getLabel("LBL_NAME")->setText("");
+	getLabel("LBL_CLASS")->setText("");
+
+	getLabel("WILL_ARROW_LBL")->setText("");
+	getLabel("REFL_ARROW_LBL")->setText("");
+	getLabel("FORT_ARROW_LBL")->setText("");
+
+	getWidget("NEW_LBL")->setInvisible(true);
+	getWidget("OLD_LBL")->setInvisible(true);
+
+	getWidget("LBL_LEVEL_VAL")->setInvisible(true);
+	getWidget("LBL_LEVEL")->setInvisible(true);
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor/gui/chargen/charactergeneration.cpp
@@ -23,12 +23,15 @@
  */
 
 #include "src/engines/kotor/gui/chargen/charactergeneration.h"
+#include "src/engines/kotor/gui/chargen/quickorcustom.h"
+#include "src/engines/kotor/gui/chargen/quickchar.h"
+#include "src/engines/kotor/gui/chargen/customchar.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-CharacterGenerationMenu::CharacterGenerationMenu(Module *UNUSED(module), Console *console) : GUI(console) {
+CharacterGenerationMenu::CharacterGenerationMenu(Module *module, Console *console) : GUI(console) {
 	load("maincg");
 
 	addBackground(kBackgroundTypeMenu);
@@ -48,6 +51,41 @@ CharacterGenerationMenu::CharacterGenerationMenu(Module *UNUSED(module), Console
 
 	getWidget("LBL_LEVEL_VAL")->setInvisible(true);
 	getWidget("LBL_LEVEL")->setInvisible(true);
+
+	showQuickOrCustom();
+}
+
+CharacterGenerationMenu::~CharacterGenerationMenu() {
+}
+
+void CharacterGenerationMenu::showQuickOrCustom() {
+	if (_quickChar)
+		removeChild(_quickChar.get());
+	if (_customChar)
+		removeChild(_customChar.get());
+
+	_quickOrCustom.reset(new QuickOrCustomPanel(this));
+	addChild(_quickOrCustom.get());
+}
+
+void CharacterGenerationMenu::showQuick() {
+	if (_quickOrCustom)
+		removeChild(_quickOrCustom.get());
+	if (_customChar)
+		removeChild(_customChar.get());
+
+	_quickChar.reset(new QuickCharPanel(this));
+	addChild(_quickChar.get());
+}
+
+void CharacterGenerationMenu::showCustom() {
+	if(_quickOrCustom)
+		removeChild(_quickOrCustom.get());
+	if(_quickChar)
+		removeChild(_quickChar.get());
+
+	_customChar.reset(new CustomCharPanel(this));
+	addChild(_customChar.get());
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/chargen/charactergeneration.h
+++ b/src/engines/kotor/gui/chargen/charactergeneration.h
@@ -27,25 +27,43 @@
 
 #include "src/engines/kotor/module.h"
 #include "src/engines/kotor/gui/gui.h"
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
 #include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/chargenbase.h"
 
 namespace Engines {
 
 namespace KotOR {
 
+class CharacterGenerationInfo;
+
 class CharacterGenerationMenu : public GUI {
 public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
+	CharacterGenerationMenu(Module *module, CharacterGenerationInfo *pc, ::Engines::Console *console = 0);
 	~CharacterGenerationMenu();
 
 	void showQuickOrCustom();
 	void showQuick();
 	void showCustom();
 
+	void showPotrait();
+	void showName();
+
+	int getStep();
+	void decStep();
+
+	void start();
+
 private:
+	int _step;
+	Module* _module;
+	CharacterGenerationInfo* _pc;
+
 	Common::ScopedPtr<GUI> _quickOrCustom;
 	Common::ScopedPtr<GUI> _quickChar;
 	Common::ScopedPtr<GUI> _customChar;
+
+	Common::ScopedPtr<CharacterGenerationBaseMenu> _charGenMenu;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/chargen/charactergeneration.h
+++ b/src/engines/kotor/gui/chargen/charactergeneration.h
@@ -1,0 +1,48 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The primary character generation menu.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+
+#include "src/engines/kotor/module.h"
+#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/kotor/gui/chargen/classselection.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class CharacterGenerationMenu : public GUI {
+public:
+	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
+
+private:
+	GUI *_currentPanel;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H

--- a/src/engines/kotor/gui/chargen/chargenbase.cpp
+++ b/src/engines/kotor/gui/chargen/chargenbase.cpp
@@ -1,0 +1,46 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A base class for all character creation menus.
+ */
+
+#include <src/engines/kotor/console.h>
+#include "chargenbase.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+CharacterGenerationBaseMenu::CharacterGenerationBaseMenu(CharacterGenerationInfo &info, Engines::Console *console) :
+		GUI(console), _info(info), _accepted(false) {
+}
+
+bool CharacterGenerationBaseMenu::isAccepted() {
+	return _accepted;
+}
+
+void CharacterGenerationBaseMenu::accept() {
+	_accepted = true;
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/chargenbase.h
+++ b/src/engines/kotor/gui/chargen/chargenbase.h
@@ -1,0 +1,57 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A base class for all character creation menus.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARGENBASE_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CHARGENBASE_H
+
+#include "src/engines/kotor/gui/gui.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class CharacterGenerationInfo;
+
+class CharacterGenerationBaseMenu : public GUI {
+public:
+	CharacterGenerationBaseMenu(CharacterGenerationInfo &info, ::Engines::Console *console = 0);
+
+	bool isAccepted();
+
+protected:
+	void accept();
+
+	CharacterGenerationInfo &_info;
+
+private:
+	bool _accepted;
+
+	virtual void callbackActive(Widget &UNUSED(widget)){};
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif //ENGINES_KOTOR_GUI_CHARGEN_CHARGENBASE_H

--- a/src/engines/kotor/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor/gui/chargen/chargeninfo.cpp
@@ -1,0 +1,175 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The class for storing character information for generation.
+ */
+
+#include "src/common/strutil.h"
+#include "src/common/error.h"
+#include "chargeninfo.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomMaleSoldier() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderMale;
+	info->_class = kClassSoldier;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomMaleScout() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderMale;
+	info->_class = kClassScout;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomMaleScoundrel() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderMale;
+	info->_class = kClassScoundrel;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomFemaleSoldier() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderFemale;
+	info->_class = kClassSoldier;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomFemaleScout() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderFemale;
+	info->_class = kClassScout;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+CharacterGenerationInfo *CharacterGenerationInfo::createRandomFemaleScoundrel() {
+	CharacterGenerationInfo *info = new CharacterGenerationInfo();
+	info->_gender = kGenderFemale;
+	info->_class = kClassScoundrel;
+	info->_face = std::rand() % 5;
+	info->_skin = Skin(std::rand() % kSkinMAX);
+	info->_name = "";
+
+	return info;
+}
+
+Common::UString CharacterGenerationInfo::getName() {
+	return _name;
+}
+
+Common::UString CharacterGenerationInfo::getPortrait() {
+	Common::UString portrait;
+	portrait = "po_p";
+
+	switch (_gender) {
+		case kGenderMale:
+			portrait += "mh";
+			break;
+		case kGenderFemale:
+			portrait += "fh";
+			break;
+		default:
+			throw Common::Exception("Gender unknown for creating portrait string");
+	}
+
+	switch (_skin) {
+		case kSkinA:
+			portrait += "a";
+			break;
+		case kSkinB:
+			portrait += "b";
+			break;
+		case kSkinC:
+			portrait += "c";
+			break;
+		default:
+			throw Common::Exception("Skin unknown for creating portrait string");
+	}
+
+	portrait += Common::composeString(_face + 1);
+
+	return portrait;
+}
+
+Skin CharacterGenerationInfo::getSkin() {
+	return _skin;
+}
+
+uint8_t CharacterGenerationInfo::getFace() {
+	return _face;
+}
+
+Class CharacterGenerationInfo::getClass() {
+	return _class;
+}
+
+Gender CharacterGenerationInfo::getGender() {
+	return _gender;
+}
+
+void CharacterGenerationInfo::setName(Common::UString name) {
+	_name = name;
+}
+
+void CharacterGenerationInfo::setSkin(Skin skin) {
+	_skin = skin;
+}
+
+void CharacterGenerationInfo::setFace(uint8 face) {
+	_face = face;
+}
+
+Creature *CharacterGenerationInfo::getCharacter() {
+	return new Creature();
+}
+
+CharacterGenerationInfo::CharacterGenerationInfo() {
+
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor/gui/chargen/chargeninfo.cpp
@@ -163,7 +163,9 @@ void CharacterGenerationInfo::setFace(uint8 face) {
 }
 
 Creature *CharacterGenerationInfo::getCharacter() {
-	return new Creature();
+	Creature* creature = new Creature();
+	creature->createPC(this);
+	return creature;
 }
 
 CharacterGenerationInfo::CharacterGenerationInfo() {

--- a/src/engines/kotor/gui/chargen/chargeninfo.h
+++ b/src/engines/kotor/gui/chargen/chargeninfo.h
@@ -1,0 +1,83 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The class for storing character information for generation.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARGENCHAR_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CHARGENCHAR_H
+
+#include <src/engines/kotor/types.h>
+#include <src/common/ustring.h>
+#include <src/engines/kotor/creature.h>
+
+namespace Engines {
+
+namespace KotOR {
+
+class CharacterGenerationInfo {
+public:
+	/** Create a random character from the six stereotypes. */
+	static CharacterGenerationInfo *createRandomMaleSoldier();
+	static CharacterGenerationInfo *createRandomMaleScout();
+	static CharacterGenerationInfo *createRandomMaleScoundrel();
+	static CharacterGenerationInfo *createRandomFemaleSoldier();
+	static CharacterGenerationInfo *createRandomFemaleScout();
+	static CharacterGenerationInfo *createRandomFemaleScoundrel();
+
+	/** Get the name of the character. */
+	Common::UString getName();
+	/** Get the name of the portrait of this character. */
+	Common::UString getPortrait();
+	/** Get the skin type of the character. */
+	Skin getSkin();
+	/** Get the current face index of the character. */
+	uint8_t getFace();
+	/** Get the class of the Character, defined in types.h. */
+	Class getClass();
+	/** Get the Gender of the Character. */
+	Gender getGender();
+
+	/** Set the name of the Character. */
+	void setName(Common::UString);
+	/** Set the skin type of the Character. */
+	void setSkin(Skin);
+	/** Set the face index of the character. */
+	void setFace(uint8);
+
+	Creature *getCharacter();
+
+private:
+	CharacterGenerationInfo();
+
+	Class _class;
+	Gender _gender;
+	Skin _skin;
+	uint8 _face;
+
+	Common::UString _name;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARGENCHAR_H

--- a/src/engines/kotor/gui/chargen/chargeninfo.h
+++ b/src/engines/kotor/gui/chargen/chargeninfo.h
@@ -33,6 +33,8 @@ namespace Engines {
 
 namespace KotOR {
 
+class Creature;
+
 class CharacterGenerationInfo {
 public:
 	/** Create a random character from the six stereotypes. */

--- a/src/engines/kotor/gui/chargen/chargenname.cpp
+++ b/src/engines/kotor/gui/chargen/chargenname.cpp
@@ -1,0 +1,58 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu for modifying the name of the character
+ */
+
+#include "src/engines/kotor/gui/chargen/chargenname.h"
+#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/kotor/gui/widgets/label.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+CharacterGenerationNameMenu::CharacterGenerationNameMenu(CharacterGenerationInfo &info, Console *console) :
+		CharacterGenerationBaseMenu(info, console) {
+
+	load("name");
+
+	addBackground(kBackgroundTypeMenu);
+
+	getLabel("NAME_BOX_EDIT")->setText("");
+}
+
+void CharacterGenerationNameMenu::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_BACK") {
+		_returnCode = 1;
+		return;
+	}
+
+	if (widget.getTag() == "END_BTN") {
+		_returnCode = 1;
+		accept();
+		return;
+	}
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/chargenname.h
+++ b/src/engines/kotor/gui/chargen/chargenname.h
@@ -1,0 +1,47 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu for modifying the name of the character
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARGENNAME_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CHARGENNAME_H
+
+#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/kotor/gui/chargen/chargenbase.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class CharacterGenerationNameMenu : public CharacterGenerationBaseMenu {
+public:
+	CharacterGenerationNameMenu(CharacterGenerationInfo &info, ::Engines::Console *console = 0);
+
+private:
+	void callbackActive(Widget &widget);
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_

--- a/src/engines/kotor/gui/chargen/chargenportrait.cpp
+++ b/src/engines/kotor/gui/chargen/chargenportrait.cpp
@@ -1,0 +1,112 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu for modifying the portrait of the.
+ */
+
+#include "chargenportrait.h"
+
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
+#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/kotor/gui/widgets/button.h"
+#include "src/engines/kotor/gui/widgets/label.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+CharacterGenerationPortraitMenu::CharacterGenerationPortraitMenu(CharacterGenerationInfo &info, Console *console) :
+		CharacterGenerationBaseMenu(info, console) {
+
+	load("portcust");
+
+	addBackground(kBackgroundTypeMenu);
+
+	getLabel("LBL_PORTRAIT")->setFill(_info.getPortrait());
+}
+
+void CharacterGenerationPortraitMenu::callbackActive(Widget &widget)
+{
+	if (widget.getTag() == "BTN_BACK") {
+		_returnCode = 1;
+		return;
+	}
+	if (widget.getTag() == "BTN_ACCEPT") {
+		accept();
+		_returnCode = 1;
+		return;
+	}
+
+	if (widget.getTag() == "BTN_ARRL") {
+		// Get the current skin and face
+		Skin skin = _info.getSkin();
+		uint8_t face = _info.getFace();
+
+		// Move them to left and go in another skin type if needed
+		if (face == 0) {
+			if (skin == kSkinA)
+				skin = kSkinC;
+			else
+				skin = Skin(skin - 1);
+			face = 4;
+		} else {
+			face -= 1;
+		}
+
+		// Set the new skin and face values
+		_info.setSkin(skin);
+		_info.setFace(face);
+
+		// And then reset the portrait
+		getLabel("LBL_PORTRAIT")->setFill(_info.getPortrait());
+
+		return;
+	}
+	if (widget.getTag() == "BTN_ARRR") {
+		// Get the current skin and face
+		Skin skin = _info.getSkin();
+		uint8_t face = _info.getFace();
+
+		// Move them to right and go in another skin type if needed
+		if (face == 4) {
+			if (skin == kSkinC)
+				skin = kSkinA;
+			else
+				skin = Skin(skin + 1);
+			face = 0;
+		} else {
+			face += 1;
+		}
+
+		// Set the new skin and face values
+		_info.setSkin(skin);
+		_info.setFace(face);
+
+		// And then reset the portrait
+		getLabel("LBL_PORTRAIT")->setFill(_info.getPortrait());
+
+		return;
+	}
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/chargenportrait.h
+++ b/src/engines/kotor/gui/chargen/chargenportrait.h
@@ -1,0 +1,49 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu for modifying the portrait of the.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARGENPOTRAIT_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CHARGENPOTRAIT_H
+
+#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/kotor/gui/chargen/chargenbase.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class CharacterGenerationInfo;
+
+class CharacterGenerationPortraitMenu : public CharacterGenerationBaseMenu {
+public:
+	CharacterGenerationPortraitMenu(CharacterGenerationInfo &chargen, ::Engines::Console *console = 0);
+
+private:
+	void callbackActive(Widget &widget);
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARGENPOTRAIT_H

--- a/src/engines/kotor/gui/chargen/classselection.cpp
+++ b/src/engines/kotor/gui/chargen/classselection.cpp
@@ -74,9 +74,6 @@ ClassSelectionMenu::ClassSelectionMenu(Module *module, ::Engines::Console *conso
 }
 
 void ClassSelectionMenu::createCharacterGeneration() {
-	if(_charGen)
-		return;
-
 	_charGen.reset(new CharacterGenerationMenu(_module));
 }
 

--- a/src/engines/kotor/gui/chargen/classselection.cpp
+++ b/src/engines/kotor/gui/chargen/classselection.cpp
@@ -27,6 +27,7 @@
 #include "src/engines/kotor/gui/chargen/classselection.h"
 #include "src/engines/kotor/gui/widgets/kotorwidget.h"
 #include "src/engines/kotor/gui/chargen/charactergeneration.h"
+#include "src/engines/kotor/creature.h"
 
 namespace Engines {
 
@@ -71,10 +72,28 @@ ClassSelectionMenu::ClassSelectionMenu(Module *module, ::Engines::Console *conso
 	_scoutFemaleTitle = femalePrefix + " " + TalkMan.getString(133);
 	_scoundrelMaleTitle = malePrefix + " " + TalkMan.getString(135);
 	_scoundrelFemaleTitle = femalePrefix + " " + TalkMan.getString(135);
+
+	// Create the random Characters
+	_maleSoldier = CharacterGenerationInfo::createRandomMaleSoldier();
+	_maleScout = CharacterGenerationInfo::createRandomMaleScout();
+	_maleScoundrel = CharacterGenerationInfo::createRandomMaleScoundrel();
+	_femaleSoldier = CharacterGenerationInfo::createRandomFemaleSoldier();
+	_femaleScout = CharacterGenerationInfo::createRandomFemaleScout();
+	_femaleScoundrel = CharacterGenerationInfo::createRandomFemaleScoundrel();
 }
 
-void ClassSelectionMenu::createCharacterGeneration() {
-	_charGen.reset(new CharacterGenerationMenu(_module));
+ClassSelectionMenu::~ClassSelectionMenu()
+{
+	delete _maleSoldier;
+	delete _maleScout;
+	delete _maleScoundrel;
+	delete _femaleSoldier;
+	delete _femaleScout;
+	delete _femaleScoundrel;
+}
+
+void ClassSelectionMenu::createCharacterGeneration(CharacterGenerationInfo* info) {
+	_charGen.reset(new CharacterGenerationMenu(_module, info));
 }
 
 void ClassSelectionMenu::callbackRun() {
@@ -124,30 +143,42 @@ void ClassSelectionMenu::callbackActive(Widget &widget) {
 		return;
 	}
 
-	// start the character generation with
+	// Start the character generation with
 	if (widget.getTag() == "BTN_SEL1") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_maleScoundrel);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 	if (widget.getTag() == "BTN_SEL2") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_maleScout);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 	if (widget.getTag() == "BTN_SEL3") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_maleSoldier);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 	if (widget.getTag() == "BTN_SEL4") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_femaleSoldier);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 	if (widget.getTag() == "BTN_SEL5") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_femaleScout);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 	if (widget.getTag() == "BTN_SEL6") {
-		createCharacterGeneration();
-		sub(*_charGen);
+		createCharacterGeneration(_femaleScoundrel);
+		if (sub(*_charGen) == 2) {
+			_returnCode = 2;
+		}
 	}
 }
 

--- a/src/engines/kotor/gui/chargen/classselection.cpp
+++ b/src/engines/kotor/gui/chargen/classselection.cpp
@@ -26,6 +26,7 @@
 
 #include "src/engines/kotor/gui/chargen/classselection.h"
 #include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
@@ -70,6 +71,13 @@ ClassSelectionMenu::ClassSelectionMenu(Module *module, ::Engines::Console *conso
 	_scoutFemaleTitle = femalePrefix + " " + TalkMan.getString(133);
 	_scoundrelMaleTitle = malePrefix + " " + TalkMan.getString(135);
 	_scoundrelFemaleTitle = femalePrefix + " " + TalkMan.getString(135);
+}
+
+void ClassSelectionMenu::createCharacterGeneration() {
+	if(_charGen)
+		return;
+
+	_charGen.reset(new CharacterGenerationMenu(_module));
 }
 
 void ClassSelectionMenu::callbackRun() {
@@ -119,18 +127,30 @@ void ClassSelectionMenu::callbackActive(Widget &widget) {
 		return;
 	}
 
-	// TODO: add class specific character generation code
+	// start the character generation with
 	if (widget.getTag() == "BTN_SEL1") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 	if (widget.getTag() == "BTN_SEL2") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 	if (widget.getTag() == "BTN_SEL3") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 	if (widget.getTag() == "BTN_SEL4") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 	if (widget.getTag() == "BTN_SEL5") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 	if (widget.getTag() == "BTN_SEL6") {
+		createCharacterGeneration();
+		sub(*_charGen);
 	}
 }
 

--- a/src/engines/kotor/gui/chargen/classselection.cpp
+++ b/src/engines/kotor/gui/chargen/classselection.cpp
@@ -1,0 +1,139 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The class selection menu.
+ */
+
+#include "src/aurora/talkman.h"
+
+#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+ClassSelectionMenu::ClassSelectionMenu(Module *module, ::Engines::Console *console) : GUI(console),
+	_module(module) {
+
+	load("classsel");
+
+	addBackground(kBackgroundTypeMenu);
+
+	// Get the six class buttons
+	_maleScoundrelButton = getButton("BTN_SEL1");
+	_maleScoutButton = getButton("BTN_SEL2");
+	_maleSoldierButton = getButton("BTN_SEL3");
+	_femaleSoldierButton = getButton("BTN_SEL4");
+	_femaleScoutButton = getButton("BTN_SEL5");
+	_femaleScoundrelButton = getButton("BTN_SEL6");
+
+	// Get the description label
+	_labelDesc = getLabel("LBL_DESC");
+	_labelDesc->setWrapped(true);
+	_labelDesc->setText(TalkMan.getString(32111));
+
+	// Get the title label
+	_labelTitle = getLabel("LBL_CLASS");
+	_labelTitle->setText("");
+
+	// Get the class descriptions
+	_soldierDesc = TalkMan.getString(32111);
+	_scoutDesc = TalkMan.getString(32110);
+	_scoundrelDesc = TalkMan.getString(32109);
+
+	// Combine the titles with gender prefix and class name
+	Common::UString malePrefix, femalePrefix;
+	malePrefix = TalkMan.getString(358);
+	femalePrefix = TalkMan.getString(359);
+	_soldierMaleTitle = malePrefix + " " + TalkMan.getString(134);
+	_soldierFemaleTitle = femalePrefix + " " + TalkMan.getString(134);
+	_scoutMaleTitle = malePrefix + " " + TalkMan.getString(133);
+	_scoutFemaleTitle = femalePrefix + " " + TalkMan.getString(133);
+	_scoundrelMaleTitle = malePrefix + " " + TalkMan.getString(135);
+	_scoundrelFemaleTitle = femalePrefix + " " + TalkMan.getString(135);
+}
+
+void ClassSelectionMenu::callbackRun() {
+	// Check if a specific button is hovered and set title and description
+	if (_maleSoldierButton->isHovered() && _hoveredButton != _maleSoldierButton) {
+		_labelDesc->setText(_soldierDesc);
+		_labelTitle->setText(_soldierMaleTitle);
+		_hoveredButton = _maleSoldierButton;
+		return;
+	}
+	if (_femaleSoldierButton->isHovered() && _hoveredButton != _femaleSoldierButton) {
+		_labelDesc->setText(_soldierDesc);
+		_labelTitle->setText(_soldierFemaleTitle);
+		_hoveredButton = _femaleSoldierButton;
+		return;
+	}
+	if (_maleScoutButton->isHovered() && _hoveredButton != _maleScoutButton) {
+		_labelDesc->setText(_scoutDesc);
+		_labelTitle->setText(_scoutMaleTitle);
+		_hoveredButton = _maleScoutButton;
+		return;
+	}
+	if (_femaleScoutButton->isHovered() && _hoveredButton != _femaleScoutButton) {
+		_labelDesc->setText(_scoutDesc);
+		_labelTitle->setText(_scoutFemaleTitle);
+		_hoveredButton = _femaleScoutButton;
+		return;
+	}
+	if (_maleScoundrelButton->isHovered() && _hoveredButton != _maleScoundrelButton) {
+		_labelDesc->setText(_scoundrelDesc);
+		_labelTitle->setText(_scoundrelMaleTitle);
+		_hoveredButton = _maleScoundrelButton;
+		return;
+	}
+	if (_femaleScoundrelButton->isHovered() && _hoveredButton != _femaleScoundrelButton) {
+		_labelDesc->setText(_scoundrelDesc);
+		_labelTitle->setText(_scoundrelFemaleTitle);
+		_hoveredButton = _femaleScoundrelButton;
+		return;
+	}
+}
+
+void ClassSelectionMenu::callbackActive(Widget &widget) {
+	// Return to the main menu
+	if (widget.getTag() == "BTN_BACK") {
+		_returnCode = 1;
+		return;
+	}
+
+	// TODO: add class specific character generation code
+	if (widget.getTag() == "BTN_SEL1") {
+	}
+	if (widget.getTag() == "BTN_SEL2") {
+	}
+	if (widget.getTag() == "BTN_SEL3") {
+	}
+	if (widget.getTag() == "BTN_SEL4") {
+	}
+	if (widget.getTag() == "BTN_SEL5") {
+	}
+	if (widget.getTag() == "BTN_SEL6") {
+	}
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/classselection.h
+++ b/src/engines/kotor/gui/chargen/classselection.h
@@ -40,8 +40,12 @@ public:
 	ClassSelectionMenu(Module *module, ::Engines::Console *console = 0);
 
 private:
+	void createCharacterGeneration();
+
 	void callbackRun();
 	void callbackActive(Widget &widget);
+
+	Common::ScopedPtr<GUI> _charGen;
 
 	WidgetLabel *_labelDesc;
 	WidgetLabel *_labelTitle;

--- a/src/engines/kotor/gui/chargen/classselection.h
+++ b/src/engines/kotor/gui/chargen/classselection.h
@@ -27,7 +27,7 @@
 
 #include "src/engines/kotor/module.h"
 #include "src/engines/kotor/gui/gui.h"
-
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
 #include "src/engines/kotor/gui/widgets/button.h"
 #include "src/engines/kotor/gui/widgets/label.h"
 
@@ -38,9 +38,10 @@ namespace KotOR {
 class ClassSelectionMenu : public GUI {
 public:
 	ClassSelectionMenu(Module *module, ::Engines::Console *console = 0);
+	virtual ~ClassSelectionMenu();
 
 private:
-	void createCharacterGeneration();
+	void createCharacterGeneration(CharacterGenerationInfo*);
 
 	void callbackRun();
 	void callbackActive(Widget &widget);
@@ -71,6 +72,13 @@ private:
 	Common::UString _scoundrelFemaleTitle;
 	Common::UString _scoutMaleTitle;
 	Common::UString _scoutFemaleTitle;
+
+	CharacterGenerationInfo* _maleSoldier;
+	CharacterGenerationInfo* _maleScout;
+	CharacterGenerationInfo* _maleScoundrel;
+	CharacterGenerationInfo* _femaleSoldier;
+	CharacterGenerationInfo* _femaleScout;
+	CharacterGenerationInfo* _femaleScoundrel;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/chargen/classselection.h
+++ b/src/engines/kotor/gui/chargen/classselection.h
@@ -1,0 +1,77 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The class selection menu.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CLASSSELECTION_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CLASSSELECTION_H
+
+#include "src/engines/kotor/module.h"
+#include "src/engines/kotor/gui/gui.h"
+
+#include "src/engines/kotor/gui/widgets/button.h"
+#include "src/engines/kotor/gui/widgets/label.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class ClassSelectionMenu : public GUI {
+public:
+	ClassSelectionMenu(Module *module, ::Engines::Console *console = 0);
+
+private:
+	void callbackRun();
+	void callbackActive(Widget &widget);
+
+	WidgetLabel *_labelDesc;
+	WidgetLabel *_labelTitle;
+
+	WidgetButton *_maleSoldierButton;
+	WidgetButton *_maleScoutButton;
+	WidgetButton *_maleScoundrelButton;
+	WidgetButton *_femaleSoldierButton;
+	WidgetButton *_femaleScoutButton;
+	WidgetButton *_femaleScoundrelButton;
+
+	WidgetButton *_hoveredButton;
+
+	Module *_module;
+
+	Common::UString _soldierDesc;
+	Common::UString _scoundrelDesc;
+	Common::UString _scoutDesc;
+
+	Common::UString _soldierMaleTitle;
+	Common::UString _soldierFemaleTitle;
+	Common::UString _scoundrelMaleTitle;
+	Common::UString _scoundrelFemaleTitle;
+	Common::UString _scoutMaleTitle;
+	Common::UString _scoutFemaleTitle;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_CLASSSELECTION_H

--- a/src/engines/kotor/gui/chargen/customchar.cpp
+++ b/src/engines/kotor/gui/chargen/customchar.cpp
@@ -19,37 +19,34 @@
  */
 
 /** @file
- *  The primary character generation menu.
+ *  The panel to customize a quick character.
  */
-
-#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-
-#include "src/engines/kotor/module.h"
-#include "src/engines/kotor/gui/gui.h"
-#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/customchar.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-class CharacterGenerationMenu : public GUI {
-public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
-	~CharacterGenerationMenu();
+CustomCharPanel::CustomCharPanel(CharacterGenerationMenu *charGenMenu, Console *console) :
+		GUI(console), _charGen(charGenMenu) {
 
-	void showQuickOrCustom();
-	void showQuick();
-	void showCustom();
+	load("custpnl");
 
-private:
-	Common::ScopedPtr<GUI> _quickOrCustom;
-	Common::ScopedPtr<GUI> _quickChar;
-	Common::ScopedPtr<GUI> _customChar;
-};
+	setPosition(137, 16, 0);
+
+	float width, height;
+	width = getLabel("LBL_BG")->getWidth();
+	height = getLabel("LBL_BG")->getHeight();
+	getLabel("LBL_BG")->setScissor(5, 40, width-5, height-60);
+}
+
+void CustomCharPanel::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_CANCEL") {
+		_charGen->showQuickOrCustom();
+		return;
+	}
+}
 
 } // End of namespace KotOR
 
 } // End of namespace Engines
-
-#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H

--- a/src/engines/kotor/gui/chargen/customchar.cpp
+++ b/src/engines/kotor/gui/chargen/customchar.cpp
@@ -45,6 +45,13 @@ void CustomCharPanel::callbackActive(Widget &widget) {
 		_charGen->showQuickOrCustom();
 		return;
 	}
+
+	if (widget.getTag() == "BTN_BACK") {
+		_charGen->decStep();
+		return;
+	}
+
+	// TODO implement the custom character generation
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/chargen/customchar.h
+++ b/src/engines/kotor/gui/chargen/customchar.h
@@ -19,37 +19,31 @@
  */
 
 /** @file
- *  The primary character generation menu.
+ *  The panel to customize a quick character.
  */
 
-#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_CUSTOMCHAR_H
+#define ENGINES_KOTOR_GUI_CHARGEN_CUSTOMCHAR_H
 
-#include "src/engines/kotor/module.h"
 #include "src/engines/kotor/gui/gui.h"
-#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-class CharacterGenerationMenu : public GUI {
+class CustomCharPanel : public GUI {
 public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
-	~CharacterGenerationMenu();
-
-	void showQuickOrCustom();
-	void showQuick();
-	void showCustom();
+	CustomCharPanel(CharacterGenerationMenu *charGenMenu, Console *console = 0);
 
 private:
-	Common::ScopedPtr<GUI> _quickOrCustom;
-	Common::ScopedPtr<GUI> _quickChar;
-	Common::ScopedPtr<GUI> _customChar;
+	virtual void callbackActive(Widget &widget);
+
+	CharacterGenerationMenu *_charGen;
 };
 
 } // End of namespace KotOR
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#endif // ENGINES_KOTOR_GUI_CHARGEN_CUSTOMCHAR_H

--- a/src/engines/kotor/gui/chargen/quickchar.cpp
+++ b/src/engines/kotor/gui/chargen/quickchar.cpp
@@ -88,6 +88,10 @@ void QuickCharPanel::updateButtons()
 			getButton("BTN_STEPNAME1")->setPermanentHighlight(true);
 			getButton("BTN_STEPNAME2")->setPermanentHighlight(false);
 			getButton("BTN_STEPNAME3")->setPermanentHighlight(false);
+
+			getButton("BTN_STEPNAME1")->setDisableHighlight(false);
+			getButton("BTN_STEPNAME2")->setDisableHighlight(true);
+			getButton("BTN_STEPNAME3")->setDisableHighlight(true);
 			break;
 
 		case 1:
@@ -98,6 +102,10 @@ void QuickCharPanel::updateButtons()
 			getButton("BTN_STEPNAME1")->setPermanentHighlight(false);
 			getButton("BTN_STEPNAME2")->setPermanentHighlight(true);
 			getButton("BTN_STEPNAME3")->setPermanentHighlight(false);
+
+			getButton("BTN_STEPNAME1")->setDisableHighlight(true);
+			getButton("BTN_STEPNAME2")->setDisableHighlight(false);
+			getButton("BTN_STEPNAME3")->setDisableHighlight(true);
 			break;
 
 		default:
@@ -109,6 +117,10 @@ void QuickCharPanel::updateButtons()
 			getButton("BTN_STEPNAME1")->setPermanentHighlight(false);
 			getButton("BTN_STEPNAME2")->setPermanentHighlight(false);
 			getButton("BTN_STEPNAME3")->setPermanentHighlight(true);
+
+			getButton("BTN_STEPNAME1")->setDisableHighlight(true);
+			getButton("BTN_STEPNAME2")->setDisableHighlight(true);
+			getButton("BTN_STEPNAME3")->setDisableHighlight(false);
 			break;
 	}
 

--- a/src/engines/kotor/gui/chargen/quickchar.cpp
+++ b/src/engines/kotor/gui/chargen/quickchar.cpp
@@ -40,12 +40,82 @@ QuickCharPanel::QuickCharPanel(CharacterGenerationMenu *charGenMenu, Console *co
 	width = getLabel("LBL_DECORATION")->getWidth();
 	height = getLabel("LBL_DECORATION")->getHeight();
 	getLabel("LBL_DECORATION")->setScissor(5, 40, width-5, height-40-40);
+
+	getButton("BTN_STEPNAME1")->setDisableHoverSound(true);
+	getButton("BTN_STEPNAME2")->setDisableHoverSound(true);
+	getButton("BTN_STEPNAME3")->setDisableHoverSound(true);
+
+	updateButtons();
 }
 
 void QuickCharPanel::callbackActive(Widget &widget) {
 	if (widget.getTag() == "BTN_CANCEL") {
 		_charGen->showQuickOrCustom();
 		return;
+	}
+
+	if (widget.getTag() == "BTN_BACK") {
+		_charGen->decStep();
+		updateButtons();
+		return;
+	}
+
+	if (widget.getTag() == "BTN_STEPNAME1") {
+		_charGen->showPotrait();
+		updateButtons();
+		return;
+	}
+	if (widget.getTag() == "BTN_STEPNAME2") {
+		_charGen->showName();
+		updateButtons();
+		return;
+	}
+	if (widget.getTag() == "BTN_STEPNAME3") {
+		_charGen->start();
+		_returnCode = 2;
+		return;
+	}
+}
+
+void QuickCharPanel::updateButtons()
+{
+	switch (_charGen->getStep()) {
+		case 0:
+			getButton("BTN_STEPNAME1")->setDisabled(false);
+			getButton("BTN_STEPNAME2")->setDisabled(true);
+			getButton("BTN_STEPNAME3")->setDisabled(true);
+
+			getButton("BTN_STEPNAME1")->setPermanentHighlight(true);
+			getButton("BTN_STEPNAME2")->setPermanentHighlight(false);
+			getButton("BTN_STEPNAME3")->setPermanentHighlight(false);
+			break;
+
+		case 1:
+			getButton("BTN_STEPNAME1")->setDisabled(true);
+			getButton("BTN_STEPNAME2")->setDisabled(false);
+			getButton("BTN_STEPNAME3")->setDisabled(true);
+
+			getButton("BTN_STEPNAME1")->setPermanentHighlight(false);
+			getButton("BTN_STEPNAME2")->setPermanentHighlight(true);
+			getButton("BTN_STEPNAME3")->setPermanentHighlight(false);
+			break;
+
+		default:
+		case 2:
+			getButton("BTN_STEPNAME1")->setDisabled(true);
+			getButton("BTN_STEPNAME2")->setDisabled(true);
+			getButton("BTN_STEPNAME3")->setDisabled(false);
+
+			getButton("BTN_STEPNAME1")->setPermanentHighlight(false);
+			getButton("BTN_STEPNAME2")->setPermanentHighlight(false);
+			getButton("BTN_STEPNAME3")->setPermanentHighlight(true);
+			break;
+	}
+
+	if (_charGen->getStep() == 0) {
+		getWidget("BTN_BACK")->setDisabled(true);
+	} else {
+		getWidget("BTN_BACK")->setDisabled(false);
 	}
 }
 

--- a/src/engines/kotor/gui/chargen/quickchar.cpp
+++ b/src/engines/kotor/gui/chargen/quickchar.cpp
@@ -19,37 +19,36 @@
  */
 
 /** @file
- *  The primary character generation menu.
+ *  The panel to customize a custom character.
  */
 
-#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-
-#include "src/engines/kotor/module.h"
-#include "src/engines/kotor/gui/gui.h"
-#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/quickchar.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-class CharacterGenerationMenu : public GUI {
-public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
-	~CharacterGenerationMenu();
+QuickCharPanel::QuickCharPanel(CharacterGenerationMenu *charGenMenu, Console *console) :
+		GUI(console),
+		_charGen(charGenMenu) {
 
-	void showQuickOrCustom();
-	void showQuick();
-	void showCustom();
+	load("quickpnl");
 
-private:
-	Common::ScopedPtr<GUI> _quickOrCustom;
-	Common::ScopedPtr<GUI> _quickChar;
-	Common::ScopedPtr<GUI> _customChar;
-};
+	setPosition(137, 15, 0);
+
+	float width, height;
+	width = getLabel("LBL_DECORATION")->getWidth();
+	height = getLabel("LBL_DECORATION")->getHeight();
+	getLabel("LBL_DECORATION")->setScissor(5, 40, width-5, height-40-40);
+}
+
+void QuickCharPanel::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_CANCEL") {
+		_charGen->showQuickOrCustom();
+		return;
+	}
+}
 
 } // End of namespace KotOR
 
 } // End of namespace Engines
-
-#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H

--- a/src/engines/kotor/gui/chargen/quickchar.h
+++ b/src/engines/kotor/gui/chargen/quickchar.h
@@ -19,37 +19,31 @@
  */
 
 /** @file
- *  The primary character generation menu.
+ *  The panel to customize a custom character.
  */
 
-#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_QUICKCHAR_H
+#define ENGINES_KOTOR_GUI_CHARGEN_QUICKCHAR_H
 
-#include "src/engines/kotor/module.h"
 #include "src/engines/kotor/gui/gui.h"
-#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-class CharacterGenerationMenu : public GUI {
+class QuickCharPanel : public GUI {
 public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
-	~CharacterGenerationMenu();
-
-	void showQuickOrCustom();
-	void showQuick();
-	void showCustom();
+	QuickCharPanel(CharacterGenerationMenu *charGenMenu, Console *console = 0);
 
 private:
-	Common::ScopedPtr<GUI> _quickOrCustom;
-	Common::ScopedPtr<GUI> _quickChar;
-	Common::ScopedPtr<GUI> _customChar;
+	void callbackActive(Widget &widget);
+
+	CharacterGenerationMenu *_charGen;
 };
 
 } // End of namespace KotOR
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#endif // ENGINES_KOTOR_GUI_CHARGEN_QUICKCHAR_H

--- a/src/engines/kotor/gui/chargen/quickchar.h
+++ b/src/engines/kotor/gui/chargen/quickchar.h
@@ -38,6 +38,7 @@ public:
 
 private:
 	void callbackActive(Widget &widget);
+	void updateButtons();
 
 	CharacterGenerationMenu *_charGen;
 };

--- a/src/engines/kotor/gui/chargen/quickorcustom.cpp
+++ b/src/engines/kotor/gui/chargen/quickorcustom.cpp
@@ -1,0 +1,70 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The panel to choose between quick or custom characters.
+ */
+
+#include "src/engines/kotor/gui/chargen/quickorcustom.h"
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+QuickOrCustomPanel::QuickOrCustomPanel(CharacterGenerationMenu *charGenMenu, Console *console) :
+		GUI(console),
+		_charGenMenu(charGenMenu) {
+
+	load("qorcpnl");
+
+	setPosition(139, 13, 0);
+
+	float width, height;
+	width = getLabel("LBL_RBG")->getWidth();
+	height = getLabel("LBL_RBG")->getHeight();
+	getLabel("LBL_RBG")->setScissor(5, 0, width-5, height);
+	width = getLabel("LBL_DECORATION")->getWidth();
+	height = getLabel("LBL_DECORATION")->getHeight();
+	getLabel("LBL_DECORATION")->setScissor(5, 0, width-5, height);
+}
+
+QuickOrCustomPanel::~QuickOrCustomPanel() {
+}
+
+void QuickOrCustomPanel::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_BACK") {
+		_returnCode = 1;
+		return;
+	}
+
+	if (widget.getTag() == "QUICK_CHAR_BTN") {
+		_charGenMenu->showQuick();
+		return;
+	}
+	if (widget.getTag() == "CUST_CHAR_BTN") {
+		_charGenMenu->showCustom();
+		return;
+	}
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/chargen/quickorcustom.h
+++ b/src/engines/kotor/gui/chargen/quickorcustom.h
@@ -19,37 +19,33 @@
  */
 
 /** @file
- *  The primary character generation menu.
+ *  The panel to choose between quick or custom characters.
  */
 
-#ifndef ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
-#define ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+#ifndef ENGINES_KOTOR_GUI_CHARGEN_QUICKORCUSTOM_H
+#define ENGINES_KOTOR_GUI_CHARGEN_QUICKORCUSTOM_H
 
-#include "src/engines/kotor/module.h"
 #include "src/engines/kotor/gui/gui.h"
-#include "src/engines/kotor/gui/chargen/classselection.h"
+#include "src/engines/kotor/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-class CharacterGenerationMenu : public GUI {
+class QuickOrCustomPanel : public GUI {
 public:
-	CharacterGenerationMenu(Module *module, ::Engines::Console *console = 0);
-	~CharacterGenerationMenu();
-
-	void showQuickOrCustom();
-	void showQuick();
-	void showCustom();
+	QuickOrCustomPanel(CharacterGenerationMenu *charGenMenu, Console *console = 0);
+	~QuickOrCustomPanel();
 
 private:
-	Common::ScopedPtr<GUI> _quickOrCustom;
-	Common::ScopedPtr<GUI> _quickChar;
-	Common::ScopedPtr<GUI> _customChar;
+	void callbackActive(Widget &widget);
+
+	CharacterGenerationMenu *_charGenMenu;
 };
 
 } // End of namespace KotOR
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTOR_GUI_CHARGEN_CHARACTERGENERATION_H
+
+#endif // ENGINES_KOTOR_GUI_CHARGEN_QUICKORCUSTOM_H

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -21,8 +21,10 @@
 
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/classselection.h \
+    src/engines/kotor/gui/chargen/charactergeneration.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/classselection.cpp \
+    src/engines/kotor/gui/chargen/charactergeneration.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -27,6 +27,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/customchar.h \
     src/engines/kotor/gui/chargen/chargeninfo.h \
     src/engines/kotor/gui/chargen/chargenbase.h \
+    src/engines/kotor/gui/chargen/chargenportrait.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -37,4 +38,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/customchar.cpp \
     src/engines/kotor/gui/chargen/chargeninfo.cpp \
 	src/engines/kotor/gui/chargen/chargenbase.cpp \
+    src/engines/kotor/gui/chargen/chargenportrait.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -28,6 +28,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/chargeninfo.h \
     src/engines/kotor/gui/chargen/chargenbase.h \
     src/engines/kotor/gui/chargen/chargenportrait.h \
+    src/engines/kotor/gui/chargen/chargenname.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -39,4 +40,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/chargeninfo.cpp \
 	src/engines/kotor/gui/chargen/chargenbase.cpp \
     src/engines/kotor/gui/chargen/chargenportrait.cpp \
+	src/engines/kotor/gui/chargen/chargenname.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -20,7 +20,9 @@
 # Character generation menu in Star Wars: Knights of the Old Republic.
 
 src_engines_kotor_libkotor_la_SOURCES += \
+    src/engines/kotor/gui/chargen/classselection.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
+    src/engines/kotor/gui/chargen/classselection.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -22,9 +22,15 @@
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/classselection.h \
     src/engines/kotor/gui/chargen/charactergeneration.h \
+    src/engines/kotor/gui/chargen/quickorcustom.h \
+    src/engines/kotor/gui/chargen/quickchar.h \
+    src/engines/kotor/gui/chargen/customchar.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/classselection.cpp \
     src/engines/kotor/gui/chargen/charactergeneration.cpp \
+    src/engines/kotor/gui/chargen/quickorcustom.cpp \
+    src/engines/kotor/gui/chargen/quickchar.cpp \
+    src/engines/kotor/gui/chargen/customchar.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -26,6 +26,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/quickchar.h \
     src/engines/kotor/gui/chargen/customchar.h \
     src/engines/kotor/gui/chargen/chargeninfo.h \
+    src/engines/kotor/gui/chargen/chargenbase.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -35,4 +36,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/quickchar.cpp \
     src/engines/kotor/gui/chargen/customchar.cpp \
     src/engines/kotor/gui/chargen/chargeninfo.cpp \
+	src/engines/kotor/gui/chargen/chargenbase.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -17,19 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with xoreos. If not, see <http://www.gnu.org/licenses/>.
 
-# GUI system in Star Wars: Knights of the Old Republic.
+# Character generation menu in Star Wars: Knights of the Old Republic.
 
 src_engines_kotor_libkotor_la_SOURCES += \
-    src/engines/kotor/gui/gui.h \
-    src/engines/kotor/gui/guibackground.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
-    src/engines/kotor/gui/gui.cpp \
-    src/engines/kotor/gui/guibackground.cpp \
     $(EMPTY)
-
-include src/engines/kotor/gui/widgets/rules.mk
-include src/engines/kotor/gui/main/rules.mk
-include src/engines/kotor/gui/options/rules.mk
-include src/engines/kotor/gui/chargen/rules.mk

--- a/src/engines/kotor/gui/chargen/rules.mk
+++ b/src/engines/kotor/gui/chargen/rules.mk
@@ -25,6 +25,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/quickorcustom.h \
     src/engines/kotor/gui/chargen/quickchar.h \
     src/engines/kotor/gui/chargen/customchar.h \
+    src/engines/kotor/gui/chargen/chargeninfo.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -33,4 +34,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/chargen/quickorcustom.cpp \
     src/engines/kotor/gui/chargen/quickchar.cpp \
     src/engines/kotor/gui/chargen/customchar.cpp \
+    src/engines/kotor/gui/chargen/chargeninfo.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/main/main.cpp
+++ b/src/engines/kotor/gui/main/main.cpp
@@ -144,7 +144,11 @@ void MainMenu::callbackActive(Widget &widget) {
 
 		// start the charGen Music
 		startCharGenMusic();
-		sub(*_classSelection);
+		if (sub(*_classSelection) == 2) {
+			_returnCode = 2;
+			stopMenuMusic();
+			return;
+		}
 
 		/* if we return from the chargen we stop the music
 		 * and play the main music. */

--- a/src/engines/kotor/gui/main/main.cpp
+++ b/src/engines/kotor/gui/main/main.cpp
@@ -24,17 +24,20 @@
 
 #include "src/common/util.h"
 
+#include "src/engines/aurora/util.h"
+
+#include "src/sound/sound.h"
+
 #include "src/events/events.h"
 
 #include "src/engines/aurora/widget.h"
 
 #include "src/engines/kotor/module.h"
-
 #include "src/engines/kotor/gui/guibackground.h"
 #include "src/engines/kotor/gui/main/main.h"
 #include "src/engines/kotor/gui/main/movies.h"
 #include "src/engines/kotor/gui/main/options.h"
-
+#include "src/engines/kotor/gui/chargen/classselection.h"
 #include "src/engines/kotor/gui/widgets/button.h"
 
 namespace Engines {
@@ -47,11 +50,20 @@ MainMenu::MainMenu(Module &module, bool isXbox, ::Engines::Console *console) : G
 	load(isXbox ? "mainmenu" : "mainmenu16x12");
 
 	addBackground(kBackgroundTypeMenu);
+
+	startMainMusic();
 }
 
 MainMenu::~MainMenu() {
 }
 
+void MainMenu::createClassSelection() {
+	if (_classSelection)
+		return;
+
+	// Create the class selection menu
+	_classSelection.reset(new ClassSelectionMenu(_module, _console));
+}
 
 void MainMenu::createMovies() {
 	if (_movies)
@@ -68,6 +80,18 @@ void MainMenu::createOptions() {
 	// Create the options menu
 	_options.reset(new OptionsMenu(_console));
 
+}
+
+void MainMenu::startMainMusic() {
+	_menuMusic = playSound("mus_theme_cult", Sound::kSoundTypeMusic, true);
+}
+
+void MainMenu::startCharGenMusic() {
+	_menuMusic = playSound("mus_theme_rep", Sound::kSoundTypeMusic, true);
+}
+
+void MainMenu::stopMenuMusic() {
+	SoundMan.stopChannel(_menuMusic);
 }
 
 void MainMenu::initWidget(Widget &widget) {
@@ -113,14 +137,20 @@ void MainMenu::initWidget(Widget &widget) {
 void MainMenu::callbackActive(Widget &widget) {
 
 	if (widget.getTag() == "BTN_NEWGAME") {
-		try {
-			_module->load("end_m01aa");
-		} catch (...) {
-			Common::exceptionDispatcherWarning();
-			return;
-		}
+		// stop the currently running main music
+		stopMenuMusic();
 
-		_returnCode = 2;
+		createClassSelection();
+
+		// start the charGen Music
+		startCharGenMusic();
+		sub(*_classSelection);
+
+		/* if we return from the chargen we stop the music
+		 * and play the main music. */
+		stopMenuMusic();
+		startMainMusic();
+
 		return;
 	}
 

--- a/src/engines/kotor/gui/main/main.h
+++ b/src/engines/kotor/gui/main/main.h
@@ -49,9 +49,17 @@ private:
 	Module *_module;
 	bool _isXbox;
 
+	Common::ScopedPtr<GUI> _classSelection;
 	Common::ScopedPtr<GUI> _movies;
 	Common::ScopedPtr<GUI> _options;
 
+	Sound::ChannelHandle _menuMusic;
+
+	void startMainMusic();
+	void startCharGenMusic();
+	void stopMenuMusic();
+
+	void createClassSelection();
 	void createMovies();
 	void createOptions();
 };

--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -40,7 +40,7 @@ namespace Engines {
 namespace KotOR {
 
 WidgetButton::WidgetButton(::Engines::GUI &gui, const Common::UString &tag) :
-	KotORWidget(gui, tag), _permanentHighlight(false) {
+	KotORWidget(gui, tag), _permanentHighlight(false), _hovered(false) {
 }
 
 WidgetButton::~WidgetButton() {
@@ -70,6 +70,10 @@ void WidgetButton::load(const Aurora::GFF3Struct &gff) {
 	}
 }
 
+bool WidgetButton::isHovered() {
+	return _hovered;
+}
+
 void WidgetButton::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)) {
 	if (isDisabled())
 		return;
@@ -85,6 +89,9 @@ void WidgetButton::enter() {
 	if (!_permanentHighlight) {
 		startHighlight();
 	}
+
+	// the button is at the moment hovered
+	_hovered = true;
 }
 
 void WidgetButton::leave() {
@@ -94,6 +101,9 @@ void WidgetButton::leave() {
 	if (!_permanentHighlight) {
 		stopHighlight();
 	}
+
+	// the buttone is not anymore hovered
+	_hovered = false;
 }
 
 void WidgetButton::startHighlight() {
@@ -112,6 +122,7 @@ void WidgetButton::startHighlight() {
 		_quad->setColor(r, g, b, a);
 		getQuadHighlightableComponent()->setHighlighted(true);
 	}
+
 }
 
 void WidgetButton::stopHighlight() {

--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -40,7 +40,8 @@ namespace Engines {
 namespace KotOR {
 
 WidgetButton::WidgetButton(::Engines::GUI &gui, const Common::UString &tag) :
-	KotORWidget(gui, tag), _permanentHighlight(false), _hovered(false) {
+	KotORWidget(gui, tag), _permanentHighlight(false), _disableHighlight(false),
+	_disableHoverSound(false),  _hovered(false) {
 }
 
 WidgetButton::~WidgetButton() {
@@ -52,6 +53,14 @@ void WidgetButton::setPermanentHighlight(bool permanentHighlight) {
 	if (_permanentHighlight) {
 		startHighlight();
 	} else {
+		stopHighlight();
+	}
+}
+
+void WidgetButton::setDisableHighlight(bool disableHighlight) {
+	_disableHighlight = disableHighlight;
+
+	if (_disableHighlight) {
 		stopHighlight();
 	}
 }
@@ -86,7 +95,7 @@ void WidgetButton::enter() {
 	if (!_disableHoverSound)
 		_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
 
-	if (!_permanentHighlight) {
+	if (!_permanentHighlight && !_disableHighlight) {
 		startHighlight();
 	}
 
@@ -98,7 +107,7 @@ void WidgetButton::leave() {
 	if (!_disableHoverSound)
 		SoundMan.stopChannel(_sound);
 
-	if (!_permanentHighlight) {
+	if (!_permanentHighlight && !_disableHighlight) {
 		stopHighlight();
 	}
 

--- a/src/engines/kotor/gui/widgets/button.h
+++ b/src/engines/kotor/gui/widgets/button.h
@@ -45,6 +45,8 @@ public:
 
 	void mouseUp(uint8 state, float x, float y);
 
+	bool isHovered();
+
 	virtual void enter();
 
 	virtual void leave();
@@ -55,6 +57,8 @@ private:
 
 	Sound::ChannelHandle _sound;
 	float _unselectedR, _unselectedG, _unselectedB, _unselectedA;
+
+	bool _hovered;
 
 	void setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable);
 

--- a/src/engines/kotor/gui/widgets/button.h
+++ b/src/engines/kotor/gui/widgets/button.h
@@ -39,6 +39,7 @@ public:
 	~WidgetButton();
 
 	void setPermanentHighlight(bool);
+	void setDisableHighlight(bool);
 	void setDisableHoverSound(bool);
 
 	virtual void load(const Aurora::GFF3Struct &gff);
@@ -53,6 +54,7 @@ public:
 
 private:
 	bool _permanentHighlight;
+	bool _disableHighlight;
 	bool _disableHoverSound;
 
 	Sound::ChannelHandle _sound;

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -57,7 +57,7 @@ KotORWidget::Text::Text() : strRef(Aurora::kStrRefInvalid), halign(0.0f), valign
 
 
 KotORWidget::KotORWidget(::Engines::GUI &gui, const Common::UString &tag) :
-	Widget(gui, tag), _width(0.0f), _height(0.0f), _r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f) {
+	Widget(gui, tag), _width(0.0f), _height(0.0f), _r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f), _wrapped(false) {
 
 }
 
@@ -86,6 +86,10 @@ void KotORWidget::hide() {
 		_text->hide();
 
 	Widget::hide();
+}
+
+void KotORWidget::setWrapped(bool wrapped) {
+	_wrapped = wrapped;
 }
 
 void KotORWidget::setTag(const Common::UString &tag) {
@@ -201,7 +205,11 @@ void KotORWidget::setText(const Common::UString &text) {
 
 		const float halign = (textX - extendX) / (_width - _text->getWidth());
 		const float valign = (textY - extendY) / (_height - _text->getHeight());
-		 _text->set(text);
+
+		if (_wrapped)
+			_text->set(text, _width);
+		else
+			_text->set(text);
 
 		const float hspan = _width - _text->getWidth();
 		const float vspan = _height - _text->getHeight();

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -123,6 +123,11 @@ void KotORWidget::setPosition(float x, float y, float z) {
 	}
 }
 
+void KotORWidget::setScissor(int x, int y, int width, int height) {
+	_quad->setScissor(true);
+	_quad->setScissor(x, y, width, height);
+}
+
 float KotORWidget::getWidth() const {
 	return _width;
 }

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -56,6 +56,7 @@ public:
 	void setTag(const Common::UString &tag);
 
 	void setPosition(float x, float y, float z);
+	void setScissor(int x, int y, int width, int height); //< create a scissor test over this widget
 
 	float getWidth () const;
 	float getHeight() const;

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -51,6 +51,8 @@ public:
 	void show();
 	void hide();
 
+	void setWrapped(bool wrapped);
+
 	void setTag(const Common::UString &tag);
 
 	void setPosition(float x, float y, float z);
@@ -113,6 +115,8 @@ protected:
 	float _g;
 	float _b;
 	float _a;
+
+	bool _wrapped;
 
 	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _quad;
 	Common::ScopedPtr<Graphics::Aurora::HighlightableText> _text;

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -63,6 +63,7 @@ Module::Module(::Engines::Console &console) : Object(kObjectTypeModule),
 	_console(&console), _hasModule(false), _running(false),
 	_currentTexturePack(-1), _exit(false), _entryLocationType(kObjectTypeAll),
 	_fade(new Graphics::Aurora::FadeQuad()) {
+	loadTexturePack();
 }
 
 Module::~Module() {
@@ -297,9 +298,6 @@ void Module::enter() {
 	if (!_hasModule)
 		throw Common::Exception("Module::enter(): Lacking a module?!?");
 
-	if (!_pc)
-		throw Common::Exception("Module::enter(): Lacking a PC?!?");
-
 	_console->printf("Entering module \"%s\"", _name.c_str());
 
 	Common::UString startMovie = _ifo.getStartMovie();
@@ -309,6 +307,17 @@ void Module::enter() {
 	float entryX, entryY, entryZ, entryAngle;
 	if (!getEntryObjectLocation(entryX, entryY, entryZ, entryAngle))
 		getEntryIFOLocation(entryX, entryY, entryZ, entryAngle);
+
+	if (_pc) {
+		_pc->setPosition(entryX, entryY, entryZ);
+		_pc->show();
+	} else {
+		usePC(new Creature());
+		_pc->createFakePC();
+	}
+
+	if (!_pc)
+		throw Common::Exception("Module::enter(): Lacking a PC?!?");
 
 	// Roughly head position
 	CameraMan.setPosition(entryX, entryY, entryZ + 1.8f);

--- a/src/engines/kotor/types.h
+++ b/src/engines/kotor/types.h
@@ -105,6 +105,28 @@ enum Script {
 	kScriptMAX
 };
 
+enum Gender {
+	kGenderMale = 0,
+	kGenderFemale,
+	kGenderNone
+};
+
+
+enum Skin {
+	kSkinA = 0,
+	kSkinB,
+	kSkinC,
+
+	kSkinMAX
+};
+
+enum Class {
+	kClassNone = 0,
+	kClassSoldier,
+	kClassScout,
+	kClassScoundrel
+};
+
 } // End of namespace KotOR
 
 } // End of namespace Engines


### PR DESCRIPTION
This is a simplified and yet extendable version of the KotOR character creation menu. At the moment you can only create a quick character. I disabled the custom character because most of the stuff, used there is practically not yet implemented. This Code should allow you to create a character and after that see the first level including the created player character standing on the starting point.
What is currently partly or not working:
- The 3d views of the characters
- The custom character creation. You can enter the menu, but the buttons have no functionality
- The buttons in the quick character menu have a glitch which makes the text invisible when disabling them
- The naked body of the characters, because they are weird to handle because of different skin colors
- The name menu is currently only a stub where you can neither create a random name nor create a custom name