### PR TITLE
DISTS: Add CLion project folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ Makefile.in
 # Netbeans project files
 /nbproject/
 
+# CLion project files
+/.idea/
+
 # Debian temp files
 /debian
 /dists/debian/autoreconf.after


### PR DESCRIPTION
I'm working with CLion and since it always asks me to add the project files to git, i disabled the specific folder in the .gitignore file.