### PR TITLE
KOTOR: Initial satellite camera implementation w\ PC movement

### DIFF
--- a/src/engines/aurora/freeroamcamera.cpp
+++ b/src/engines/aurora/freeroamcamera.cpp
@@ -19,16 +19,18 @@
  */
 
 /** @file
- *  Engine utility functions for camera handling.
+ *  Engine utility class for free-roam camera handling.
  */
 
 #include "src/graphics/camera.h"
 
-#include "src/engines/aurora/camera.h"
+#include "src/engines/aurora/freeroamcamera.h"
+
+DECLARE_SINGLETON(Engines::FreeRoamCamera)
 
 namespace Engines {
 
-bool handleCameraInput(const Events::Event &e) {
+bool FreeRoamCamera::handleCameraInput(const Events::Event &e) {
 	if      (e.type == Events::kEventKeyDown)
 		return handleCameraKeyboardInput(e);
 	else if (e.type == Events::kEventMouseMove)
@@ -37,7 +39,7 @@ bool handleCameraInput(const Events::Event &e) {
 	return false;
 }
 
-bool handleCameraKeyboardInput(const Events::Event &e) {
+bool FreeRoamCamera::handleCameraKeyboardInput(const Events::Event &e) {
 	float multiplier = 1.0f;
 	if (e.key.keysym.mod & KMOD_SHIFT)
 		multiplier = 5.0f;
@@ -80,7 +82,7 @@ bool handleCameraKeyboardInput(const Events::Event &e) {
 	return true;
 }
 
-bool handleCameraMouseInput(const Events::Event &e) {
+bool FreeRoamCamera::handleCameraMouseInput(const Events::Event &e) {
 	// Holding down the middle mouse button enables free look.
 	if (e.motion.state & SDL_BUTTON(2))
 		CameraMan.turn(-0.5f * e.motion.yrel, 0.0f, -0.5f * e.motion.xrel);

--- a/src/engines/aurora/freeroamcamera.h
+++ b/src/engines/aurora/freeroamcamera.h
@@ -1,0 +1,46 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Engine utility class for free-roam camera handling.
+ */
+
+#ifndef ENGINES_AURORA_FREEROAMCAMERA_H
+#define ENGINES_AURORA_FREEROAMCAMERA_H
+
+#include "src/common/singleton.h"
+
+#include "src/events/types.h"
+
+namespace Engines {
+
+class FreeRoamCamera : public Common::Singleton<FreeRoamCamera> {
+public:
+	bool handleCameraInput(const Events::Event &e);
+private:
+	bool handleCameraKeyboardInput(const Events::Event &e);
+	bool handleCameraMouseInput(const Events::Event &e);
+};
+
+} // End of namespace Engines
+
+#define FreeRoamCam ::Engines::FreeRoamCamera::instance()
+
+#endif // ENGINES_AURORA_FREEROAMCAMERA_H

--- a/src/engines/aurora/rules.mk
+++ b/src/engines/aurora/rules.mk
@@ -32,7 +32,8 @@ src_engines_aurora_libaurora_la_SOURCES += \
     src/engines/aurora/gui.h \
     src/engines/aurora/console.h \
     src/engines/aurora/loadprogress.h \
-    src/engines/aurora/camera.h \
+    src/engines/aurora/freeroamcamera.h \
+    src/engines/aurora/satellitecamera.h \
     $(EMPTY)
 
 src_engines_aurora_libaurora_la_SOURCES += \
@@ -45,5 +46,6 @@ src_engines_aurora_libaurora_la_SOURCES += \
     src/engines/aurora/gui.cpp \
     src/engines/aurora/console.cpp \
     src/engines/aurora/loadprogress.cpp \
-    src/engines/aurora/camera.cpp \
+    src/engines/aurora/freeroamcamera.cpp \
+    src/engines/aurora/satellitecamera.cpp \
     $(EMPTY)

--- a/src/engines/aurora/satellitecamera.cpp
+++ b/src/engines/aurora/satellitecamera.cpp
@@ -1,0 +1,88 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Engine utility class for camera handling where camera rotates around PC.
+ */
+
+#include "src/common/maths.h"
+
+#include "src/engines/aurora/satellitecamera.h"
+
+#include "src/graphics/camera.h"
+
+DECLARE_SINGLETON(Engines::SatelliteCamera)
+
+namespace Engines {
+
+const float ROTATION_SPEED = M_PI / 16.f;
+
+SatelliteCamera::SatelliteCamera()
+		: _distance(0), _yaw(0), _pitch(0), _pitchSin(0), _pitchCos(1) {
+}
+
+void SatelliteCamera::setTarget(float x, float y, float z) {
+	_target._x = x;
+	_target._y = y;
+	_target._z = z;
+}
+
+void SatelliteCamera::setDistance(float value) {
+	_distance = value;
+}
+
+void SatelliteCamera::setPitch(float value) {
+	_pitch = value;
+	float pitchRad = Common::deg2rad(_pitch);
+	_pitchSin = sin(pitchRad);
+	_pitchCos = cos(pitchRad);
+}
+
+float SatelliteCamera::getYaw() const {
+	return _yaw;
+}
+
+bool SatelliteCamera::handleCameraInput(const Events::Event &e) {
+	if (e.type == Events::kEventKeyDown) {
+		switch (e.key.keysym.scancode) {
+			case SDL_SCANCODE_A:
+				_yaw += ROTATION_SPEED;
+				break;
+			case SDL_SCANCODE_D:
+				_yaw -= ROTATION_SPEED;
+				break;
+			default:
+				return false;
+		}
+	}
+	update();
+	return true;
+}
+
+void SatelliteCamera::update() {
+	float x = _target._x + _distance * sin(_yaw);
+	float y = _target._y - _distance * cos(_yaw) * _pitchSin;
+	float z = _target._z + _distance * _pitchCos;
+	CameraMan.setPosition(x, y, z);
+	CameraMan.setOrientation(_pitch, 0, Common::rad2deg(_yaw));
+	CameraMan.update();
+}
+
+} // End of namespace Engines

--- a/src/engines/aurora/satellitecamera.h
+++ b/src/engines/aurora/satellitecamera.h
@@ -19,23 +19,42 @@
  */
 
 /** @file
- *  Engine utility functions for camera handling.
+ *  Engine utility class for camera handling where camera rotates around PC.
  */
 
-#ifndef ENGINES_AURORA_CAMERA_H
-#define ENGINES_AURORA_CAMERA_H
+#ifndef ENGINES_AURORA_SATELLITECAMERA_H
+#define ENGINES_AURORA_SATELLITECAMERA_H
+
+#include "src/common/singleton.h"
+#include "src/common/vector3.h"
 
 #include "src/events/types.h"
 
 namespace Engines {
 
-/** Evaluate all input events that modify the camera position / orientation. */
-bool handleCameraInput(const Events::Event &e);
-/** Evaluate keyboard input events that modify the camera position / orientation. */
-bool handleCameraKeyboardInput(const Events::Event &e);
-/** Evaluate mouse input events that modify the camera position / orientation. */
-bool handleCameraMouseInput(const Events::Event &e);
+class SatelliteCamera : public Common::Singleton<SatelliteCamera> {
+public:
+	SatelliteCamera();
+	void setTarget(float x, float y, float z);
+	void setDistance(float value);
+	void setPitch(float value);
+	float getYaw() const;
+	bool handleCameraInput(const Events::Event &e);
+	void update();
+private:
+	Common::Vector3 _target;
+	float _distance;
+	float _yaw;
+	float _pitch;
+	float _pitchSin;
+	float _pitchCos;
+
+	void updatePosition();
+	void updateOrientation();
+};
 
 } // End of namespace Engines
 
-#endif // ENGINES_AURORA_CAMERA_H
+#define SatelliteCam ::Engines::SatelliteCamera::instance()
+
+#endif // ENGINES_AURORA_SATELLITECAMERA_H

--- a/src/engines/dragonage/campaigns.cpp
+++ b/src/engines/dragonage/campaigns.cpp
@@ -33,7 +33,7 @@
 #include "src/events/events.h"
 
 #include "src/engines/aurora/console.h"
-#include "src/engines/aurora/camera.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/dragonage/game.h"
 #include "src/engines/dragonage/campaigns.h"
@@ -293,7 +293,7 @@ void Campaigns::handleEvents() {
 		}
 
 		// Camera
-		if (handleCameraInput(*event))
+		if (FreeRoamCam.handleCameraInput(*event))
 			continue;
 
 		if (_currentCampaign)

--- a/src/engines/dragonage2/campaigns.cpp
+++ b/src/engines/dragonage2/campaigns.cpp
@@ -33,7 +33,7 @@
 #include "src/events/events.h"
 
 #include "src/engines/aurora/console.h"
-#include "src/engines/aurora/camera.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/dragonage2/game.h"
 #include "src/engines/dragonage2/campaigns.h"
@@ -293,7 +293,7 @@ void Campaigns::handleEvents() {
 		}
 
 		// Camera
-		if (handleCameraInput(*event))
+		if (FreeRoamCam.handleCameraInput(*event))
 			continue;
 
 		if (_currentCampaign)

--- a/src/engines/jade/jade.cpp
+++ b/src/engines/jade/jade.cpp
@@ -47,7 +47,6 @@
 #include "src/engines/aurora/loadprogress.h"
 #include "src/engines/aurora/resources.h"
 #include "src/engines/aurora/model.h"
-#include "src/engines/aurora/camera.h"
 
 #include "src/engines/jade/gui/main/main.h"
 

--- a/src/engines/jade/module.cpp
+++ b/src/engines/jade/module.cpp
@@ -31,8 +31,8 @@
 #include "src/events/events.h"
 
 #include "src/engines/aurora/util.h"
-#include "src/engines/aurora/camera.h"
 #include "src/engines/aurora/console.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/jade/module.h"
 #include "src/engines/jade/area.h"
@@ -269,7 +269,7 @@ void Module::handleEvents() {
 
 		// Camera
 		if (!_console->isVisible())
-			if (handleCameraInput(*event))
+			if (FreeRoamCam.handleCameraInput(*event))
 				continue;
 
 		_area->addEvent(*event);

--- a/src/engines/kotor/console.cpp
+++ b/src/engines/kotor/console.cpp
@@ -49,19 +49,21 @@ Console::Console(KotOREngine &engine) :
 	::Engines::Console(engine, Graphics::Aurora::kSystemFontMono, 13),
 	_engine(&engine), _maxSizeMusic(0) {
 
-	registerCommand("exitmodule" , boost::bind(&Console::cmdExitModule , this, _1),
+	registerCommand("exitmodule" , boost::bind(&Console::cmdExitModule   , this, _1),
 			"Usage: exitmodule\nExit the module, returning to the main menu");
-	registerCommand("listmodules", boost::bind(&Console::cmdListModules, this, _1),
+	registerCommand("listmodules", boost::bind(&Console::cmdListModules  , this, _1),
 			"Usage: listmodules\nList all modules");
-	registerCommand("loadmodule" , boost::bind(&Console::cmdLoadModule , this, _1),
+	registerCommand("loadmodule" , boost::bind(&Console::cmdLoadModule   , this, _1),
 			"Usage: loadmodule <module>\nLoad and enter the specified module");
-	registerCommand("listmusic"  , boost::bind(&Console::cmdListMusic  , this, _1),
+	registerCommand("listmusic"  , boost::bind(&Console::cmdListMusic    , this, _1),
 			"Usage: listmusic\nList all available music resources");
-	registerCommand("stopmusic"  , boost::bind(&Console::cmdStopMusic  , this, _1),
+	registerCommand("stopmusic"  , boost::bind(&Console::cmdStopMusic    , this, _1),
 			"Usage: stopmusic\nStop the currently playing music resource");
-	registerCommand("playmusic"  , boost::bind(&Console::cmdPlayMusic  , this, _1),
+	registerCommand("playmusic"  , boost::bind(&Console::cmdPlayMusic    , this, _1),
 			"Usage: playmusic [<music>]\nPlay the specified music resource. "
 			"If none was specified, play the default area music.");
+	registerCommand("tfc"        , boost::bind(&Console::cmdToggleFreeCam, this, _1),
+			"Usage: tfc\nToggle free roam camera mode");
 }
 
 Console::~Console() {
@@ -139,6 +141,10 @@ void Console::cmdStopMusic(const CommandLine &UNUSED(cl)) {
 
 void Console::cmdPlayMusic(const CommandLine &cl) {
 	_engine->getGame().playMusic(cl.args);
+}
+
+void Console::cmdToggleFreeCam(const CommandLine &UNUSED(cl)) {
+	_engine->getGame().getModule().toggleFreeRoamCamera();
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/console.h
+++ b/src/engines/kotor/console.h
@@ -57,12 +57,13 @@ private:
 	void updateMusic();
 
 	// The commands
-	void cmdExitModule (const CommandLine &cl);
-	void cmdListModules(const CommandLine &cl);
-	void cmdLoadModule (const CommandLine &cl);
-	void cmdListMusic  (const CommandLine &cl);
-	void cmdStopMusic  (const CommandLine &cl);
-	void cmdPlayMusic  (const CommandLine &cl);
+	void cmdExitModule   (const CommandLine &cl);
+	void cmdListModules  (const CommandLine &cl);
+	void cmdLoadModule   (const CommandLine &cl);
+	void cmdListMusic    (const CommandLine &cl);
+	void cmdStopMusic    (const CommandLine &cl);
+	void cmdPlayMusic    (const CommandLine &cl);
+	void cmdToggleFreeCam(const CommandLine &cl);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -410,6 +410,10 @@ bool Creature::click(Object *triggerer) {
 	return false;
 }
 
+Common::ScopedPtr<Graphics::Aurora::Model> &Creature::getModel() {
+	return _model;
+}
+
 } // End of namespace KotOR
 
 } // End of namespace Engines

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -90,6 +90,8 @@ public:
 	/** The creature was clicked. */
 	bool click(Object *triggerer = 0);
 
+	Common::ScopedPtr<Graphics::Aurora::Model> &getModel();
+
 private:
 	/** Parts of a creature's body. */
 	struct PartModels {

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -136,10 +136,17 @@ public:
 	void processEventQueue();
 	// '---
 
+	void toggleFreeRoamCamera();
+
 private:
 	enum ActionType {
 		kActionNone   = 0,
 		kActionScript = 1
+	};
+
+	enum MovementDirection {
+		kForward   = 0,
+		kBackwards = 1
 	};
 
 	struct Action {
@@ -197,6 +204,8 @@ private:
 	EventQueue  _eventQueue;
 	ActionQueue _delayedActions;
 
+	bool _freeCamEnabled;
+
 
 	// .--- Unloading
 	/** Unload the whole shebang.
@@ -243,6 +252,7 @@ private:
 	void handleEvents();
 
 	void handleActions();
+	void movePC(MovementDirection direction);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor2/module.cpp
+++ b/src/engines/kotor2/module.cpp
@@ -44,8 +44,8 @@
 
 #include "src/engines/aurora/util.h"
 #include "src/engines/aurora/resources.h"
-#include "src/engines/aurora/camera.h"
 #include "src/engines/aurora/console.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/kotor2/module.h"
 #include "src/engines/kotor2/area.h"
@@ -426,7 +426,7 @@ void Module::handleEvents() {
 
 		// Camera
 		if (!_console->isVisible())
-			if (handleCameraInput(*event))
+			if (FreeRoamCam.handleCameraInput(*event))
 				continue;
 
 		_area->addEvent(*event);

--- a/src/engines/nwn/module.cpp
+++ b/src/engines/nwn/module.cpp
@@ -45,8 +45,8 @@
 
 #include "src/engines/aurora/util.h"
 #include "src/engines/aurora/tokenman.h"
-#include "src/engines/aurora/camera.h"
 #include "src/engines/aurora/console.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/nwn/types.h"
 #include "src/engines/nwn/version.h"
@@ -496,7 +496,7 @@ void Module::handleEvents() {
 
 		// Camera
 		if (!_console->isVisible())
-			if (handleCameraInput(*event))
+			if (FreeRoamCam.handleCameraInput(*event))
 				continue;
 
 		_ingameGUI->addEvent(*event);

--- a/src/engines/nwn2/campaign.cpp
+++ b/src/engines/nwn2/campaign.cpp
@@ -43,7 +43,7 @@
 
 #include "src/engines/aurora/resources.h"
 #include "src/engines/aurora/console.h"
-#include "src/engines/aurora/camera.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/nwn2/campaign.h"
 #include "src/engines/nwn2/module.h"
@@ -282,7 +282,7 @@ void Campaign::handleEvents() {
 		}
 
 		// Camera
-		if (handleCameraInput(*event))
+		if (FreeRoamCam.handleCameraInput(*event))
 			continue;
 
 		_module->addEvent(*event);

--- a/src/engines/witcher/campaign.cpp
+++ b/src/engines/witcher/campaign.cpp
@@ -37,7 +37,7 @@
 #include "src/events/events.h"
 
 #include "src/engines/aurora/console.h"
-#include "src/engines/aurora/camera.h"
+#include "src/engines/aurora/freeroamcamera.h"
 
 #include "src/engines/witcher/campaign.h"
 #include "src/engines/witcher/module.h"
@@ -287,7 +287,7 @@ void Campaign::handleEvents() {
 		}
 
 		// Camera
-		if (handleCameraInput(*event))
+		if (FreeRoamCam.handleCameraInput(*event))
 			continue;
 
 		_module->addEvent(*event);

--- a/src/graphics/aurora/model.cpp
+++ b/src/graphics/aurora/model.cpp
@@ -213,6 +213,21 @@ void Model::playDefaultAnimation() {
 	}
 }
 
+void Model::clearDefaultAnimations() {
+	_defaultAnimations.clear();
+}
+
+void Model::addDefaultAnimation(const Common::UString &name, uint8 probability) {
+	Animation *anim = getAnimation(name);
+	if (!anim)
+		return;
+
+	DefaultAnimation da;
+	da.animation = anim;
+	da.probability = probability;
+	_defaultAnimations.push_back(da);
+}
+
 Animation *Model::selectDefaultAnimation() const {
 	uint8 pick = std::rand() % 100;
 	for (DefaultAnimations::const_iterator a = _defaultAnimations.begin(); a != _defaultAnimations.end(); ++a) {

--- a/src/graphics/aurora/model.h
+++ b/src/graphics/aurora/model.h
@@ -178,6 +178,9 @@ public:
 	/** Play a default idle animation. */
 	void playDefaultAnimation();
 
+	void clearDefaultAnimations();
+	void addDefaultAnimation(const Common::UString &name, uint8 probability);
+
 
 	// Renderable
 	void calculateDistance();


### PR DESCRIPTION
Alters camera behavior in KotOR to match the original game. Press A/D to rotate the camera around PC, W/S to move PC forward or backwards. Use console command "tfc" to toggle free roam camera mode.

TODO: Use FOV, pitch and distance values from camerastyle.2da; smooth out camera rotation and PC movement