### PR TITLE
KOTOR: Fix font bug in chargenname gui

### DIFF
--- a/src/engines/kotor/gui/chargen/chargenname.cpp
+++ b/src/engines/kotor/gui/chargen/chargenname.cpp
@@ -38,7 +38,8 @@ CharacterGenerationNameMenu::CharacterGenerationNameMenu(CharacterGenerationInfo
 
 	addBackground(kBackgroundTypeMenu);
 
-	getLabel("NAME_BOX_EDIT")->setText("");
+	getLabel("NAME_BOX_EDIT")->setFont("fnt_d16x16b");
+	getLabel("NAME_BOX_EDIT")->setText("_");
 }
 
 void CharacterGenerationNameMenu::callbackActive(Widget &widget) {

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -136,6 +136,10 @@ float KotORWidget::getHeight() const {
 	return _height;
 }
 
+void KotORWidget::setFont(const Common::UString &fnt) {
+	_text->setFont(fnt);
+}
+
 void KotORWidget::setFill(const Common::UString &fill) {
 	if (!_quad) {
 		float x, y, z;

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -60,6 +60,9 @@ public:
 	/** Create a scissor test over this widget. */
 	void setScissor(int x, int y, int width, int height);
 
+	/** Change the font for this widget. */
+	void setFont(const Common::UString &fnt);
+
 	float getWidth () const;
 	float getHeight() const;
 

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -26,6 +26,7 @@
 
 #include "src/graphics/font.h"
 
+#include "src/graphics/aurora/fontman.h"
 #include "src/graphics/aurora/text.h"
 
 namespace Graphics {
@@ -240,6 +241,10 @@ void Text::parseColors(const Common::UString &str, Common::UString &parsed,
 			parsed += *t;
 
 	}
+}
+
+void Text::setFont(const Common::UString &fnt) {
+	_font = FontMan.get(fnt);
 }
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -54,6 +54,9 @@ public:
 	void unsetColor();
 	void setAlign(float align);
 
+	/** Change the font of the text. */
+	void setFont(const Common::UString &fnt);
+
 	/** Disable parsing <c color tokens into actual coloring. */
 	void disableColorTokens(bool disabled);
 


### PR DESCRIPTION
The chargenname gui uses a font, which is somehow corrupted. I added the possiblity to change a widgets font and changed it inside the name generation gui.