### PR TITLE
Base work for text rendering changes

### DIFF
--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -35,6 +35,7 @@
 #include "src/graphics/aurora/text.h"
 #include "src/graphics/aurora/highlightabletext.h"
 #include "src/graphics/aurora/highlightableguiquad.h"
+#include "src/graphics/aurora/types.h"
 
 #include "src/engines/kotor/gui/widgets/kotorwidget.h"
 
@@ -370,10 +371,10 @@ KotORWidget::Text KotORWidget::createText(const Aurora::GFF3Struct &gff) {
 
 		// TODO: KotORWidget::getText(): Alignment
 		if (alignment == 10) {
-			text.halign = 0.5f;
+			text.halign = Graphics::Aurora::kHAlignCenter;
 			text.valign = 1.0f;
 		} else if (alignment == 18) {
-			text.halign = 0.5f;
+			text.halign = Graphics::Aurora::kHAlignCenter;
 			text.valign = 0.5f;
 		}
 	}

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -372,10 +372,10 @@ KotORWidget::Text KotORWidget::createText(const Aurora::GFF3Struct &gff) {
 		// TODO: KotORWidget::getText(): Alignment
 		if (alignment == 10) {
 			text.halign = Graphics::Aurora::kHAlignCenter;
-			text.valign = 1.0f;
+			text.valign = Graphics::Aurora::kVAlignTop;
 		} else if (alignment == 18) {
 			text.halign = Graphics::Aurora::kHAlignCenter;
-			text.valign = 0.5f;
+			text.valign = Graphics::Aurora::kVAlignMiddle;
 		}
 	}
 

--- a/src/engines/nwn/gui/main/newmodule.cpp
+++ b/src/engines/nwn/gui/main/newmodule.cpp
@@ -58,7 +58,7 @@ WidgetListItemModule::WidgetListItemModule(::Engines::GUI &gui,
 	Graphics::Aurora::FontHandle f = FontMan.get(font);
 	f.getFont().split(text, splitText, _button->getWidth() - 8.0f);
 
-	_text.reset(new Graphics::Aurora::Text(f, splitText, 1.0f, 1.0f, 1.0f, 1.0f, 0.5f));
+	_text.reset(new Graphics::Aurora::Text(f, splitText, 1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter));
 }
 
 WidgetListItemModule::~WidgetListItemModule() {

--- a/src/engines/nwn/gui/main/newpremium.cpp
+++ b/src/engines/nwn/gui/main/newpremium.cpp
@@ -60,7 +60,7 @@ WidgetListItemPremium::WidgetListItemPremium(::Engines::GUI &gui,
 	Graphics::Aurora::FontHandle f = FontMan.get(font);
 	f.getFont().split(text, splitText, _button->getWidth() - 8.0f);
 
-	_text.reset(new Graphics::Aurora::Text(f, splitText, 1.0f, 1.0f, 1.0f, 1.0f, 0.5f));
+	_text.reset(new Graphics::Aurora::Text(f, splitText, 1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter));
 }
 
 WidgetListItemPremium::~WidgetListItemPremium() {

--- a/src/engines/nwn/gui/widgets/listbox.cpp
+++ b/src/engines/nwn/gui/widgets/listbox.cpp
@@ -151,7 +151,7 @@ WidgetListItemTextLine::WidgetListItemTextLine(::Engines::GUI &gui,
 
 	_fontHeight = f.getFont().getHeight();
 
-	_text.reset(new Graphics::Aurora::Text(f, text, _uR, _uG, _uB, _uA, 0.0f));
+	_text.reset(new Graphics::Aurora::Text(f, text, _uR, _uG, _uB, _uA));
 
 	_text->setClickable(true);
 }

--- a/src/engines/nwn/gui/widgets/textwidget.cpp
+++ b/src/engines/nwn/gui/widgets/textwidget.cpp
@@ -80,9 +80,9 @@ void TextWidget::setColor(float r, float g, float b, float a) {
 	_text->setColor(_r, _g, _b, _a);
 }
 
-void TextWidget::setText(const Common::UString &text, float align, float maxWidth, float maxHeight) {
+void TextWidget::setText(const Common::UString &text, float halign, float maxWidth, float maxHeight) {
 	_text->set(text, maxWidth, maxHeight);
-	_text->setAlign(align);
+	_text->setHorizontalAlign(halign);
 }
 
 const Common::UString TextWidget::getText() const {

--- a/src/engines/nwn/gui/widgets/textwidget.cpp
+++ b/src/engines/nwn/gui/widgets/textwidget.cpp
@@ -39,7 +39,7 @@ TextWidget::TextWidget(::Engines::GUI &gui, const Common::UString &tag,
                        const Common::UString &font, const Common::UString &text) :
 	NWNWidget(gui, tag), _r(1.0f), _g(1.0f), _b(1.0f), _a(1.0f) {
 
-	_text.reset(new Graphics::Aurora::Text(FontMan.get(font), text, _r, _g, _b, _a, 0.5f));
+	_text.reset(new Graphics::Aurora::Text(FontMan.get(font), text, _r, _g, _b, _a, Graphics::Aurora::kHAlignCenter));
 	_text->setTag(tag);
 }
 

--- a/src/engines/nwn/gui/widgets/textwidget.h
+++ b/src/engines/nwn/gui/widgets/textwidget.h
@@ -55,7 +55,7 @@ public:
 
 	void setPosition(float x, float y, float z);
 	void setColor(float r, float g, float b, float a);
-	void setText(const Common::UString &text, float halign = 0.5f, float maxWidth = 0.0f, float maxHeight = 0.0f);
+	void setText(const Common::UString &text, float halign = Graphics::Aurora::kHAlignCenter, float maxWidth = 0.0f, float maxHeight = 0.0f);
 	const Common::UString getText() const;
 
 	float getWidth () const;

--- a/src/engines/nwn/gui/widgets/textwidget.h
+++ b/src/engines/nwn/gui/widgets/textwidget.h
@@ -55,7 +55,7 @@ public:
 
 	void setPosition(float x, float y, float z);
 	void setColor(float r, float g, float b, float a);
-	void setText(const Common::UString &text, float align = 0.5f, float maxWidth = 0.0f, float maxHeight = 0.0f);
+	void setText(const Common::UString &text, float halign = 0.5f, float maxWidth = 0.0f, float maxHeight = 0.0f);
 	const Common::UString getText() const;
 
 	float getWidth () const;

--- a/src/engines/sonic/game.cpp
+++ b/src/engines/sonic/game.cpp
@@ -210,12 +210,12 @@ bool Game::showQuote() {
 	_engine->getLanguage(language);
 
 	const float length = (language == Aurora::kLanguageJapanese) ? 236.0f : 256.0f;
-	const float align  = (language == Aurora::kLanguageJapanese) ?   0.0f :   0.5f;
+	const float halign = (language == Aurora::kLanguageJapanese) ?   0.0f :   0.5f;
 
 	Common::UString quote = TalkMan.getString(21712);
 	_guiFont.getFont().split(quote, length, 0.0f, false);
 
-	Graphics::Aurora::Text quoteText(_quoteFont, quote, 1.0f, 1.0f, 1.0f, 1.0f, align);
+	Graphics::Aurora::Text quoteText(_quoteFont, quote, 1.0f, 1.0f, 1.0f, 1.0f, halign);
 
 	const float quoteTextX = kTopScreenX + ((kScreenWidth  - quoteText.getWidth())  / 2.0f);
 	const float quoteTextY = kTopScreenY + ((kScreenHeight - quoteText.getHeight()) / 2.0f);

--- a/src/engines/sonic/game.cpp
+++ b/src/engines/sonic/game.cpp
@@ -210,7 +210,8 @@ bool Game::showQuote() {
 	_engine->getLanguage(language);
 
 	const float length = (language == Aurora::kLanguageJapanese) ? 236.0f : 256.0f;
-	const float halign = (language == Aurora::kLanguageJapanese) ?   0.0f :   0.5f;
+	const float halign = (language == Aurora::kLanguageJapanese) ?
+	                                        Graphics::Aurora::kHAlignLeft : Graphics::Aurora::kHAlignCenter;
 
 	Common::UString quote = TalkMan.getString(21712);
 	_guiFont.getFont().split(quote, length, 0.0f, false);

--- a/src/graphics/aurora/highlightabletext.cpp
+++ b/src/graphics/aurora/highlightabletext.cpp
@@ -28,6 +28,10 @@ HighlightableText::HighlightableText(const FontHandle &font, const Common::UStri
 	Text(font, str, r, g, b, a, halign, valign) {
 }
 
+HighlightableText::HighlightableText(const FontHandle &font, float w, float h, const Common::UString &str, float r, float g, float b, float a, float halign, float valign) :
+	Text(font, w, h, str, r, g, b, a, halign, valign) {
+}
+
 HighlightableText::~HighlightableText() {
 }
 

--- a/src/graphics/aurora/highlightabletext.cpp
+++ b/src/graphics/aurora/highlightabletext.cpp
@@ -24,8 +24,8 @@ namespace Graphics {
 
 namespace Aurora {
 
-HighlightableText::HighlightableText(const FontHandle &font, const Common::UString &str, float r, float g, float b, float a, float align) :
-	Text(font, str, r, g, b, a, align) {
+HighlightableText::HighlightableText(const FontHandle &font, const Common::UString &str, float r, float g, float b, float a, float halign) :
+	Text(font, str, r, g, b, a, halign) {
 }
 
 HighlightableText::~HighlightableText() {

--- a/src/graphics/aurora/highlightabletext.cpp
+++ b/src/graphics/aurora/highlightabletext.cpp
@@ -24,8 +24,8 @@ namespace Graphics {
 
 namespace Aurora {
 
-HighlightableText::HighlightableText(const FontHandle &font, const Common::UString &str, float r, float g, float b, float a, float halign) :
-	Text(font, str, r, g, b, a, halign) {
+HighlightableText::HighlightableText(const FontHandle &font, const Common::UString &str, float r, float g, float b, float a, float halign, float valign) :
+	Text(font, str, r, g, b, a, halign, valign) {
 }
 
 HighlightableText::~HighlightableText() {

--- a/src/graphics/aurora/highlightabletext.h
+++ b/src/graphics/aurora/highlightabletext.h
@@ -32,7 +32,7 @@ class HighlightableText: public Text, public Highlightable {
 
   public:
 	HighlightableText(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = 0.0f);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = kHAlignLeft);
 	~HighlightableText();
 
 	void render(RenderPass pass);

--- a/src/graphics/aurora/highlightabletext.h
+++ b/src/graphics/aurora/highlightabletext.h
@@ -32,7 +32,8 @@ class HighlightableText: public Text, public Highlightable {
 
   public:
 	HighlightableText(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = kHAlignLeft);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
+	     float halign = kHAlignLeft, float valign = kVAlignTop);
 	~HighlightableText();
 
 	void render(RenderPass pass);

--- a/src/graphics/aurora/highlightabletext.h
+++ b/src/graphics/aurora/highlightabletext.h
@@ -32,7 +32,7 @@ class HighlightableText: public Text, public Highlightable {
 
   public:
 	HighlightableText(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float align = 0.0f);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = 0.0f);
 	~HighlightableText();
 
 	void render(RenderPass pass);

--- a/src/graphics/aurora/highlightabletext.h
+++ b/src/graphics/aurora/highlightabletext.h
@@ -34,6 +34,9 @@ class HighlightableText: public Text, public Highlightable {
 	HighlightableText(const FontHandle &font, const Common::UString &str,
 	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
 	     float halign = kHAlignLeft, float valign = kVAlignTop);
+	HighlightableText(const FontHandle &font, float w, float h, const Common::UString &str,
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
+	     float halign = kHAlignLeft, float valign = kVAlignTop);
 	~HighlightableText();
 
 	void render(RenderPass pass);

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -34,9 +34,9 @@ namespace Graphics {
 namespace Aurora {
 
 Text::Text(const FontHandle &font, const Common::UString &str,
-		float r, float g, float b, float a, float halign) :
+		float r, float g, float b, float a, float halign, float valign) :
 	Graphics::GUIElement(Graphics::GUIElement::kGUIElementFront),
-	_r(r), _g(g), _b(b), _a(a), _font(font), _x(0.0f), _y(0.0f), _halign(halign),
+	_r(r), _g(g), _b(b), _a(a), _font(font), _x(0.0f), _y(0.0f), _halign(halign),_valign(valign),
 	_disableColorTokens(false) {
 
 	set(str);
@@ -96,6 +96,10 @@ void Text::unsetColor() {
 
 void Text::setHorizontalAlign(float halign) {
 	_halign = halign;
+}
+
+void Text::setVerticalAlign(float valign) {
+	_valign = valign;
 }
 
 const Common::UString &Text::get() const {

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -165,23 +165,7 @@ void Text::render(RenderPass pass) {
 		// Save the current position
 		glPushMatrix();
 
-		// Align
-		glTranslatef(roundf((maxLength - font.getLineWidth(*l)) * _align), 0.0f, 0.0f);
-
-		// Draw line
-		for (Common::UString::iterator s = l->begin(); s != l->end(); ++s, position++) {
-			// If we have color changes, apply them
-			while ((color != _colors.end()) && (color->position <= position)) {
-				if (color->defaultColor)
-					glColor4f(_r, _g, _b, _a);
-				else
-					glColor4f(color->r, color->g, color->b, color->a);
-
-				++color;
-			}
-
-			font.draw(*s);
-		}
+		drawLine(*l, maxLength, color, position);
 
 		// Restore position to the start of the line
 		glPopMatrix();
@@ -292,6 +276,30 @@ void Text::parseColors(const Common::UString &str, Common::UString &parsed,
 
 void Text::setFont(const Common::UString &fnt) {
 	_font = FontMan.get(fnt);
+}
+
+void Text::drawLine(const Common::UString &line, float maxLength,
+                    ColorPositions::const_iterator color, size_t position) {
+
+	Font &font = _font.getFont();
+
+	// Align
+	glTranslatef(roundf((maxLength - font.getLineWidth(line)) * _align), 0.0f, 0.0f);
+
+	// Draw line
+	for (Common::UString::iterator s = line.begin(); s != line.end(); ++s, position++) {
+		// If we have color changes, apply them
+		while ((color != _colors.end()) && (color->position <= position)) {
+			if (color->defaultColor)
+				glColor4f(_r, _g, _b, _a);
+			else
+				glColor4f(color->r, color->g, color->b, color->a);
+
+			++color;
+		}
+
+		font.draw(*s);
+	}
 }
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -44,6 +44,17 @@ Text::Text(const FontHandle &font, const Common::UString &str,
 	_distance = -FLT_MAX;
 }
 
+Text::Text(const FontHandle &font, float w, float h, const Common::UString &str,
+		float r, float g, float b, float a, float halign, float valign) :
+	Graphics::GUIElement(Graphics::GUIElement::kGUIElementFront), _r(r), _g(g), _b(b), _a(a),
+	_font(font), _x(0.0f), _y(0.0f), _width(w), _height(h), _halign(halign),_valign(valign),
+	_disableColorTokens(false) {
+
+	set(str);
+
+	_distance = -FLT_MAX;
+}
+
 Text::~Text() {
 	hide();
 }

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -145,6 +145,7 @@ void Text::render(RenderPass pass) {
 		return;
 
 	Font &font = _font.getFont();
+	float lineHeight = font.getHeight() + font.getLineSpacing();
 
 	glTranslatef(_x, _y, 0.0f);
 
@@ -154,7 +155,7 @@ void Text::render(RenderPass pass) {
 	float maxLength = font.split(_str, lines, _width, _height, false);
 
 	// Move position to the top
-	glTranslatef(0.0f, (lines.size() - 1) * (font.getHeight() + font.getLineSpacing()), 0.0f);
+	glTranslatef(0.0f, (lines.size() - 1) * lineHeight, 0.0f);
 
 	size_t position = 0;
 
@@ -171,7 +172,7 @@ void Text::render(RenderPass pass) {
 		glPopMatrix();
 
 		// Move to the next line
-		glTranslatef(0.0f, -(font.getHeight() + font.getLineSpacing()), 0.0f);
+		glTranslatef(0.0f, -lineHeight, 0.0f);
 
 		// \n character
 		position++;

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -34,9 +34,9 @@ namespace Graphics {
 namespace Aurora {
 
 Text::Text(const FontHandle &font, const Common::UString &str,
-		float r, float g, float b, float a, float align) :
+		float r, float g, float b, float a, float halign) :
 	Graphics::GUIElement(Graphics::GUIElement::kGUIElementFront),
-	_r(r), _g(g), _b(b), _a(a), _font(font), _x(0.0f), _y(0.0f), _align(align),
+	_r(r), _g(g), _b(b), _a(a), _font(font), _x(0.0f), _y(0.0f), _halign(halign),
 	_disableColorTokens(false) {
 
 	set(str);
@@ -94,8 +94,8 @@ void Text::unsetColor() {
 	setColor(1.0f, 1.0f, 1.0f, 1.0f);
 }
 
-void Text::setAlign(float align) {
-	_align = align;
+void Text::setHorizontalAlign(float halign) {
+	_halign = halign;
 }
 
 const Common::UString &Text::get() const {
@@ -284,8 +284,8 @@ void Text::drawLine(const Common::UString &line, float maxLength,
 
 	Font &font = _font.getFont();
 
-	// Align
-	glTranslatef(roundf((maxLength - font.getLineWidth(line)) * _align), 0.0f, 0.0f);
+	// Horizontal Align
+	glTranslatef(roundf((maxLength - font.getLineWidth(line)) * _halign), 0.0f, 0.0f);
 
 	// Draw line
 	for (Common::UString::iterator s = line.begin(); s != line.end(); ++s, position++) {

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -32,6 +32,7 @@
 #include <src/graphics/guielement.h>
 
 #include "src/graphics/aurora/fonthandle.h"
+#include "src/graphics/aurora/types.h"
 
 namespace Graphics {
 
@@ -41,7 +42,7 @@ namespace Aurora {
 class Text : public GUIElement {
 public:
 	Text(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = 0.0f);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = kHAlignLeft);
 	~Text();
 
 	const Common::UString &get() const;

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -93,6 +93,8 @@ private:
 
 	void parseColors(const Common::UString &str, Common::UString &parsed,
 	                 ColorPositions &colors);
+
+	void drawLine(const Common::UString &line, float maxLength, ColorPositions::const_iterator color, size_t position);
 };
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -41,7 +41,7 @@ namespace Aurora {
 class Text : public GUIElement {
 public:
 	Text(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float align = 0.0f);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = 0.0f);
 	~Text();
 
 	const Common::UString &get() const;
@@ -52,7 +52,7 @@ public:
 	void setPosition(float x, float y, float z = -FLT_MAX);
 	void setColor(float r, float g, float b, float a);
 	void unsetColor();
-	void setAlign(float align);
+	void setHorizontalAlign(float halign);
 
 	/** Change the font of the text. */
 	void setFont(const Common::UString &fnt);
@@ -84,7 +84,7 @@ private:
 	float _width;
 	float _height;
 
-	float _align;
+	float _halign;
 
 	Common::UString _str;
 	ColorPositions  _colors;

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -42,7 +42,8 @@ namespace Aurora {
 class Text : public GUIElement {
 public:
 	Text(const FontHandle &font, const Common::UString &str,
-	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f, float halign = kHAlignLeft);
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
+	     float halign = kHAlignLeft, float valign = kVAlignTop);
 	~Text();
 
 	const Common::UString &get() const;
@@ -54,6 +55,7 @@ public:
 	void setColor(float r, float g, float b, float a);
 	void unsetColor();
 	void setHorizontalAlign(float halign);
+	void setVerticalAlign(float valign);
 
 	/** Change the font of the text. */
 	void setFont(const Common::UString &fnt);
@@ -86,6 +88,7 @@ private:
 	float _height;
 
 	float _halign;
+	float _valign;
 
 	Common::UString _str;
 	ColorPositions  _colors;

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -44,6 +44,9 @@ public:
 	Text(const FontHandle &font, const Common::UString &str,
 	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
 	     float halign = kHAlignLeft, float valign = kVAlignTop);
+	Text(const FontHandle &font, float w, float h, const Common::UString &str,
+	     float r = 1.0f, float g = 1.0f, float b = 1.0f, float a = 1.0f,
+	     float halign = kHAlignLeft, float valign = kVAlignTop);
 	~Text();
 
 	const Common::UString &get() const;

--- a/src/graphics/aurora/types.h
+++ b/src/graphics/aurora/types.h
@@ -43,6 +43,10 @@ const float kHAlignLeft   = 0.0f;
 const float kHAlignCenter = 0.5f;
 const float kHAlignRight  = 1.0f;
 
+const float kVAlignTop     = 1.0f;
+const float kVAlignMiddle  = 0.5f;
+const float kVAlignBottom  = 0.0f;
+
 /** The display type of a model. */
 enum ModelType {
 	kModelTypeObject   = kRenderableTypeObject,  ///< A real object in the game world.

--- a/src/graphics/aurora/types.h
+++ b/src/graphics/aurora/types.h
@@ -39,6 +39,10 @@ namespace Aurora {
 /** Identifier used for the monospaced system font. */
 extern const char *kSystemFontMono;
 
+const float kHAlignLeft   = 0.0f;
+const float kHAlignCenter = 0.5f;
+const float kHAlignRight  = 1.0f;
+
 /** The display type of a model. */
 enum ModelType {
 	kModelTypeObject   = kRenderableTypeObject,  ///< A real object in the game world.

--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -66,57 +66,6 @@ float Font::getHeight(const Common::UString &text, float maxWidth, float maxHeig
 void Font::buildChars(const Common::UString &UNUSED(str)) {
 }
 
-void Font::draw(Common::UString text, const ColorPositions &colors,
-                float r, float g, float b, float a, float align, float maxWidth, float maxHeight) const {
-
-	glColor4f(r, g, b, a);
-
-	std::vector<Common::UString> lines;
-	float maxLength = split(text, lines, maxWidth, maxHeight, false);
-
-	// Move position to the top
-	glTranslatef(0.0f, (lines.size() - 1) * (getHeight() + getLineSpacing()), 0.0f);
-
-	size_t position = 0;
-
-	ColorPositions::const_iterator color = colors.begin();
-
-	// Draw lines
-	for (std::vector<Common::UString>::iterator l = lines.begin(); l != lines.end(); ++l) {
-		// Save the current position
-		glPushMatrix();
-
-		// Align
-		glTranslatef(roundf((maxLength - getLineWidth(*l)) * align), 0.0f, 0.0f);
-
-		// Draw line
-		for (Common::UString::iterator s = l->begin(); s != l->end(); ++s, position++) {
-			// If we have color changes, apply them
-			while ((color != colors.end()) && (color->position <= position)) {
-				if (color->defaultColor)
-					glColor4f(r, g, b, a);
-				else
-					glColor4f(color->r, color->g, color->b, color->a);
-
-				++color;
-			}
-
-			draw(*s);
-		}
-
-		// Restore position to the start of the line
-		glPopMatrix();
-
-		// Move to the next line
-		glTranslatef(0.0f, -(getHeight() + getLineSpacing()), 0.0f);
-
-		// \n character
-		position++;
-	}
-
-	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-}
-
 float Font::split(const Common::UString &line, std::vector<Common::UString> &lines,
                   float maxWidth, float maxHeight, bool trim) const {
 

--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -63,9 +63,6 @@ public:
 	/** Draw this character. */
 	virtual void draw(uint32 c) const = 0;
 
-	void draw(Common::UString text, const ColorPositions &colors,
-		  float r, float g, float b, float a, float align = 0.0f, float maxWidth = 0.0f, float maxHeight = 0.0f) const;
-
 	float split(const Common::UString &line, std::vector<Common::UString> &lines,
 	            float maxWidth = 0.0f, float maxHeight = 0.0f, bool trim = true) const;
 	float split(Common::UString &line, float maxWidth, float maxHeight = 0.0f, bool trim = true) const;

--- a/src/graphics/font.h
+++ b/src/graphics/font.h
@@ -54,6 +54,8 @@ public:
 	float getWidth (const Common::UString &text, float maxWidth = 0.0f) const;
 	/** Return the height this string would take. */
 	float getHeight(const Common::UString &text, float maxWidth = 0.0f, float maxHeight = 0.0f) const;
+	/** Return the width of this string. */
+	float getLineWidth(const Common::UString &text) const;
 
 	/** Build all necessary characters to display this string. */
 	virtual void buildChars(const Common::UString &str);
@@ -70,7 +72,6 @@ public:
 	float split(const Common::UString &line, Common::UString &lines, float maxWidth, float maxHeight = 0.0f, bool trim = true) const;
 
 private:
-	float getLineWidth(const Common::UString &text) const;
 	bool addLine(std::vector<Common::UString> &lines, const Common::UString &newLine, float maxHeight) const;
 };
 


### PR DESCRIPTION
To make text layouting possible we need to give the text quad the same height and width as the underlaying widget quad. Layouting is done by defining a writing direction (ltr,rtl) and a block direction (these come later and are defined by the display language) and then aligning the text in the text quad according to vertical and horizontal alignment.

This PR
* renames the existing align to horizontal align
* add a vertical align
* defines common values for vertical and horizontal align
* adds a Text constructor with width and height parameters added