### PR TITLE
AURORA: Add a text input callback to the gui class

### DIFF
--- a/src/engines/aurora/gui.cpp
+++ b/src/engines/aurora/gui.cpp
@@ -200,6 +200,8 @@ uint32 GUI::processEventQueue() {
 			mouseUp(*e);
 		else if (e->type == Events::kEventMouseWheel)
 			mouseWheel(*e);
+		else if (e->type == Events::kEventTextInput)
+			textInput(*e);
 	}
 
 	_eventQueue.clear();
@@ -217,6 +219,8 @@ void GUI::callbackRun() {
 void GUI::callbackActive(Widget &UNUSED(widget)) {
 }
 
+void GUI::callbackTextInput(const Common::UString &UNUSED(text)) {
+}
 
 void GUI::addChild(GUI *gui) {
 	_childGUIs.push_back(gui);
@@ -506,6 +510,10 @@ void GUI::mouseWheel(const Events::Event &event) {
 		changedWidget(widget);
 
 	mouseWheel(_currentWidget, event);
+}
+
+void GUI::textInput(const Events::Event &event) {
+	callbackTextInput(event.text.text);
 }
 
 float GUI::toGUIX(int x) {

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -114,6 +114,8 @@ protected:
 	virtual void callbackRun();
 	/** Callback that's triggered when a widget was activated. */
 	virtual void callbackActive(Widget &widget);
+	/** Callback that's triggered when a text input is received. */
+	virtual void callbackTextInput(const Common::UString &text);
 
 	/** Add a child GUI object to this GUI. Ownership of the pointer is not transferred. */
 	void addChild(GUI *gui);
@@ -145,6 +147,7 @@ private:
 	void mouseDown(const Events::Event &event); ///< Mouse down event triggered.
 	void mouseUp(const Events::Event &event);   ///< Mouse up event triggered.
 	void mouseWheel(const Events::Event &event); ///< Mouse wheel event triggered.
+	void textInput(const Events::Event &event); ///< Text input event received.
 
 	float toGUIX(int x); // Convert an event X coordinate to a GUI X coordinate
 	float toGUIY(int y); // Convert an event Y coordinate to a GUI Y coordinate


### PR DESCRIPTION
Adds a simple solution for gui wide text input over a callback. For deleting characters i thought about another callback for keys which could also be used for ingame shortcuts.