### PR TITLE
KOTOR: Widget border fix

### DIFF
--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -193,7 +193,9 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 		_quad->setColor(0.0f, 0.0f, 0.0f, 0.0f);
 
 	if (!border.edge.empty() && !border.corner.empty()) {
-		_border.reset(new Graphics::Aurora::BorderQuad(border.edge, border.corner, extend.x, extend.y, extend.w, extend.h));
+		_border.reset(new Graphics::Aurora::BorderQuad(border.edge, border.corner,
+		                                               extend.x, extend.y, extend.w, extend.h,
+		                                               border.dimension));
 	}
 
 	Text text = createText(gff);

--- a/src/graphics/aurora/borderquad.cpp
+++ b/src/graphics/aurora/borderquad.cpp
@@ -33,17 +33,30 @@ namespace Graphics {
 namespace Aurora {
 
 BorderQuad::BorderQuad(const Common::UString &edge, const Common::UString &corner,
-                       float x, float y, float w, float h) :
+                       float x, float y, float w, float h, int dimension) :
 	Renderable(kRenderableTypeGUIFront), _edgeWidth(0), _edgeHeight(0), _cornerWidth(0), _cornerHeight(0),
 	_x(x), _y(y), _w(w), _h(h) {
 
 	_edge = TextureMan.get(edge);
 	_corner = TextureMan.get(corner);
 
-	_cornerWidth = _corner.getTexture().getWidth();
-	_cornerHeight = _corner.getTexture().getHeight();
-	_edgeWidth = _edge.getTexture().getWidth();
-	_edgeHeight = _edge.getTexture().getHeight();
+	if (dimension == 0) {
+		_cornerWidth = _corner.getTexture().getWidth();
+		_cornerHeight = _corner.getTexture().getHeight();
+		_edgeWidth = _edge.getTexture().getWidth();
+		_edgeHeight = _edge.getTexture().getHeight();
+	} else {
+		/*
+		 * because we do not have a proper factor for modifying the corners, we simply calculate the
+		 * factor with the difference of the edge to the dimension
+		 */
+		float widthFactor = static_cast<float>(dimension)/ static_cast<float>(_edge.getTexture().getWidth());
+		float heightFactor = static_cast<float>(dimension)/ static_cast<float>(_edge.getTexture().getHeight());
+		_cornerWidth = widthFactor * _corner.getTexture().getWidth();
+		_cornerHeight = heightFactor * _corner.getTexture().getHeight();
+		_edgeWidth = dimension;
+		_edgeHeight = dimension;
+	}
 
 	_distance = -FLT_MAX;
 

--- a/src/graphics/aurora/borderquad.h
+++ b/src/graphics/aurora/borderquad.h
@@ -37,7 +37,8 @@ namespace Aurora {
 
 class BorderQuad : public Renderable {
 public:
-	BorderQuad(const Common::UString &edge, const Common::UString &corner, float x, float y, float w, float h);
+	BorderQuad(const Common::UString &edge, const Common::UString &corner, float x, float y, float w, float h,
+	           int dimension = 0);
 
 	void setPosition(float x, float y, float z);
 	void getPosition(float &x, float &y, float &z);


### PR DESCRIPTION
I recognized, that in some cases, the borders became oversized. I investigated this, and found out, that there is a dimension parameter which controls the thickness of the border. I added handling for this parameter in the BorderQuad and KotORWidget classes.