### PR TITLE
KOTOR: Load screen

### DIFF
--- a/src/engines/kotor/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor/gui/chargen/charactergeneration.cpp
@@ -186,6 +186,8 @@ void CharacterGenerationMenu::decStep() {
 }
 
 void CharacterGenerationMenu::start() {
+	hide();
+
 	try {
 		_module->usePC(_pc->getCharacter());
 		_module->load("end_m01aa");
@@ -193,6 +195,8 @@ void CharacterGenerationMenu::start() {
 		Common::exceptionDispatcherWarning();
 		return;
 	}
+
+	show();
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/loadscreen/loadscreen.cpp
+++ b/src/engines/kotor/gui/loadscreen/loadscreen.cpp
@@ -1,0 +1,66 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The loading screen gui
+ */
+
+#include <boost/bind.hpp>
+
+#include "src/aurora/2dareg.h"
+#include "src/aurora/talkman.h"
+
+#include "src/engines/kotor/gui/loadscreen/loadscreen.h"
+
+#include "src/engines/kotor/gui/widgets/panel.h"
+#include "src/engines/kotor/gui/widgets/progressbar.h"
+#include "src/engines/kotor/gui/widgets/label.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+LoadScreen::LoadScreen(const Common::UString &loadScreenName, Console *console)
+		: GUI(console) {
+	load("loadscreen");
+
+	getPanel("TGuiPanel")->setFill("load_" + loadScreenName);
+
+	// TODO: Add loading hints according to loadscreenhints.2da
+	getLabel("LBL_HINT")->setFont("fnt_d16x16b");
+	getLabel("LBL_HINT")->setText("");
+
+	addBackground(kBackgroundTypeLoad);
+
+	_progressBar = getProgressbar("PB_PROGRESS");
+	_progressBar->setCurrentValue(0);
+}
+
+void LoadScreen::setLoadingProgress(unsigned int progress) {
+	_progressBar->setCurrentValue(progress);
+}
+
+LoadingProgressFunc LoadScreen::getLoadingProgressFunc() {
+	return boost::bind(&LoadScreen::setLoadingProgress, this, _1);
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/loadscreen/loadscreen.h
+++ b/src/engines/kotor/gui/loadscreen/loadscreen.h
@@ -1,0 +1,56 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The loading screen gui
+ */
+
+#ifndef ENGINES_KOTOR_GUI_LOADSCREEN_LOADSCREEN_H
+#define ENGINES_KOTOR_GUI_LOADSCREEN_LOADSCREEN_H
+
+#include <boost/function.hpp>
+
+#include "src/common/thread.h"
+
+#include "src/engines/kotor/module.h"
+#include "src/engines/kotor/gui/gui.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+typedef boost::function<void(unsigned int)> LoadingProgressFunc;
+
+class LoadScreen : public GUI {
+public:
+	LoadScreen(const Common::UString &loadScreenName, Console *console = 0);
+
+	void setLoadingProgress(unsigned int progress);
+	LoadingProgressFunc getLoadingProgressFunc();
+
+private:
+	WidgetProgressbar *_progressBar;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_LOADSCREEN_LOADSCREEN_H

--- a/src/engines/kotor/gui/loadscreen/rules.mk
+++ b/src/engines/kotor/gui/loadscreen/rules.mk
@@ -20,7 +20,9 @@
 # Load screen system in Star Wars: Knights of the Old Republic.
 
 src_engines_kotor_libkotor_la_SOURCES += \
+    src/engines/kotor/gui/loadscreen/loadscreen.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
+    src/engines/kotor/gui/loadscreen/loadscreen.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/loadscreen/rules.mk
+++ b/src/engines/kotor/gui/loadscreen/rules.mk
@@ -17,26 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with xoreos. If not, see <http://www.gnu.org/licenses/>.
 
-# GUI system in Star Wars: Knights of the Old Republic.
+# Load screen system in Star Wars: Knights of the Old Republic.
 
 src_engines_kotor_libkotor_la_SOURCES += \
-    src/engines/kotor/gui/gui.h \
-    src/engines/kotor/gui/guibackground.h \
-    src/engines/kotor/gui/saveload.h \
-    src/engines/kotor/gui/dialog.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
-    src/engines/kotor/gui/gui.cpp \
-    src/engines/kotor/gui/guibackground.cpp \
-    src/engines/kotor/gui/saveload.cpp \
-    src/engines/kotor/gui/dialog.cpp \
     $(EMPTY)
-
-include src/engines/kotor/gui/widgets/rules.mk
-include src/engines/kotor/gui/main/rules.mk
-include src/engines/kotor/gui/options/rules.mk
-include src/engines/kotor/gui/chargen/rules.mk
-include src/engines/kotor/gui/ingame/rules.mk
-include src/engines/kotor/gui/dialogs/rules.mk
-include src/engines/kotor/gui/loadscreen/rules.mk

--- a/src/engines/kotor/gui/main/main.cpp
+++ b/src/engines/kotor/gui/main/main.cpp
@@ -22,6 +22,8 @@
  *  The KotOR main menu.
  */
 
+#include <boost/bind.hpp>
+
 #include "src/common/util.h"
 
 #include "src/sound/sound.h"
@@ -35,6 +37,8 @@
 
 #include "src/engines/kotor/gui/guibackground.h"
 #include "src/engines/kotor/gui/saveload.h"
+
+#include "src/engines/kotor/gui/loadscreen/loadscreen.h"
 
 #include "src/engines/kotor/gui/widgets/button.h"
 
@@ -62,11 +66,15 @@ MainMenu::~MainMenu() {
 }
 
 void MainMenu::createClassSelection() {
-	if (_classSelection)
-		return;
+	hide();
+	LoadScreen loadScreen("chargen", _console);
+	loadScreen.show();
 
 	// Create the class selection menu
 	_classSelection.reset(new ClassSelectionMenu(_module, _console));
+
+	loadScreen.hide();
+	show();
 }
 
 void MainMenu::createMovies() {
@@ -149,10 +157,10 @@ void MainMenu::initWidget(Widget &widget) {
 void MainMenu::callbackActive(Widget &widget) {
 
 	if (widget.getTag() == "BTN_NEWGAME") {
+		createClassSelection();
+
 		// Stop the currently running main music
 		stopMenuMusic();
-
-		createClassSelection();
 
 		// Start the charGen music
 		startCharGenMusic();

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -58,6 +58,8 @@
 
 #include "src/engines/kotor/gui/ingame/ingame.h"
 
+#include "src/engines/kotor/gui/loadscreen/loadscreen.h"
+
 namespace Engines {
 
 namespace KotOR {
@@ -118,6 +120,10 @@ void Module::load(const Common::UString &module, const Common::UString &entryLoc
 
 void Module::loadModule(const Common::UString &module, const Common::UString &entryLocation,
                         ObjectType entryLocationType) {
+	_ingame->hide();
+
+	LoadScreen loadScreen(module, _console);
+	loadScreen.show();
 
 	unload(false);
 
@@ -159,6 +165,10 @@ void Module::loadModule(const Common::UString &module, const Common::UString &en
 	_newModule.clear();
 
 	_hasModule = true;
+
+	loadScreen.hide();
+
+	_ingame->show();
 }
 
 void Module::usePC(Creature *pc) {


### PR DESCRIPTION
This PR introduces a loading screen for kotor, which at the moment will be between the mainmenu and the chargen menu and between entering different modules.