### PR TITLE
KOTOR: Correctly changing the buttons border when highlighted

### DIFF
--- a/src/engines/kotor/gui/main/options.cpp
+++ b/src/engines/kotor/gui/main/options.cpp
@@ -85,6 +85,13 @@ void OptionsMenu::callbackActive(Widget &widget) {
 	}
 }
 
+void OptionsMenu::initWidget(Widget &widget) {
+    if(widget.getTag().beginsWith("BTN_")){
+        ((WidgetButton&) widget).setHighlightCornerTexture();
+        ((WidgetButton&) widget).setHighlightEdgeTexture();
+    }
+}
+
 void OptionsMenu::adoptChanges() {
 	dynamic_cast<OptionsGameplayMenu &>(*_gameplay).adoptChanges();
 }

--- a/src/engines/kotor/gui/widgets/button.cpp
+++ b/src/engines/kotor/gui/widgets/button.cpp
@@ -23,14 +23,16 @@
  */
 
 #include "src/common/system.h"
-
 #include "src/aurora/gff3file.h"
 
 #include "src/sound/sound.h"
 
 #include "src/graphics/aurora/guiquad.h"
+
 #include "src/graphics/aurora/text.h"
 #include "src/graphics/aurora/highlightabletext.h"
+#include "src/graphics/aurora/highlightableborder.h"
+#include "src/graphics/aurora/textureman.h"
 
 #include "src/engines/aurora/util.h"
 #include "src/engines/kotor/gui/widgets/button.h"
@@ -83,6 +85,9 @@ void WidgetButton::load(const Aurora::GFF3Struct &gff) {
 	if (getQuadHighlightableComponent() != 0) {
 		  setDefaultHighlighting(getQuadHighlightableComponent());
 	}
+    if (getBorderHighlightableComponent() != 0) {
+        setDefaultHighlighting(getBorderHighlightableComponent());
+    }
 }
 
 bool WidgetButton::isHovered() {
@@ -138,6 +143,10 @@ void WidgetButton::startHighlight() {
 		getQuadHighlightableComponent()->setHighlighted(true);
 	}
 
+    if (getBorderHighlightableComponent() && getBorderHighlightableComponent()->isHighlightable()) {
+        getBorderHighlightableComponent()->setHighlighted(true);
+    }
+
 	_highlighted = true;
 }
 
@@ -151,6 +160,10 @@ void WidgetButton::stopHighlight() {
 		_quad->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
 	}
 
+    if (getBorderHighlightableComponent() && getBorderHighlightableComponent()->isHighlightable()) {
+        getBorderHighlightableComponent()->setHighlighted(false);
+    }
+
 	_highlighted = false;
 }
 
@@ -159,6 +172,18 @@ void WidgetButton::setDefaultHighlighting(Graphics::Aurora::Highlightable *highl
 	highlightable->setHighlightDelta(0, 0, 0, .05);
 	highlightable->setHighlightLowerBound(1, 1, 0, .2);
 	highlightable->setHighlightUpperBound(1, 1, 0, 1);
+}
+
+void WidgetButton::setHighlightEdgeTexture() {
+    if(getBorderHighlightableComponent() != 0) {
+        ((Graphics::Aurora::HighlightableBorder*) getBorderHighlightableComponent())->setHighlightEdgeTexture(TextureMan.get("boxline6"));
+    }
+}
+
+void WidgetButton::setHighlightCornerTexture() {
+    if(getBorderHighlightableComponent() != 0) {
+        ((Graphics::Aurora::HighlightableBorder*) getBorderHighlightableComponent())->setHighlightCornerTexture(TextureMan.get("boxline5"));
+    }
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/widgets/button.h
+++ b/src/engines/kotor/gui/widgets/button.h
@@ -42,6 +42,9 @@ public:
 	void setDisableHighlight(bool);
 	void setDisableHoverSound(bool);
 
+    void setHighlightEdgeTexture();
+    void setHighlightCornerTexture();
+
 	virtual void load(const Aurora::GFF3Struct &gff);
 
 	void mouseUp(uint8 state, float x, float y);

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -23,16 +23,17 @@
  */
 
 #include "src/common/util.h"
-
 #include "src/aurora/types.h"
+
 #include "src/aurora/gff3file.h"
 #include "src/aurora/talkman.h"
-
 #include "src/graphics/aurora/fontman.h"
+
 #include "src/graphics/aurora/guiquad.h"
 #include "src/graphics/aurora/text.h"
 #include "src/graphics/aurora/highlightabletext.h"
 #include "src/graphics/aurora/highlightableguiquad.h"
+#include <src/graphics/aurora/highlightableborder.h>
 
 #include "src/engines/kotor/gui/widgets/kotorwidget.h"
 
@@ -178,6 +179,7 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 	Widget::setPosition(extend.x, extend.y, 0.0f);
 
 	Border border = createBorder(gff);
+	Border highlight = createHighlightBorder(gff);
 
 	if (!border.fill.empty()) {
 		_quad.reset(new Graphics::Aurora::HighlightableGUIQuad(border.fill, 0.0f, 0.0f, extend.w, extend.h));
@@ -195,6 +197,9 @@ void KotORWidget::load(const Aurora::GFF3Struct &gff) {
 	if (!border.edge.empty() && !border.corner.empty()) {
 		_border.reset(new Graphics::Aurora::BorderQuad(border.edge, border.corner, extend.x, extend.y, extend.w, extend.h));
 	}
+    if (!border.edge.empty() && !border.corner.empty() && !highlight.edge.empty() && !highlight.corner.empty()) {
+        _border.reset(new Graphics::Aurora::HighlightableBorder(border.edge, border.corner, extend.x, extend.y, extend.w, extend.h, highlight.corner, highlight.edge));
+    }
 
 	Text text = createText(gff);
 
@@ -277,6 +282,27 @@ KotORWidget::Border KotORWidget::createBorder(const Aurora::GFF3Struct &gff) {
 	return border;
 }
 
+KotORWidget::Border KotORWidget::createHighlightBorder(const Aurora::GFF3Struct &gff) {
+    Border border;
+
+    if (gff.hasField("HILIGHT")) {
+        const Aurora::GFF3Struct &b = gff.getStruct("HILIGHT");
+
+        border.corner = b.getString("CORNER");
+        border.edge   = b.getString("EDGE");
+        border.fill   = b.getString("FILL");
+
+        border.fillStyle   = b.getUint("FILLSTYLE");
+        border.dimension   = b.getUint("DIMENSION");
+        border.innerOffset = b.getUint("INNEROFFSET");
+
+        b.getVector("COLOR", border.r, border.g, border.b);
+
+        border.pulsing = b.getBool("PULSING");
+    }
+    return border;
+}
+
 KotORWidget::Text KotORWidget::createText(const Aurora::GFF3Struct &gff) {
 	Text text;
 
@@ -316,6 +342,10 @@ Graphics::Aurora::Highlightable* KotORWidget::getTextHighlightableComponent() co
 
 Graphics::Aurora::Highlightable* KotORWidget::getQuadHighlightableComponent() const {
 	return dynamic_cast<Graphics::Aurora::Highlightable*>(_quad.get());
+}
+
+Graphics::Aurora::Highlightable *KotORWidget::getBorderHighlightableComponent() const {
+    return dynamic_cast<Graphics::Aurora::Highlightable*>(_border.get());
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -114,6 +114,7 @@ protected:
 
 	Graphics::Aurora::Highlightable *getTextHighlightableComponent() const;
 	Graphics::Aurora::Highlightable *getQuadHighlightableComponent() const;
+	Graphics::Aurora::Highlightable *getBorderHighlightableComponent() const;
 
 	float _width;
 	float _height;
@@ -133,6 +134,8 @@ protected:
 	Extend createExtend(const Aurora::GFF3Struct &gff);
 	Border createBorder(const Aurora::GFF3Struct &gff);
 	Text   createText  (const Aurora::GFF3Struct &gff);
+
+    Border createHighlightBorder(const Aurora::GFF3Struct &gff);
 };
 
 } // End of namespace KotOR

--- a/src/graphics/aurora/borderquad.cpp
+++ b/src/graphics/aurora/borderquad.cpp
@@ -183,6 +183,14 @@ void BorderQuad::render(RenderPass pass) {
 	glEnd();
 }
 
+void BorderQuad::setCornerTexture(const TextureHandle &corner) {
+	_corner = corner;
+}
+
+void BorderQuad::setEdgeTexture(const TextureHandle &edge) {
+	_edge = edge;
+}
+
 } // End of namespace Aurora
 
 } // End of namespace Graphics

--- a/src/graphics/aurora/borderquad.h
+++ b/src/graphics/aurora/borderquad.h
@@ -43,6 +43,9 @@ public:
 	void getPosition(float &x, float &y, float &z);
 	void setSize(float w, float h);
 
+    void setCornerTexture(const TextureHandle &corner);
+    void setEdgeTexture(const TextureHandle &edge);
+
 	virtual void calculateDistance();
 
 	void render(RenderPass pass);

--- a/src/graphics/aurora/highlightableborder.cpp
+++ b/src/graphics/aurora/highlightableborder.cpp
@@ -1,0 +1,62 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "src/graphics/aurora/textureman.h"
+#include "highlightableborder.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+HighlightableBorder::HighlightableBorder(const Common::UString &edge, const Common::UString &corner, float x,
+                                         float y, float w, float h,
+                                         const Common::UString &cornerH, const Common::UString &edgeH): BorderQuad(edge, corner, x, y, w, h)
+{
+    _edge = TextureMan.get(edge);
+    _edgeH = TextureMan.get(edgeH);
+    _corner = TextureMan.get(corner);
+    _cornerH = TextureMan.get(cornerH);
+
+}
+
+HighlightableBorder::~HighlightableBorder() {}
+
+void HighlightableBorder::render(RenderPass pass) {
+    if(isHighlightable() && isHightlighted()){
+        setCornerTexture(_cornerH);
+        setEdgeTexture(_edgeH);
+    } else {
+        setCornerTexture(_corner);
+        setEdgeTexture(_edge);
+    }
+    Graphics::Aurora::BorderQuad::render(pass);
+}
+
+void HighlightableBorder::setHighlightCornerTexture(const TextureHandle &corner) {
+    _cornerH = corner;
+}
+
+void HighlightableBorder::setHighlightEdgeTexture(const TextureHandle &edge) {
+    _edgeH = edge;
+}
+
+}
+
+}

--- a/src/graphics/aurora/highlightableborder.h
+++ b/src/graphics/aurora/highlightableborder.h
@@ -18,45 +18,43 @@
  * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @file
- *  The options menu.
- */
 
-#ifndef ENGINES_KOTOR_GUI_MAIN_OPTIONS_H
-#define ENGINES_KOTOR_GUI_MAIN_OPTIONS_H
+#ifndef XOREOS_HIGHLIGHTABLEBORDER_H
+#define XOREOS_HIGHLIGHTABLEBORDER_H
 
-#include "src/common/scopedptr.h"
 
+
+#include "src/graphics/aurora/borderquad.h"
 #include "src/graphics/aurora/highlightable.h"
 
-#include "src/engines/kotor/gui/gui.h"
+namespace Graphics {
 
-#include "src/engines/kotor/gui/options/gameplay.h"
+namespace Aurora {
 
-namespace Engines {
+class HighlightableBorder : public Highlightable, public BorderQuad {
 
-namespace KotOR {
-
-class OptionsMenu : public GUI {
 public:
-	OptionsMenu(::Engines::Console *console = 0);
-	~OptionsMenu();
+    HighlightableBorder(const Common::UString &edge, const Common::UString &corner, float x, float y, float w, float h, const Common::UString &cornerH, const Common::UString &edgeH);
+    ~HighlightableBorder();
 
-protected:
-	void callbackActive(Widget &widget);
-	void initWidget(Widget &widget);
+    void render(RenderPass pass);
+
+    void setHighlightCornerTexture(const TextureHandle& corner);
+    void setHighlightEdgeTexture(const TextureHandle& edge);
+
 private:
-	void adoptChanges();
+    TextureHandle _cornerH;
+    TextureHandle _edgeH;
 
-	Common::ScopedPtr<GUI> _gameplay;
-	Common::ScopedPtr<GUI> _feedback;
-	Common::ScopedPtr<GUI> _autopause;
-	Common::ScopedPtr<GUI> _graphics;
-	Common::ScopedPtr<GUI> _sound;
+    TextureHandle _edge;
+    TextureHandle _corner;
 };
 
-} // End of namespace KotOR
 
-} // End of namespace Engines
+}
 
-#endif // ENGINES_KOTOR_GUI_MAIN_OPTIONS_H
+}
+
+
+
+#endif //XOREOS_HIGHLIGHTABLEBORDER_H

--- a/src/graphics/aurora/rules.mk
+++ b/src/graphics/aurora/rules.mk
@@ -39,6 +39,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/highlightable.h \
     src/graphics/aurora/text.h \
     src/graphics/aurora/highlightabletext.h \
+    src/graphics/aurora/highlightableborder.h \
     src/graphics/aurora/fps.h \
     src/graphics/aurora/cube.h \
     src/graphics/aurora/guiquad.h \
@@ -75,6 +76,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/highlightable.cpp \
     src/graphics/aurora/text.cpp \
     src/graphics/aurora/highlightabletext.cpp \
+    src/graphics/aurora/highlightableborder.cpp \
     src/graphics/aurora/fps.cpp \
     src/graphics/aurora/cube.cpp \
     src/graphics/aurora/highlightableguiquad.cpp \


### PR DESCRIPTION
The PR aims to improve the KOTOR menu buttons by highlighting them correctly.

As a reminder, the original game looks like this :

![image](https://user-images.githubusercontent.com/3481273/31990458-74b979f4-b975-11e7-88b8-9078c739d950.png)

And xoreos at master : 

![image](https://user-images.githubusercontent.com/3481273/31990339-202d09fa-b975-11e7-9597-c434b9d72b05.png)

After discussing with Nostritius on IRC, he recommended me to make the highlighted borders white first.

The goal of PRing this early is to make sure I'm doing my first contribution right.

The big problem I see with what I did in the commit, is that we would have to specify for every screen that contains a WidgetButton to put the highlighted texture.

Don't hesitate to make any remark, the goal is really to make this clean.

Thanks

 