### PR TITLE
Textrender2

### DIFF
--- a/src/engines/aurora/loadprogress.cpp
+++ b/src/engines/aurora/loadprogress.cpp
@@ -51,18 +51,22 @@ LoadProgress::LoadProgress(size_t steps) : _steps(steps), _currentStep(0),
 	const Common::UString barLowerStr = createProgressbarLower(kBarLength);
 	const Common::UString barStr      = createProgressbar(kBarLength, _currentAmount);
 
-	_description.reset(new Graphics::Aurora::Text(font, ""));
-	_barUpper.reset   (new Graphics::Aurora::Text(font, barUpperStr));
-	_barLower.reset   (new Graphics::Aurora::Text(font, barLowerStr));
-	_progressbar.reset(new Graphics::Aurora::Text(font, barStr));
-	_percent.reset    (new Graphics::Aurora::Text(font, ""));
+	float left = -(WindowMan.getWindowWidth() / 2.0f);
+	float width = WindowMan.getWindowWidth();
+	float height = font.getFont().getHeight();
 
-	_description->setPosition(0.0f,  font.getFont().getHeight());
-	_percent    ->setPosition(0.0f, -font.getFont().getHeight());
+	_description.reset(new Graphics::Aurora::Text(font, width, height, "",          1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter, Graphics::Aurora::kVAlignBottom));
+	_barUpper.reset   (new Graphics::Aurora::Text(font, width, height, barUpperStr, 1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter, Graphics::Aurora::kVAlignBottom));
+	_barLower.reset   (new Graphics::Aurora::Text(font, width, height, barLowerStr, 1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter, Graphics::Aurora::kVAlignTop));
+	_progressbar.reset(new Graphics::Aurora::Text(font, width, height, barStr,      1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter, Graphics::Aurora::kVAlignMiddle));
+	_percent.reset    (new Graphics::Aurora::Text(font, width, height, "",          1.0f, 1.0f, 1.0f, 1.0f, Graphics::Aurora::kHAlignCenter, Graphics::Aurora::kVAlignTop));
 
-	_barUpper   ->setPosition(-(_barUpper   ->getWidth() / 2.0f), 0.0f);
-	_barLower   ->setPosition(-(_barLower   ->getWidth() / 2.0f), 0.0f);
-	_progressbar->setPosition(-(_progressbar->getWidth() / 2.0f), 0.0f);
+	_description->setPosition(left,  height);
+	_percent    ->setPosition(left, -height);
+
+	_barUpper   ->setPosition(left, 0.0f);
+	_barLower   ->setPosition(left, 0.0f);
+	_progressbar->setPosition(left, 0.0f);
 }
 
 LoadProgress::~LoadProgress() {
@@ -95,21 +99,11 @@ void LoadProgress::step(const Common::UString &description) {
 		const Common::UString percentStr = Common::UString::format("%d%%", percentage);
 		const Common::UString barStr     = createProgressbar(kBarLength, _currentAmount);
 
-		float x, y, z;
-
 		GfxMan.lockFrame();
 
-		// Update the description text and center it
-		_description->getPosition(x, y, z);
-		_description->set(description + " " + timeStr);
-		_description->setPosition(-(_description->getWidth() / 2.0f), y);
-
-		// Update the percentage text and center it
-		_percent->getPosition(x, y, z);
-		_percent->set(percentStr);
-		_percent->setPosition(-(_percent->getWidth() / 2.0f), y);
-
-		_progressbar->set(barStr);
+		_description->setText(description + " " + timeStr);
+		_percent->setText(percentStr);
+		_progressbar->setText(barStr);
 
 		_description->show();
 		_barUpper   ->show();

--- a/src/graphics/aurora/fps.cpp
+++ b/src/graphics/aurora/fps.cpp
@@ -38,12 +38,6 @@ FPS::FPS(const FontHandle &font) : Text(font, "0 fps"), _fps(0) {
 	init();
 }
 
-FPS::FPS(const FontHandle &font, float r, float g, float b, float a) :
-	Text(font, "0 fps", r, g, b, a), _fps(0) {
-
-	init();
-}
-
 FPS::~FPS() {
 	hide();
 }

--- a/src/graphics/aurora/fps.cpp
+++ b/src/graphics/aurora/fps.cpp
@@ -34,7 +34,7 @@ namespace Graphics {
 
 namespace Aurora {
 
-FPS::FPS(const FontHandle &font) : Text(font, "0 fps"), _fps(0) {
+FPS::FPS(const FontHandle &font) : Text(font, WindowMan.getWindowWidth(), WindowMan.getWindowHeight(), "0 fps"), _fps(0) {
 	init();
 }
 
@@ -57,7 +57,7 @@ void FPS::render(RenderPass pass) {
 	if (fps != _fps) {
 		_fps = fps;
 
-		set(Common::UString::format("%d fps", _fps));
+		setText(Common::UString::format("%d fps", _fps));
 	}
 
 	Text::render(pass);
@@ -65,9 +65,10 @@ void FPS::render(RenderPass pass) {
 
 void FPS::notifyResized(int UNUSED(oldWidth), int UNUSED(oldHeight), int newWidth, int newHeight) {
 	float posX = -(newWidth  / 2.0f);
-	float posY =  (newHeight / 2.0f) - getHeight();
+	float posY = -(newHeight / 2.0f);
 
 	setPosition(posX, posY);
+	setSize(newWidth, newHeight);
 }
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/fps.h
+++ b/src/graphics/aurora/fps.h
@@ -37,7 +37,6 @@ namespace Aurora {
 class FPS : public Text, public Events::Notifyable {
 public:
 	FPS(const FontHandle &font);
-	FPS(const FontHandle &font, float r, float g, float b, float a);
 	~FPS();
 
 	// Renderable

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -47,8 +47,11 @@ Text::Text(const FontHandle &font, const Common::UString &str,
 Text::Text(const FontHandle &font, float w, float h, const Common::UString &str,
 		float r, float g, float b, float a, float halign, float valign) :
 	Graphics::GUIElement(Graphics::GUIElement::kGUIElementFront), _r(r), _g(g), _b(b), _a(a),
-	_font(font), _x(0.0f), _y(0.0f), _width(w), _height(h), _halign(halign),_valign(valign),
+	_font(font), _x(0.0f), _y(0.0f), _halign(halign),_valign(valign),
 	_disableColorTokens(false) {
+
+	_width = roundf(w);
+	_height = roundf(h);
 
 	setText(str);
 

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -155,6 +155,17 @@ void Text::setPosition(float x, float y, float z) {
 	unlockFrameIfVisible();
 }
 
+void Text::setSize(float width, float height) {
+	lockFrameIfVisible();
+
+	_width = roundf(width);
+	_height = roundf(height);
+
+	_lineCount = _font.getFont().getLineCount(_str, _width, _height);
+
+	unlockFrameIfVisible();
+}
+
 bool Text::empty() {
 	return _str.empty();
 }

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -56,6 +56,7 @@ public:
 	void set(const Common::UString &str, float maxWidth = 0.0f, float maxHeight = 0.0f);
 	void setText(const Common::UString &str);
 	void setPosition(float x, float y, float z = -FLT_MAX);
+	void setSize(float width, float height);
 	void setColor(float r, float g, float b, float a);
 	void unsetColor();
 	void setHorizontalAlign(float halign);

--- a/src/graphics/aurora/text.h
+++ b/src/graphics/aurora/text.h
@@ -54,6 +54,7 @@ public:
 	void getColor(float &r, float &g, float &b, float &a) const;
 
 	void set(const Common::UString &str, float maxWidth = 0.0f, float maxHeight = 0.0f);
+	void setText(const Common::UString &str);
 	void setPosition(float x, float y, float z = -FLT_MAX);
 	void setColor(float r, float g, float b, float a);
 	void unsetColor();
@@ -101,7 +102,7 @@ private:
 	void parseColors(const Common::UString &str, Common::UString &parsed,
 	                 ColorPositions &colors);
 
-	void drawLine(const Common::UString &line, float maxLength, ColorPositions::const_iterator color, size_t position);
+	void drawLine(const Common::UString &line, ColorPositions::const_iterator color, size_t position);
 };
 
 } // End of namespace Aurora


### PR DESCRIPTION
This is the 2nd part of the changes to layout text according to alignment.

This PR has the actual changes to the layout algorithm.
The changes to the FPS and LoadProgress classes are showcases that were simple to implement.

There should be no regressions to any Text drawing not using the new constructor introduced in part 1.

To test out these changes the FPS class uses the whole xoreos window for layouting.
Using different alignment values than the default (Upper Left) should put the text in another part of the screen.