### PR TITLE
KOTOR: Container menu

### DIFF
--- a/src/engines/aurora/gui.cpp
+++ b/src/engines/aurora/gui.cpp
@@ -341,20 +341,20 @@ uint32 GUI::sub(GUI &gui, uint32 startCode, bool showSelf, bool hideSelf) {
 	if (hideSelf)
 		hide();
 
-	GfxMan.unlockFrame();
-
 	// Move the gui a bit behind the sub gui
 	float x, y, z;
 	getPosition(x, y, z);
 	setPosition(x, y, z + 100.0f);
 
+	GfxMan.unlockFrame();
+
 	// Run the sub GUI
 	uint32 code = gui.run(startCode);
 
+	GfxMan.lockFrame();
+
 	// Reset the position
 	setPosition(x, y, z);
-
-	GfxMan.lockFrame();
 
 	// Hide the sub GUI
 	if (hideSelf && showSelf)

--- a/src/engines/kotor/area.cpp
+++ b/src/engines/kotor/area.cpp
@@ -491,6 +491,7 @@ void Area::click(int x, int y) {
 		return;
 
 	o->click(_module->getPC());
+	_module->clickObject(o);
 }
 
 void Area::highlightAll(bool enabled) {

--- a/src/engines/kotor/gui/ingame/container.cpp
+++ b/src/engines/kotor/gui/ingame/container.cpp
@@ -1,0 +1,48 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The ingame container inventory menu.
+ */
+
+#include "src/engines/kotor/gui/widgets/panel.h"
+#include "src/engines/kotor/gui/ingame/container.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+ContainerMenu::ContainerMenu(Console *console) : GUI(console) {
+	load("container");
+
+	WidgetPanel *guiPanel = getPanel("TGuiPanel");
+	guiPanel->setPosition(-guiPanel->getWidth()/2, -guiPanel->getHeight()/2, 0);
+}
+
+void ContainerMenu::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_CANCEL") {
+		_returnCode = kReturnCodeAbort;
+		return;
+	}
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/ingame/container.h
+++ b/src/engines/kotor/gui/ingame/container.h
@@ -1,0 +1,50 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The ingame container inventory menu.
+ */
+
+#ifndef ENGINES_KOTOR_GUI_INGAME_CONTAINER_H
+#define ENGINES_KOTOR_GUI_INGAME_CONTAINER_H
+
+#include "src/engines/aurora/console.h"
+
+#include "src/engines/kotor/module.h"
+#include "src/engines/kotor/gui/gui.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class ContainerMenu : public GUI {
+public:
+	ContainerMenu(Engines::Console *console = 0);
+
+protected:
+	void callbackActive(Widget &widget);
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+
+#endif // ENGINES_KOTOR_GUI_INGAME_CONTAINER_H

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -131,6 +131,11 @@ void HUD::setPosition(float x, float y) {
 		_minimap->setPosition(x, y);
 }
 
+void HUD::showContainer() {
+	_container.reset(new ContainerMenu());
+	sub(*_container, kStartCodeNone, true, false);
+}
+
 void HUD::initWidget(Engines::Widget &widget) {
 	// Don't know what these two are doing, but they spawn over the complete screen blocking the 3d picking.
 	if (widget.getTag() == "LBL_MAP")

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -29,6 +29,7 @@
 
 #include "src/engines/kotor/gui/gui.h"
 
+#include "src/engines/kotor/gui/ingame/container.h"
 #include "src/engines/kotor/gui/ingame/menu.h"
 #include "src/engines/kotor/gui/ingame/minimap.h"
 
@@ -50,8 +51,11 @@ public:
 
 	void setPosition(float x, float y);
 
+	void showContainer();
+
 private:
 	Menu _menu;
+	Common::ScopedPtr<ContainerMenu> _container;
 
 	Common::ScopedPtr<Minimap> _minimap;
 

--- a/src/engines/kotor/gui/ingame/ingame.cpp
+++ b/src/engines/kotor/gui/ingame/ingame.cpp
@@ -63,6 +63,10 @@ void IngameGUI::setReturnEnabled(bool enabled) {
 	_hud->setReturnEnabled(enabled);
 }
 
+void IngameGUI::showContainer() {
+	_hud->showContainer();
+}
+
 void IngameGUI::addEvent(const Events::Event &event) {
 	_hud->addEvent(event);
 }

--- a/src/engines/kotor/gui/ingame/ingame.h
+++ b/src/engines/kotor/gui/ingame/ingame.h
@@ -52,6 +52,9 @@ public:
 	void setReturnQueryStrref(uint32 id);
 	void setReturnEnabled(bool enabled);
 
+	// Container inventory handling
+	void showContainer();
+
 	void addEvent(const Events::Event &event);
 	void processEventQueue();
 

--- a/src/engines/kotor/gui/ingame/rules.mk
+++ b/src/engines/kotor/gui/ingame/rules.mk
@@ -22,6 +22,7 @@
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/ingame.h \
     src/engines/kotor/gui/ingame/hud.h \
+    src/engines/kotor/gui/ingame/container.h \
     src/engines/kotor/gui/ingame/menu.h \
     src/engines/kotor/gui/ingame/menu_equ.h \
     src/engines/kotor/gui/ingame/menu_inv.h \
@@ -37,6 +38,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
 src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/ingame.cpp \
     src/engines/kotor/gui/ingame/hud.cpp \
+    src/engines/kotor/gui/ingame/container.cpp \
     src/engines/kotor/gui/ingame/menu.cpp \
     src/engines/kotor/gui/ingame/menu_equ.cpp \
     src/engines/kotor/gui/ingame/menu_inv.cpp \

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -51,6 +51,7 @@
 #include "src/engines/kotor/module.h"
 #include "src/engines/kotor/area.h"
 #include "src/engines/kotor/creature.h"
+#include "src/engines/kotor/placeable.h"
 #include "src/engines/kotor/gui/ingame/ingame.h"
 
 namespace Engines {
@@ -431,6 +432,16 @@ void Module::leaveArea() {
 	}
 
 	runScript(kScriptExit, this, _pc.get());
+}
+
+void Module::clickObject(Object *object) {
+	Placeable *placeable = ObjectContainer::toPlaceable(object);
+	if (placeable) {
+		if (placeable->hasInventory()) {
+			_ingame->showContainer();
+			placeable->close(_pc.get());
+		}
+	}
 }
 
 void Module::addEvent(const Events::Event &event) {

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -137,6 +137,9 @@ public:
 	/** Leave the running module, quitting it. */
 	void leave();
 
+	/** Open the inventory of a container. */
+	void clickObject(Object *object);
+
 	/** Add a single event for consideration into the event queue. */
 	void addEvent(const Events::Event &event);
 	/** Process the current event queue. */

--- a/src/engines/kotor/placeable.cpp
+++ b/src/engines/kotor/placeable.cpp
@@ -230,6 +230,10 @@ bool Placeable::deactivate(Object *user) {
 	return true;
 }
 
+bool Placeable::hasInventory() {
+	return _hasInventory;
+}
+
 } // End of namespace KotOR
 
 } // End of namespace Engines

--- a/src/engines/kotor/placeable.h
+++ b/src/engines/kotor/placeable.h
@@ -71,6 +71,10 @@ public:
 	/** The user object deactivates this placeable. */
 	bool deactivate(Object *closer);
 
+	// Inventory
+
+	bool hasInventory();
+
 	// Object/Cursor interactions
 
 	void enter(); ///< The cursor entered the placeable.


### PR DESCRIPTION
This commit tries to bridge between the selection of objects and the handling of module specific stuff, in this case, when the player clicks on a chest, the ingame ui will open a window for managing the contents of the container.