### PR TITLE
KOTOR2: Make the module listbox invisible

### DIFF
--- a/src/engines/kotor2/gui/main/main.cpp
+++ b/src/engines/kotor2/gui/main/main.cpp
@@ -61,6 +61,12 @@ void MainMenu::initWidget(Widget &widget) {
 		widget.setInvisible(true);
 		return;
 	}
+
+	// Whatever this module stuff is about
+	if (widget.getTag() == "LB_MODULES") {
+		widget.setInvisible(true);
+		return;
+	}
 }
 
 void MainMenu::callbackActive(Widget &widget) {


### PR DESCRIPTION
The KotOR 2 main menu contained a widget called "LB_MODULES" which is definitely not in the orignal game and became visible after the list box update. I made it invisible.