### PR TITLE
BUILD: Add a path hint for recognizing macports version of sdl2

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -29,7 +29,7 @@ if(WIN32)
   find_library(SDL2_LIBRARY NAMES SDL2 PATHS $ENV{PROGRAMFILES}/SDL2/lib DOC "The SDL2 library")
 
 else(WIN32)
-  find_path(SDL2_INCLUDE_DIR SDL.h /usr/include/SDL2 DOC "The directory where SDL.h resides")
+  find_path(SDL2_INCLUDE_DIR SDL.h HINTS /usr/include/SDL2 /opt/local/include/SDL2 DOC "The directory where SDL.h resides")
   find_library(SDL2_LIBRARY NAMES SDL2 DOC "The SDL2 library")
 
 endif(WIN32)


### PR DESCRIPTION
Because the cmake script was not able to see the correct path for the mac ports version of sdl2 i created another hint to point it there.