### PR TITLE
KOTOR: Catch exception on creature subrace load

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -201,7 +201,12 @@ void Creature::loadProperties(const Aurora::GFF3Struct &gff) {
 
 	// Race
 	_race = Race(gff.getSint("Race", _race));
-	_subRace = SubRace(gff.getSint("Subrace", _subRace));
+
+	try {
+		_subRace = SubRace(gff.getSint("Subrace", _subRace));
+	} catch (Common::Exception &e) {
+		warning(e.what());
+	}
 
 	// Scripts
 	readScripts(gff);


### PR DESCRIPTION
Commit https://github.com/xoreos/xoreos/commit/372953e4196fca6cb7fcdad685a96c6386b7401a introduced a bug: due to unhandled exception on creature subrace load KotOR became unplayable past the character generation. 