### PR TITLE
KOTOR: Widget borders

### DIFF
--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -74,12 +74,16 @@ void KotORWidget::show() {
 		_quad->show();
 	if (_text)
 		_text->show();
+	if (_border)
+		_border->show();
 }
 
 void KotORWidget::hide() {
 	if (isInvisible())
 		return;
 
+	if (_border)
+		_border->hide();
 	if (_quad)
 		_quad->hide();
 	if (_text)
@@ -120,6 +124,10 @@ void KotORWidget::setPosition(float x, float y, float z) {
 		_text->getPosition(tX, tY, tZ);
 
 		_text->setPosition(tX - oX + x, tY - oY + y, tZ - oZ + z);
+	}
+
+	if (_border) {
+		_border->setPosition(x, y, z);
 	}
 }
 
@@ -179,6 +187,10 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 
 	if (border.fill.empty())
 		_quad->setColor(0.0f, 0.0f, 0.0f, 0.0f);
+
+	if (!border.edge.empty() && !border.corner.empty()) {
+		_border.reset(new Graphics::Aurora::BorderQuad(border.edge, border.corner, extend.x, extend.y, extend.w, extend.h));
+	}
 
 	Text text = createText(gff);
 

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -33,6 +33,7 @@
 #include "src/graphics/aurora/types.h"
 #include "src/graphics/aurora/highlightable.h"
 #include "src/graphics/aurora/highlightabletext.h"
+#include "src/graphics/aurora/borderquad.h"
 
 #include "src/engines/aurora/widget.h"
 
@@ -123,6 +124,7 @@ protected:
 
 	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _quad;
 	Common::ScopedPtr<Graphics::Aurora::HighlightableText> _text;
+	Common::ScopedPtr<Graphics::Aurora::BorderQuad>        _border;
 
 
 	Extend createExtend(const Aurora::GFF3Struct &gff);

--- a/src/graphics/aurora/borderquad.cpp
+++ b/src/graphics/aurora/borderquad.cpp
@@ -1,0 +1,190 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ * A quad for generating borders.
+ */
+
+#include <cfloat>
+
+#include "borderquad.h"
+#include "textureman.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+BorderQuad::BorderQuad(const Common::UString &edge, const Common::UString &corner, float x, float y, float w, float h)
+		: Renderable(kRenderableTypeGUIFront),
+		  _edgeWidth(0), _edgeHeight(0), _cornerWidth(0), _cornerHeight(0),
+		  _x(x), _y(y), _w(w), _h(h) {
+	_edge = TextureMan.get(edge);
+	_corner = TextureMan.get(corner);
+
+	_cornerWidth = _corner.getTexture().getWidth();
+	_cornerHeight = _corner.getTexture().getHeight();
+	_edgeWidth = _edge.getTexture().getWidth();
+	_edgeHeight = _edge.getTexture().getHeight();
+
+	_distance = -FLT_MAX;
+
+	assert(!_corner.empty());
+	assert(!_edge.empty());
+}
+
+void BorderQuad::setPosition(float x, float y, float UNUSED(z)) {
+	lockFrameIfVisible();
+
+	/*
+	 * Because of some graphic glitches with non-integer floats, i have to
+	 * floor the values
+	 */
+	_x = std::floor(x);
+	_y = std::floor(y);
+
+	unlockFrameIfVisible();
+}
+
+void BorderQuad::getPosition(float &x, float &y, float &z) {
+	x = _x;
+	y = _y;
+	z = -FLT_MAX;
+}
+
+void BorderQuad::setSize(float w, float h) {
+	_w = w;
+	_h = h;
+}
+
+void BorderQuad::calculateDistance() {
+}
+
+void BorderQuad::render(RenderPass pass) {
+	bool isTransparent = (!_corner.empty() && _corner.getTexture().hasAlpha()) ||
+			(!_edge.empty() && _edge.getTexture().hasAlpha());
+	if (((pass == kRenderPassOpaque)	  &&  isTransparent) ||
+		((pass == kRenderPassTransparent) && !isTransparent))
+		return;
+
+	TextureMan.set(_corner);
+
+	// Upper left corner
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x, _y + _h - _cornerHeight);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _cornerWidth, _y + _h - _cornerHeight);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _cornerWidth, _y + _h);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x, _y + _h);
+	glEnd();
+
+	// Lower left corner
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x, _y);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _cornerWidth, _y);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _cornerWidth, _y + _cornerHeight);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x, _y + _cornerHeight);
+	glEnd();
+
+	// Upper right corner
+	glBegin(GL_QUADS);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y + _h - _cornerHeight);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _w, _y + _h - _cornerHeight);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x + _w, _y + _h);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y + _h);
+	glEnd();
+
+	// Lower right corner
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x + _w, _y);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _w, _y + _cornerHeight);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y + _cornerHeight);
+	glEnd();
+
+	TextureMan.set(_edge);
+
+	// Left edge
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _w - _edgeWidth, _y + _cornerHeight);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x + _w, _y + _cornerHeight);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _w, _y + _h - _cornerHeight);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _w - _edgeWidth, _y + _h - _cornerHeight);
+	glEnd();
+
+	// Right edge
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x, _y + _cornerHeight);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _cornerWidth, _y + _cornerHeight);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _cornerWidth, _y + _h - _cornerHeight);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x, _y + _h - _cornerHeight);
+	glEnd();
+
+	// Lower edge
+	glBegin(GL_QUADS);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x + _cornerWidth, _y);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _w - _cornerWidth, _y);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y + _edgeHeight);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _cornerWidth, _y + _edgeHeight);
+	glEnd();
+
+	// Upper Edge
+	glBegin(GL_QUADS);
+	glTexCoord2f(1, 0);
+	glVertex2f(_x + _cornerWidth, _y + _h - _edgeHeight);
+	glTexCoord2f(0, 0);
+	glVertex2f(_x + _w - _cornerWidth, _y + _h - _edgeHeight);
+	glTexCoord2f(0, 1);
+	glVertex2f(_x + _w - _cornerWidth, _y + _h);
+	glTexCoord2f(1, 1);
+	glVertex2f(_x + _cornerWidth, _y + _h);
+	glEnd();
+}
+
+} // End of namespace Aurora
+
+} // End of namespace Graphics

--- a/src/graphics/aurora/borderquad.h
+++ b/src/graphics/aurora/borderquad.h
@@ -1,0 +1,66 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ * A quad for generating borders
+ */
+
+#ifndef GRAPHICS_AURORA_BORDERQUAD_H
+#define GRAPHICS_AURORA_BORDERQUAD_H
+
+#include "src/graphics/renderable.h"
+#include "src/graphics/aurora/texture.h"
+#include "src/graphics/aurora/texturehandle.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+class BorderQuad : public Renderable {
+public:
+	BorderQuad(const Common::UString &edge, const Common::UString &corner, float x, float y, float w, float h);
+
+	void setPosition(float x, float y, float z);
+	void getPosition(float &x, float &y, float &z);
+	void setSize(float w, float h);
+
+	virtual void calculateDistance();
+
+	void render(RenderPass pass);
+
+private:
+	TextureHandle _edge, _corner;
+
+	int _edgeWidth, _edgeHeight;
+	int _cornerWidth, _cornerHeight;
+
+	float _x;
+	float _y;
+	float _z;
+	float _w;
+	float _h;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // GRAPHICS_AURORA_BORDERQUAD_H

--- a/src/graphics/aurora/rules.mk
+++ b/src/graphics/aurora/rules.mk
@@ -49,6 +49,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/animnode.h \
     src/graphics/aurora/animation.h \
     src/graphics/aurora/fadequad.h \
+    src/graphics/aurora/borderquad.h \
     src/graphics/aurora/model_nwn.h \
     src/graphics/aurora/model_nwn2.h \
     src/graphics/aurora/model_kotor.h \
@@ -84,6 +85,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/animnode.cpp \
     src/graphics/aurora/animation.cpp \
     src/graphics/aurora/fadequad.cpp \
+    src/graphics/aurora/borderquad.cpp \
     src/graphics/aurora/model_nwn.cpp \
     src/graphics/aurora/model_nwn2.cpp \
     src/graphics/aurora/model_kotor.cpp \


### PR DESCRIPTION
I have investigated the missing borders around some KotOR widgets and found out, that they are defined in the .gui file. I implemented a new class for them named BorderQuad and integrated it into the KotORWidget class.