### PR TITLE
KOTOR: Read creatures gender on loading it

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -186,6 +186,9 @@ void Creature::loadProperties(const Aurora::GFF3Struct &gff) {
 	// PC
 	_isPC = gff.getBool("IsPC", _isPC);
 
+	// Gender
+	_gender = Gender(gff.getUint("Gender"));
+
 	// Scripts
 	readScripts(gff);
 }


### PR DESCRIPTION
This PR adds the loading of the creature  gender from gff.