### PR TITLE
TESTS: Undefine SDL main macro for Google Test

### DIFF
--- a/tests/googletest/src/gtest_main.cc
+++ b/tests/googletest/src/gtest_main.cc
@@ -31,6 +31,8 @@
 
 #include "gtest/gtest.h"
 
+#undef main // negate -Dmain=SDL_main
+
 GTEST_API_ int main(int argc, char **argv) {
   printf("Running main() from gtest_main.cc\n");
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Otherwise main gets replaced with SDL_main which leads to tests
compilation errors on Windows