### PR TITLE
KOTOR2: Fix the border texture bug

### DIFF
--- a/src/engines/kotor2/gui/main/main.cpp
+++ b/src/engines/kotor2/gui/main/main.cpp
@@ -37,7 +37,7 @@ namespace Engines {
 namespace KotOR2 {
 
 MainMenu::MainMenu(Module &module, ::Engines::Console *console) : GUI(console), _module(&module) {
-	load("mainmenu16x12_p");
+	load("mainmenu8x6_p");
 }
 
 MainMenu::~MainMenu() {


### PR DESCRIPTION
![bildschirmfoto zu 2017-10-17 12-11-04](https://user-images.githubusercontent.com/17826813/31659475-8ad21224-b334-11e7-8077-e36db8c9594c.png)
While testing KOTOR2, i realized, that after the border update it crashed with unknown textures. I looked  into this in detail and realized, that even without the borders, it is not exactly like the original. The appended picture shows the differences between the old layout left, the new layout right and the original game in the mid. I changed the used layout to the new layout.
