### PR TITLE
KOTOR: Add the nwscript function GetLevelByClass

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -62,6 +62,17 @@ void Creature::init() {
 	_isPC = false;
 
 	_appearance = Aurora::kFieldIDInvalid;
+
+	_levels[kClassSoldier] = 0;
+	_levels[kClassScout] = 0;
+	_levels[kClassScoundrel] = 0;
+	_levels[kClassJediGuardian] = 0;
+	_levels[kClassJediConsular] = 0;
+	_levels[kClassJediSentinel] = 0;
+	_levels[kClassCombatDroid] = 0;
+	_levels[kClassExpertDroid] = 0;
+	_levels[kClassMinion] = 0;
+	_levels[kClassInvalid] = 0;
 }
 
 void Creature::show() {
@@ -76,6 +87,10 @@ void Creature::hide() {
 
 bool Creature::isPC() const {
 	return _isPC;
+}
+
+int Creature::getLevel(const Class &c) const {
+	return _levels.at(c);
 }
 
 void Creature::setPosition(float x, float y, float z) {
@@ -288,6 +303,9 @@ void Creature::createPC(CharacterGenerationInfo *info) {
 			parts.body += "m";
 			break;
 	}
+
+	// set the specific class to level 1
+	_levels[info->getClass()] = 1;
 
 	loadBody(parts);
 

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -62,6 +62,7 @@ public:
 	// Basic properties
 
 	bool isPC() const; ///< Is the creature a player character?
+	int getLevel(const Class &c) const; ///< Get the level of the creature regarding a specific class
 
 	// Positioning
 
@@ -96,6 +97,7 @@ private:
 
 	uint32 _appearance; ///< The creature's general appearance.
 
+	std::map<Class, int> _levels; ///< The levels of the creature.
 	Common::ScopedPtr<Graphics::Aurora::Model> _model; ///< The creature's model.
 
 

--- a/src/engines/kotor/script/function_tables.h
+++ b/src/engines/kotor/script/function_tables.h
@@ -461,7 +461,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{ 340, "GetNextItemInInventory"              , 0                                                },
 	{ 341, "GetClassByPosition"                  , 0                                                },
 	{ 342, "GetLevelByPosition"                  , 0                                                },
-	{ 343, "GetLevelByClass"                     , 0                                                },
+	{ 343, "GetLevelByClass"                     , &Functions::getLevelByClass                      },
 	{ 344, "GetDamageDealtByType"                , 0                                                },
 	{ 345, "GetTotalDamageDealt"                 , 0                                                },
 	{ 346, "GetLastDamager"                      , 0                                                },

--- a/src/engines/kotor/script/functions.h
+++ b/src/engines/kotor/script/functions.h
@@ -212,6 +212,10 @@ private:
 	// .--- Movies, functions_movie.cpp
 	void playMovie(Aurora::NWScript::FunctionContext &ctx);
 	// '---
+
+	// .--- Creatures, functions_creatures.cpp
+	void getLevelByClass(Aurora::NWScript::FunctionContext &ctx);
+	// '---
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/script/functions_creatures.cpp
+++ b/src/engines/kotor/script/functions_creatures.cpp
@@ -1,0 +1,53 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Star Wars: Knights of the Old Republic engine functions managing creatures
+ */
+
+#include "src/common/error.h"
+
+#include "src/aurora/nwscript/functioncontext.h"
+
+#include "src/engines/kotor/types.h"
+#include "src/engines/kotor/creature.h"
+#include "src/engines/kotor/objectcontainer.h"
+
+#include "src/engines/kotor/script/functions.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+void Functions::getLevelByClass(Aurora::NWScript::FunctionContext &ctx) {
+	Class creatureClass = Class(ctx.getParams()[0].getInt());
+	Aurora::NWScript::Object *object = ctx.getParams()[1].getObject();
+
+	Creature *creature = ObjectContainer::toCreature(object);
+
+	if (!creature)
+		throw Common::Exception("Functions::getGender(): object is not a creature");
+
+	ctx.getReturn() = creature->getLevel(creatureClass);
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/script/rules.mk
+++ b/src/engines/kotor/script/rules.mk
@@ -36,4 +36,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/script/functions_action.cpp \
     src/engines/kotor/script/functions_sound.cpp \
     src/engines/kotor/script/functions_movie.cpp \
+    src/engines/kotor/script/functions_creatures.cpp \
     $(EMPTY)

--- a/src/engines/kotor/types.h
+++ b/src/engines/kotor/types.h
@@ -121,10 +121,16 @@ enum Skin {
 };
 
 enum Class {
-	kClassNone = 0,
-	kClassSoldier,
+	kClassSoldier = 0,
 	kClassScout,
-	kClassScoundrel
+	kClassScoundrel,
+	kClassJediGuardian,
+	kClassJediConsular,
+	kClassJediSentinel,
+	kClassExpertDroid,
+	kClassCombatDroid,
+	kClassMinion,
+	kClassInvalid = 255
 };
 
 } // End of namespace KotOR


### PR DESCRIPTION
Add the nwscript function GetLevelByClass which returns the class level of a creature. Also I added the class level logic to the Creature class. As far as I remember, a player can have multiple class levels because of the two times, he can choose a class (Soldier, Scoundrel and Scout, and later at Dantooine the Jedi classes. Then the old level is frozen and the new one is increased at every level up. Because of that, i designed it the way, a creature can have multiple levels for every class type.