### PR TITLE
GRAPHICS: Add time handling to subscene quads

### DIFF
--- a/src/graphics/aurora/subscenequad.cpp
+++ b/src/graphics/aurora/subscenequad.cpp
@@ -28,6 +28,8 @@
 
 #include "src/graphics/aurora/subscenequad.h"
 
+#include "src/events/events.h"
+
 namespace Graphics {
 
 namespace Aurora {
@@ -70,7 +72,12 @@ void SubSceneQuad::render(RenderPass pass) {
 
 	glClear(GL_COLOR_BUFFER_BIT);
 
+	uint32 now = EventMan.getTimestamp();
+	float elapsedTime = (now - _lastSampled) / 1000.0f;
+	_lastSampled = now;
+
 	for (unsigned int i = 0; i < _renderables.size(); ++i) {
+		_renderables[i]->advanceTime(elapsedTime);
 		_renderables[i]->render(pass);
 	}
 

--- a/src/graphics/aurora/subscenequad.h
+++ b/src/graphics/aurora/subscenequad.h
@@ -57,6 +57,8 @@ private:
 	Common::Matrix4x4 _projection;
 	Common::Matrix4x4 _transformation;
 
+	uint32 _lastSampled;
+
 	int _x, _y;
 	int _width, _height;
 };


### PR DESCRIPTION
I tried to get parts of the character generation subscenes to animate until I realized, that the subscene is not giving timestamps to the renderables, so i added this in this PR.