### PR TITLE
KOTOR: Add the background for options menus

### DIFF
--- a/src/engines/kotor/gui/main/options.cpp
+++ b/src/engines/kotor/gui/main/options.cpp
@@ -41,6 +41,8 @@ namespace KotOR {
 OptionsMenu::OptionsMenu(::Engines::Console *console) : GUI(console) {
 	load("optionsmain");
 
+	addBackground(kBackgroundTypeMenu);
+
 	_gameplay.reset(new OptionsGameplayMenu(_console));
 	_feedback.reset(new OptionsFeedbackMenu(_console));
 	_autopause.reset(new OptionsAutoPauseMenu(_console));

--- a/src/engines/kotor/gui/options/autopause.cpp
+++ b/src/engines/kotor/gui/options/autopause.cpp
@@ -36,6 +36,9 @@ namespace KotOR {
 
 OptionsAutoPauseMenu::OptionsAutoPauseMenu(::Engines::Console *console) : GUI(console) {
 	load("optautopause");
+
+	addBackground(kBackgroundTypeMenu);
+
 	//Hardcoded, the gui file returns 1.0, 1.0, 1.0, 1.0
 	getCheckBox("CB_ENDROUND", true)->setColor(0.0f, 0.658824f, 0.980392f, 1.0f);
 	getCheckBox("CB_ENEMYSIGHTED", true)->setColor(0.0f, 0.658824f, 0.980392f, 1.0f);

--- a/src/engines/kotor/gui/options/feedback.cpp
+++ b/src/engines/kotor/gui/options/feedback.cpp
@@ -32,6 +32,8 @@ namespace KotOR {
 
 OptionsFeedbackMenu::OptionsFeedbackMenu(::Engines::Console *console) : GUI(console) {
 	load("optfeedback");
+
+	addBackground(kBackgroundTypeMenu);
 }
 
 OptionsFeedbackMenu::~OptionsFeedbackMenu() {

--- a/src/engines/kotor/gui/options/gameplay.cpp
+++ b/src/engines/kotor/gui/options/gameplay.cpp
@@ -42,6 +42,8 @@ namespace KotOR {
 OptionsGameplayMenu::OptionsGameplayMenu(::Engines::Console *console) : GUI(console) {
 	load("optgameplay");
 
+	addBackground(kBackgroundTypeMenu);
+
 	_mousesettings.reset(new OptionsMouseSettingsMenu(_console));
 	_keyboardconfiguration.reset(new OptionsKeyboardConfigurationMenu(_console));
 

--- a/src/engines/kotor/gui/options/graphics.cpp
+++ b/src/engines/kotor/gui/options/graphics.cpp
@@ -38,6 +38,8 @@ namespace KotOR {
 OptionsGraphicsMenu::OptionsGraphicsMenu(::Engines::Console *console) : GUI(console) {
 	load("optgraphics");
 
+	addBackground(kBackgroundTypeMenu);
+
 	_advanced.reset(new OptionsGraphicsAdvancedMenu(_console));
 
 	//Hardcoded, the gui file returns incorrect values

--- a/src/engines/kotor/gui/options/graphicsadv.cpp
+++ b/src/engines/kotor/gui/options/graphicsadv.cpp
@@ -40,6 +40,8 @@ namespace KotOR {
 OptionsGraphicsAdvancedMenu::OptionsGraphicsAdvancedMenu(::Engines::Console *console) : GUI(console) {
 	load("optgraphicsadv");
 
+	addBackground(kBackgroundTypeMenu);
+
 	//Hardcoded, the gui file returns incorrect values
 	getButton("BTN_TEXQUALLEFT", true)->setColor(0.0f, 0.658824f, 0.980392f, 1.0f);
 	getButton("BTN_TEXQUALLEFT", true)->setStaticHighlight();

--- a/src/engines/kotor/gui/options/keyboardconfig.cpp
+++ b/src/engines/kotor/gui/options/keyboardconfig.cpp
@@ -34,6 +34,8 @@ OptionsKeyboardConfigurationMenu::OptionsKeyboardConfigurationMenu(::Engines::Co
 	GUI(console) {
 
 	load("optkeymapping");
+
+	addBackground(kBackgroundTypeMenu);
 }
 
 OptionsKeyboardConfigurationMenu::~OptionsKeyboardConfigurationMenu() {

--- a/src/engines/kotor/gui/options/mousesettings.cpp
+++ b/src/engines/kotor/gui/options/mousesettings.cpp
@@ -36,6 +36,8 @@ namespace KotOR {
 OptionsMouseSettingsMenu::OptionsMouseSettingsMenu(::Engines::Console *console) : GUI(console) {
 	load("optmouse");
 
+	addBackground(kBackgroundTypeMenu);
+
 	getCheckBox("CB_REVBUTTONS", true)->setColor(0.0f, 0.658824f, 0.980392f, 1.0f);
 }
 

--- a/src/engines/kotor/gui/options/sound.cpp
+++ b/src/engines/kotor/gui/options/sound.cpp
@@ -34,6 +34,8 @@ namespace KotOR {
 OptionsSoundMenu::OptionsSoundMenu(::Engines::Console *console) : GUI(console) {
 	load("optsound");
 
+	addBackground(kBackgroundTypeMenu);
+
 	_advanced.reset(new OptionsSoundAdvancedMenu(_console));
 }
 

--- a/src/engines/kotor/gui/options/soundadv.cpp
+++ b/src/engines/kotor/gui/options/soundadv.cpp
@@ -40,6 +40,8 @@ namespace KotOR {
 OptionsSoundAdvancedMenu::OptionsSoundAdvancedMenu(::Engines::Console *console) : GUI(console) {
 	load("optsoundadv");
 
+	addBackground(kBackgroundTypeMenu);
+
 	//Hardcoded, the gui file returns incorrect values
 	getButton("BTN_EAXLEFT", true)->setColor(0.0f, 0.658824f, 0.980392f, 1.0f);
 	getButton("BTN_EAXLEFT", true)->setStaticHighlight();


### PR DESCRIPTION
After I recognized that the background for the options menu is missing, i added it.