### PR TITLE
GRAPHICS: Remove animation node caching (fix NWN animations)

### DIFF
--- a/src/graphics/aurora/animation.cpp
+++ b/src/graphics/aurora/animation.cpp
@@ -76,7 +76,7 @@ void Animation::update(Model *model, float UNUSED(lastFrame), float nextFrame) {
 	float scale = model->getAnimationScale(_name);
 	for (NodeList::iterator n = nodeList.begin(); n != nodeList.end(); ++n) {
 		ModelNode *animNode = (*n)->_nodedata;
-		ModelNode *target = model->_animNodeMap[animNode->_nodeNumber];
+		ModelNode *target = model->getNode(animNode->getName());
 		if (!target)
 			continue;
 
@@ -114,23 +114,6 @@ const ModelNode *Animation::getNode(const Common::UString &node) const {
 		return 0;
 
 	return n->second->_nodedata;
-}
-
-void Animation::makeAnimNodeMap(Model *model) {
-	int maxNodeNumber = -1;
-	for (NodeList::iterator it = nodeList.begin(); it != nodeList.end(); ++it) {
-		ModelNode *node = (*it)->_nodedata;
-		if (node->_nodeNumber > maxNodeNumber) {
-			maxNodeNumber = node->_nodeNumber;
-		}
-	}
-	if (maxNodeNumber != -1) {
-		model->_animNodeMap.reserve(maxNodeNumber + 1);
-		for (NodeList::iterator it = nodeList.begin(); it != nodeList.end(); ++it) {
-			ModelNode *node = (*it)->_nodedata;
-			model->_animNodeMap[node->_nodeNumber] = model->getNode(node->getName());
-		}
-	}
 }
 
 /** Return the dot product of two quaternions. */

--- a/src/graphics/aurora/animation.h
+++ b/src/graphics/aurora/animation.h
@@ -78,9 +78,6 @@ public:
 	/** Get the specified node. */
 	const ModelNode *getNode(const Common::UString &node) const;
 
-	/** Map node numbers to animation nodes for better performance. */
-	void makeAnimNodeMap(Model *model);
-
 protected:
 	typedef std::list<AnimNode *> NodeList;
 	typedef std::map<Common::UString, AnimNode *, Common::UString::iless> NodeMap;

--- a/src/graphics/aurora/model.cpp
+++ b/src/graphics/aurora/model.cpp
@@ -49,7 +49,7 @@ namespace Aurora {
 
 Model::Model(ModelType type) : Renderable((RenderableType) type),
 	_type(type), _superModel(0), _currentState(0),
-	_currentAnimation(0), _nextAnimation(0), _drawBound(false),
+	_currentAnimation(0), _nextAnimation(0), _skinned(false), _drawBound(false),
 	_drawSkeleton(false), _drawSkeletonInvisible(false) {
 
 	_scale   [0] = 1.0f; _scale   [1] = 1.0f; _scale   [2] = 1.0f;
@@ -230,13 +230,11 @@ void Model::setCurrentAnimation(Animation *anim) {
 
 	_currentAnimation  = anim;
 	_animationLoopTime = 0.0f;
-	anim->makeAnimNodeMap(this);
 
 	for (NodeList::iterator n = _currentState->nodeList.begin(); n != _currentState->nodeList.end(); ++n)
 		if ((*n)->_attachedModel) {
 			(*n)->_attachedModel->_currentAnimation  = anim;
 			(*n)->_attachedModel->_animationLoopTime = 0.0f;
-			anim->makeAnimNodeMap((*n)->_attachedModel);
 		}
 
 }

--- a/src/graphics/aurora/model.h
+++ b/src/graphics/aurora/model.h
@@ -288,8 +288,6 @@ private:
 	float _animationLoopLength; ///< The length of one loop of the current animation.
 	float _animationLoopTime;   ///< The time the current loop of the current animation has played.
 
-	std::vector<ModelNode *> _animNodeMap;
-
 	/** Create the list of all state names. */
 	void createStateNamesList(std::list<Common::UString> *stateNames = 0);
 	/** Create the model's bounding box. */


### PR DESCRIPTION
Both NWN and KotOR animations work now. The latter should be a little slower though.