### PR TITLE
KOTOR: Fix subrace loading bug

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -201,7 +201,7 @@ void Creature::loadProperties(const Aurora::GFF3Struct &gff) {
 
 	// Race
 	_race = Race(gff.getSint("Race", _race));
-	_subRace = SubRace(gff.getSint("Subrace", _subRace));
+	_subRace = SubRace(gff.getSint("SubraceIndex", _subRace));
 
 	// Scripts
 	readScripts(gff);


### PR DESCRIPTION
After #212 I searched for the cause of the error and found out, that the Subrace field is actually a string field and is not used, even on wookies. I found out, that there is a second field called "SubraceIndex" which contains the actual subrace information.