### PR TITLE
KOTOR: Add the typing possibility in the CharGenName class

### DIFF
--- a/src/engines/kotor/gui/chargen/chargenname.cpp
+++ b/src/engines/kotor/gui/chargen/chargenname.cpp
@@ -22,10 +22,13 @@
  *  The menu for modifying the name of the character.
  */
 
+#include "src/events/events.h"
+
 #include "src/engines/kotor/gui/widgets/kotorwidget.h"
 #include "src/engines/kotor/gui/widgets/label.h"
 
 #include "src/engines/kotor/gui/chargen/chargenname.h"
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
 
 namespace Engines {
 
@@ -38,21 +41,49 @@ CharacterGenerationNameMenu::CharacterGenerationNameMenu(CharacterGenerationInfo
 
 	addBackground(kBackgroundTypeMenu);
 
-	getLabel("NAME_BOX_EDIT")->setFont("fnt_d16x16b");
-	getLabel("NAME_BOX_EDIT")->setText("_");
+	_nameLabel = getLabel("NAME_BOX_EDIT");
+	_nameLabel->setFont("fnt_d16x16b");
+	_nameLabel->setText("_");
+
+	EventMan.enableTextInput(true);
+	EventMan.enableKeyRepeat(true);
 }
 
 void CharacterGenerationNameMenu::callbackActive(Widget &widget) {
 	if (widget.getTag() == "BTN_BACK") {
 		_returnCode = 1;
+		EventMan.enableTextInput(false);
+		EventMan.enableKeyRepeat(false);
 		return;
 	}
 
 	if (widget.getTag() == "END_BTN") {
 		_returnCode = 1;
 		accept();
+		EventMan.enableTextInput(false);
+		EventMan.enableKeyRepeat(false);
 		return;
 	}
+}
+
+void CharacterGenerationNameMenu::callbackKeyInput(const Events::Key &key, const Events::EventType &type) {
+	if (key == Events::kKeyBackspace && type == Events::kEventKeyDown) {
+		if (!_name.empty()) {
+			_name.erase(--_name.end());
+			_nameLabel->setText(_name + "_");
+		}
+	}
+}
+
+void CharacterGenerationNameMenu::callbackTextInput(const Common::UString &text) {
+	// The name should not be longer than 18 letters (according to the original game).
+	if (_name.size() == 18) {
+		return;
+	}
+
+	_name += text;
+	_info.setName(_name);
+	_nameLabel->setText(_name + "_");
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/chargen/chargenname.h
+++ b/src/engines/kotor/gui/chargen/chargenname.h
@@ -39,6 +39,11 @@ public:
 
 private:
 	void callbackActive(Widget &widget);
+	void callbackTextInput(const Common::UString &text);
+	void callbackKeyInput(const Events::Key &key, const Events::EventType &type);
+
+	WidgetLabel *_nameLabel;
+	Common::UString _name;
 };
 
 } // End of namespace KotOR


### PR DESCRIPTION
This PR adds an implemented callbackTextInput() for the CharGenName class. Now it is possible to type the character name with a maximum of 18 letters (this is the maximum of the original game).