### PR TITLE
KOTOR: Fix class body model names

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -304,11 +304,11 @@ void Creature::createPC(CharacterGenerationInfo *info) {
 			parts.body += "l";
 			break;
 		case kClassScout:
-			parts.body += "s";
+			parts.body += "m";
 			break;
 		default:
 		case kClassScoundrel:
-			parts.body += "m";
+			parts.body += "s";
 			break;
 	}
 

--- a/src/engines/kotor/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor/gui/chargen/chargeninfo.cpp
@@ -200,11 +200,11 @@ Graphics::Aurora::Model *CharacterGenerationInfo::getModel() {
 			body += "l";
 			break;
 		case kClassScout:
-			body += "s";
+			body += "m";
 			break;
 		default:
 		case kClassScoundrel:
-			body += "m";
+			body += "s";
 			break;
 	}
 


### PR DESCRIPTION
Scout and scoundrel body models were mixed up.