### PR TITLE
CMAKE: Add some lines for a make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,3 +452,12 @@ if(XOREOS_BUILD_DOCUMENTATION)
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
 endif()
+
+# -------------------------------------------------------------------------
+# installation
+if(UNIX)
+  include(GNUInstallDirs)
+  install(TARGETS xoreos
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}
+  )
+endif()


### PR DESCRIPTION
Add some lines for installing the xoreos executable into ${CMAKE_INSTALL_PREFIX}/bin on unix based systems.