### PR TITLE
JADE: Add main menu

### DIFF
--- a/src/engines/jade/game.cpp
+++ b/src/engines/jade/game.cpp
@@ -101,10 +101,6 @@ void Game::runModule() {
 }
 
 void Game::mainMenu() {
-	// TODO: implement main menu
-	_module->load("j01_town");
-	return;
-
 	EventMan.flushEvents();
 
 	MainMenu menu(*_module, _console);

--- a/src/engines/jade/gui/main/main.cpp
+++ b/src/engines/jade/gui/main/main.cpp
@@ -24,9 +24,13 @@
 
 #include "src/common/util.h"
 
+#include "src/graphics/windowman.h"
+
 #include "src/engines/jade/module.h"
 
 #include "src/engines/jade/gui/main/main.h"
+
+#include "src/engines/kotor/gui/widgets/label.h"
 
 namespace Engines {
 
@@ -36,6 +40,51 @@ MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::Kot
 	_module(&module) {
 
 	load("maingame");
+
+	/*
+	 * The original menu was intended for xbox based typical
+	 * "press start" screen. Because of that the main menu needs to be
+	 * dynamically modified to match the pc menu
+	 */
+
+	// No clue for this text, we make it invisible
+	getLabel("LabelLegend")->setInvisible(true);
+	getLabel("Labellegends")->setInvisible(true);
+
+	float wWidth = static_cast<float>(WindowMan.getWindowWidth());
+	float wHeight = static_cast<float>(WindowMan.getWindowHeight());
+
+	// If the window is not 640x480 the sizes and positions have to be modified
+	if (wWidth != 640 || wHeight != 480) {
+		float x, y, z;
+		float w, h;
+
+		// The Bioware and Gray Matter Logos
+		getLabel("LabelLogos")->getPosition(x, y, z);
+		x = (x / 640.0f) * wWidth;
+		y = (y / 480.0f) * wHeight;
+		getLabel("LabelLogos")->setPosition(x, y, z);
+
+		w = getLabel("LabelLogos")->getWidth();
+		h = getLabel("LabelLogos")->getHeight();
+		w = (w / 640.0f) * wWidth;
+		h = (h / 480.0f) * wHeight;
+		getLabel("LabelLogos")->setWidth(w);
+		getLabel("LabelLogos")->setHeight(h);
+
+		// The lower middle strip
+		getLabel("LabelHelp")->getPosition(x, y, z);
+		x = (x / 640.0f) * wWidth;
+		y = (y / 480.0f) * wHeight;
+		getLabel("LabelHelp")->setPosition(x, y, z);
+
+		w = getLabel("LabelHelp")->getWidth();
+		h = getLabel("LabelHelp")->getHeight();
+		w = (w / 640.0f) * wWidth;
+		h = (h / 480.0f) * wHeight;
+		getLabel("LabelHelp")->setWidth(w);
+		getLabel("LabelHelp")->setHeight(h);
+	}
 }
 
 MainMenu::~MainMenu() {

--- a/src/engines/jade/gui/main/main.cpp
+++ b/src/engines/jade/gui/main/main.cpp
@@ -24,6 +24,8 @@
 
 #include "src/common/util.h"
 
+#include "src/aurora/talkman.h"
+
 #include "src/graphics/windowman.h"
 
 #include "src/engines/jade/module.h"
@@ -31,6 +33,8 @@
 #include "src/engines/jade/gui/main/main.h"
 
 #include "src/engines/kotor/gui/widgets/label.h"
+#include "src/engines/kotor/gui/widgets/listbox.h"
+#include "src/engines/kotor/gui/widgets/button.h"
 
 namespace Engines {
 
@@ -42,14 +46,45 @@ MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::Kot
 	load("maingame");
 
 	/*
-	 * The original menu was intended for xbox based typical
-	 * "press start" screen. Because of that the main menu needs to be
-	 * dynamically modified to match the pc menu
+	 * The list box is initially empty, so we need to create the buttons
+	 * for the main menu
 	 */
+	getListBox("ListBoxButtons")->setFill("");
+
+	addWidget(getListBox("ListBoxButtons")->createItem("NEW_GAME"));
+	addWidget(getListBox("ListBoxButtons")->createItem("LOAD_GAME"));
+	addWidget(getListBox("ListBoxButtons")->createItem("MINIGAMES"));
+	addWidget(getListBox("ListBoxButtons")->createItem("OPTIONS"));
+	addWidget(getListBox("ListBoxButtons")->createItem("CREDITS"));
+	addWidget(getListBox("ListBoxButtons")->createItem("EXIT"));
+
+	getButton("NEW_GAME")->setText(TalkMan.getString(111));
+	getButton("LOAD_GAME")->setText(TalkMan.getString(112));
+	getButton("MINIGAMES")->setText(TalkMan.getString(114));
+	getButton("OPTIONS")->setText(TalkMan.getString(116));
+	getButton("CREDITS")->setText(TalkMan.getString(15709));
+	getButton("EXIT")->setText(TalkMan.getString(112745));
+
+	/*
+	 * The Jade Empire Logo is placed in the middle of the screen
+	 * and needs to be moved above the menu buttons
+	 */
+	getLabel("TitleLabel")->setWidth(256);
+	getLabel("TitleLabel")->setHeight(65);
+
+	float tX, tY, tZ;
+	getLabel("TitleLabel")->getPosition(tX, tY, tZ);
+	getLabel("TitleLabel")->setPosition(tX-80, tY+52, tZ);
 
 	// No clue for this text, we make it invisible
 	getLabel("LabelLegend")->setInvisible(true);
 	getLabel("Labellegends")->setInvisible(true);
+
+	/*
+	 * The original menu was intended for xbox based typical
+	 * "press start" screen. Because of that the main menu needs to be
+	 * dynamically modified to match the pc menu
+	 */
 
 	float wWidth = static_cast<float>(WindowMan.getWindowWidth());
 	float wHeight = static_cast<float>(WindowMan.getWindowHeight());
@@ -58,6 +93,19 @@ MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::Kot
 	if (wWidth != 640 || wHeight != 480) {
 		float x, y, z;
 		float w, h;
+
+		// The "Jade Empire" Logo
+		getLabel("TitleLabel")->getPosition(x, y, z);
+		x = (x / 640.0f) * wWidth;
+		y = (y / 480.0f) * wHeight;
+		getLabel("TitleLabel")->setPosition(x, y, z);
+
+		w = getLabel("TitleLabel")->getWidth();
+		h = getLabel("TitleLabel")->getHeight();
+		w = (w / 640.0f) * wWidth;
+		h = (h / 480.0f) * wHeight;
+		getLabel("TitleLabel")->setWidth(w);
+		getLabel("TitleLabel")->setHeight(h);
 
 		// The Bioware and Gray Matter Logos
 		getLabel("LabelLogos")->getPosition(x, y, z);
@@ -90,11 +138,15 @@ MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::Kot
 MainMenu::~MainMenu() {
 }
 
-void MainMenu::callbackActive(Widget &UNUSED(widget)) {
-	try {
-		_module->load("j01_town");
-	} catch (...) {
-		Common::exceptionDispatcherWarning();
+void MainMenu::callbackActive(Widget &widget) {
+	if (widget.getTag() == "NEW_GAME") {
+		try {
+			_module->load("j01_town");
+			_returnCode = 1;
+		} catch (...) {
+			Common::exceptionDispatcherWarning();
+			return;
+		}
 		return;
 	}
 }

--- a/src/engines/kotor/gui/gui.cpp
+++ b/src/engines/kotor/gui/gui.cpp
@@ -89,10 +89,9 @@ void GUI::load(const Common::UString &resref, float width, float height) {
 	_name = resref;
 
 	try {
-		Common::ScopedPtr<Aurora::GFF3File>
-			gff(new Aurora::GFF3File(resref, Aurora::kFileTypeGUI, MKTAG('G', 'U', 'I', ' ')));
+		_gff.reset(new Aurora::GFF3File(resref, Aurora::kFileTypeGUI, MKTAG('G', 'U', 'I', ' ')));
 
-		loadWidget(gff->getTopLevel(), 0, width, height);
+		loadWidget(_gff->getTopLevel(), 0, width, height);
 
 	} catch (Common::Exception &e) {
 		e.add("Can't load GUI \"%s\"", resref.c_str());

--- a/src/engines/kotor/gui/gui.h
+++ b/src/engines/kotor/gui/gui.h
@@ -28,6 +28,7 @@
 #include "src/common/scopedptr.h"
 
 #include "src/aurora/types.h"
+#include "src/aurora/gff3file.h"
 
 #include "src/graphics/aurora/types.h"
 #include "src/graphics/aurora/highlightable.h"
@@ -114,6 +115,8 @@ private:
 	float _widgetZ;
 
 	Common::ScopedPtr<GUIBackground> _background;
+
+	Common::ScopedPtr<Aurora::GFF3File> _gff;
 
 	Common::UString _name;
 

--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -128,31 +128,41 @@ void WidgetButton::leave() {
 void WidgetButton::startHighlight() {
 	float r, g, b, a;
 
-	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
-		_text->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
-		_text->getHighlightedLowerBound(r, g, b, a);
-		_text->setColor(r, g, b, a);
-		_text->setHighlighted(true);
-	}
+	if (_highlight) {
+		_highlight->show();
+	} else {
 
-	if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
-		_quad->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
-		getQuadHighlightableComponent()->getHighlightedLowerBound(r, g, b, a);
-		_quad->setColor(r, g, b, a);
-		getQuadHighlightableComponent()->setHighlighted(true);
+		if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+			_text->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+			_text->getHighlightedLowerBound(r, g, b, a);
+			_text->setColor(r, g, b, a);
+			_text->setHighlighted(true);
+		}
+
+		if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+			_quad->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+			getQuadHighlightableComponent()->getHighlightedLowerBound(r, g, b, a);
+			_quad->setColor(r, g, b, a);
+			getQuadHighlightableComponent()->setHighlighted(true);
+		}
 	}
 
 	_highlighted = true;
 }
 
 void WidgetButton::stopHighlight() {
-	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
-		_text->setHighlighted(false);
-		_text->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
-	}
-	if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
-		getQuadHighlightableComponent()->setHighlighted(false);
-		_quad->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+	if (_highlight) {
+		_highlight->hide();
+	} else {
+
+		if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+			_text->setHighlighted(false);
+			_text->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+		}
+		if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+			getQuadHighlightableComponent()->setHighlighted(false);
+			_quad->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+		}
 	}
 
 	_highlighted = false;

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -337,7 +337,10 @@ KotORWidget::Text KotORWidget::createText(const Aurora::GFF3Struct &gff) {
 			text.text = TalkMan.getString(text.strRef);
 
 		// TODO: KotORWidget::getText(): Alignment
-		if (alignment == 18) {
+		if (alignment == 10) {
+			text.halign = 0.5f;
+			text.valign = 1.0f;
+		} else if (alignment == 18) {
 			text.halign = 0.5f;
 			text.valign = 0.5f;
 		}

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -55,6 +55,9 @@ KotORWidget::Text::Text() : strRef(Aurora::kStrRefInvalid), halign(0.0f), valign
 
 }
 
+KotORWidget::Hilight::Hilight() : fill("") {
+
+}
 
 KotORWidget::KotORWidget(::Engines::GUI &gui, const Common::UString &tag) :
 	Widget(gui, tag), _width(0.0f), _height(0.0f), _r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f), _wrapped(false) {
@@ -84,6 +87,8 @@ void KotORWidget::hide() {
 
 	if (_border)
 		_border->hide();
+	if (_highlight)
+		_highlight->hide();
 	if (_quad)
 		_quad->hide();
 	if (_text)
@@ -124,6 +129,13 @@ void KotORWidget::setPosition(float x, float y, float z) {
 		_text->getPosition(tX, tY, tZ);
 
 		_text->setPosition(tX - oX + x, tY - oY + y, tZ - oZ + z);
+	}
+
+	if (_highlight) {
+		float hX, hY, hZ;
+		_highlight->getPosition(hX, hY, hZ);
+
+		_highlight->setPosition(hX - oX + x, hY - oY + y, hZ - oZ + z);
 	}
 
 	if (_border) {
@@ -188,6 +200,12 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 	Widget::setPosition(extend.x, extend.y, 0.0f);
 
 	Border border = createBorder(gff);
+	Hilight hilight = createHilight(gff);
+
+	if (!hilight.fill.empty()) {
+		_highlight.reset(new Graphics::Aurora::GUIQuad(hilight.fill, 0, 0, extend.w, extend.h));
+		_highlight->setPosition(extend.x, extend.y, 0.0f);
+	}
 
 	if (!border.fill.empty()) {
 		_quad.reset(new Graphics::Aurora::HighlightableGUIQuad(border.fill, 0.0f, 0.0f, extend.w, extend.h));
@@ -320,6 +338,18 @@ KotORWidget::Text KotORWidget::createText(const Aurora::GFF3Struct &gff) {
 	}
 
 	return text;
+}
+
+KotORWidget::Hilight KotORWidget::createHilight(const Aurora::GFF3Struct &gff) {
+	Hilight hilight;
+
+	if (gff.hasField("HILIGHT")) {
+		const Aurora::GFF3Struct &h = gff.getStruct("HILIGHT");
+
+		hilight.fill   = h.getString("FILL");
+	}
+
+	return hilight;
 }
 
 Graphics::Aurora::Highlightable* KotORWidget::getTextHighlightableComponent() const {

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -171,6 +171,12 @@ void KotORWidget::setFont(const Common::UString &fnt) {
 }
 
 void KotORWidget::setFill(const Common::UString &fill) {
+	if (fill.empty()) {
+		_quad->hide();
+		_quad.release();
+		return;
+	}
+
 	if (!_quad) {
 		float x, y, z;
 		getPosition(x, y, z);

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -136,6 +136,16 @@ void KotORWidget::setScissor(int x, int y, int width, int height) {
 	_quad->setScissor(x, y, width, height);
 }
 
+void KotORWidget::setWidth(float width) {
+	if (_quad)
+		_quad->setWidth(width);
+}
+
+void KotORWidget::setHeight(float height) {
+	if (_quad)
+		_quad->setHeight(height);
+}
+
 float KotORWidget::getWidth() const {
 	return _width;
 }

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -117,6 +117,12 @@ protected:
 		Text();
 	};
 
+	struct Hilight {
+		Common::UString fill;
+
+		Hilight();
+	};
+
 	Graphics::Aurora::Highlightable *getTextHighlightableComponent() const;
 	Graphics::Aurora::Highlightable *getQuadHighlightableComponent() const;
 
@@ -131,13 +137,15 @@ protected:
 	bool _wrapped;
 
 	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _quad;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _highlight;
 	Common::ScopedPtr<Graphics::Aurora::HighlightableText> _text;
 	Common::ScopedPtr<Graphics::Aurora::BorderQuad>        _border;
 
 
-	Extend createExtend(const Aurora::GFF3Struct &gff);
-	Border createBorder(const Aurora::GFF3Struct &gff);
-	Text   createText  (const Aurora::GFF3Struct &gff);
+	Extend  createExtend (const Aurora::GFF3Struct &gff);
+	Border  createBorder (const Aurora::GFF3Struct &gff);
+	Text    createText   (const Aurora::GFF3Struct &gff);
+	Hilight createHilight(const Aurora::GFF3Struct &gff);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -64,6 +64,11 @@ public:
 	/** Change the font for this widget. */
 	void setFont(const Common::UString &fnt);
 
+	/** Set the width of the widget */
+	void setWidth(float width);
+	/** Set the height of the widget */
+	void setHeight(float height);
+
 	float getWidth () const;
 	float getHeight() const;
 

--- a/src/engines/kotor/gui/widgets/listbox.cpp
+++ b/src/engines/kotor/gui/widgets/listbox.cpp
@@ -22,22 +22,69 @@
  *  A KotOR listbox widget.
  */
 
-#include "src/common/system.h"
+#include "src/aurora/gff3file.h"
 
+#include "src/engines/kotor/gui/gui.h"
 #include "src/engines/kotor/gui/widgets/listbox.h"
+#include "src/engines/kotor/gui/widgets/button.h"
 
 namespace Engines {
 
 namespace KotOR {
 
 WidgetListBox::WidgetListBox(::Engines::GUI &gui, const Common::UString &tag) :
-	KotORWidget(gui, tag) {
+	KotORWidget(gui, tag), _itemCount(0), _padding(0) {
 }
 
 WidgetListBox::~WidgetListBox() {
 }
 
-void WidgetListBox::load(const Aurora::GFF3Struct &UNUSED(gff)) {
+void WidgetListBox::load(const Aurora::GFF3Struct &gff) {
+	KotORWidget::load(gff);
+
+	if (gff.hasField("PROTOITEM")) {
+		_protoItem = &gff.getStruct("PROTOITEM");
+	}
+
+	if (gff.hasField("SCROLLBAR")) {
+
+	}
+
+	if (gff.hasField("PADDING")) {
+		_padding = gff.getSint("PADDING");
+	}
+}
+
+KotORWidget *WidgetListBox::createItem(Common::UString name) {
+	KotORWidget *item;
+
+	// Create a new widget.
+	switch (_protoItem->getUint("CONTROLTYPE"))
+	{
+		case 6:
+			item = new WidgetButton(*_gui, name);
+			break;
+		default:
+			throw Common::Exception("TODO: Add other supported widget types to the ListBox");
+	}
+
+	// Load the prototype item.
+	item->load(*_protoItem);
+
+	// Calculate the new position for managing it in a list.
+	float x, y, z;
+	getPosition(x, y, z);
+
+	assert(getHeight() > 0);
+
+	y = y - _itemCount * (item->getHeight() + _padding) + getHeight() - item->getHeight();
+
+	item->setPosition(x, y, z);
+	item->show();
+
+	_itemCount += 1;
+
+	return item;
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/widgets/listbox.h
+++ b/src/engines/kotor/gui/widgets/listbox.h
@@ -37,6 +37,14 @@ public:
 	~WidgetListBox();
 
 	void load(const Aurora::GFF3Struct &gff);
+
+	KotORWidget *createItem(Common::UString name);
+
+private:
+	const Aurora::GFF3Struct *_protoItem;
+
+	int _itemCount;
+	int _padding;
 };
 
 } // End of namespace KotOR


### PR DESCRIPTION
I added the buttons for the MainMenu class and modified parts to scale with non-640x480 screens. Also I added some other things mostly related to the KotOR widgets which helped me building this. Be aware, that the MainMenu only scales correctly in 640x480 resolutions