### PR TITLE
KOTOR: Add selection circle

### DIFF
--- a/src/engines/kotor/area.cpp
+++ b/src/engines/kotor/area.cpp
@@ -462,13 +462,17 @@ void Area::setActive(KotOR::Object *object) {
 	if (object == _activeObject)
 		return;
 
-	if (_activeObject)
+	if (_activeObject) {
 		_activeObject->leave();
+		_module->leaveObject(_activeObject);
+	}
 
 	_activeObject = object;
 
-	if (_activeObject)
+	if (_activeObject) {
 		_activeObject->enter();
+		_module->enterObject(_activeObject);
+	}
 }
 
 void Area::checkActive(int x, int y) {

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -50,6 +50,8 @@ HUD::HUD(Engines::Console *console) : GUI(console) {
 		return;
 	}
 
+	_circle.reset(new Graphics::Aurora::GUIQuad("friendlyreticle", 0, 0, 64, 64));
+
 	// Make the action stuff invisible.
 	getWidget("LBL_HEALTHBG")->setInvisible(true);
 	getWidget("LBL_NAMEBG")->setInvisible(true);
@@ -129,6 +131,19 @@ void HUD::setMinimap(const Common::UString &map, int northAxis,
 void HUD::setPosition(float x, float y) {
 	if (_minimap)
 		_minimap->setPosition(x, y);
+}
+
+void HUD::showSelectionCircle() {
+	_circle->show();
+}
+
+void HUD::hideSelectionCircle() {
+	_circle->hide();
+}
+
+void HUD::setSelectionPosition(float x, float y) {
+	if (_circle)
+		_circle->setPosition(x - 32, y - 32);
 }
 
 void HUD::showContainer() {

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -51,10 +51,17 @@ public:
 
 	void setPosition(float x, float y);
 
+	void showSelectionCircle();
+	void hideSelectionCircle();
+	void setSelectionPosition(float x, float y);
+
 	void showContainer();
 
 private:
 	Menu _menu;
+
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _circle;
+
 	Common::ScopedPtr<ContainerMenu> _container;
 
 	Common::ScopedPtr<Minimap> _minimap;

--- a/src/engines/kotor/gui/ingame/ingame.cpp
+++ b/src/engines/kotor/gui/ingame/ingame.cpp
@@ -51,6 +51,18 @@ void IngameGUI::setPosition(float x, float y) {
 	_hud->setPosition(x, y);
 }
 
+void IngameGUI::showSelectionCircle() {
+	_hud->showSelectionCircle();
+}
+
+void IngameGUI::hideSelectionCicle() {
+	_hud->hideSelectionCircle();
+}
+
+void IngameGUI::setSelectionPosition(float x, float y) {
+	_hud->setSelectionPosition(x, y);
+}
+
 void IngameGUI::setReturnStrref(uint32 id) {
 	_hud->setReturnStrref(id);
 }

--- a/src/engines/kotor/gui/ingame/ingame.h
+++ b/src/engines/kotor/gui/ingame/ingame.h
@@ -48,6 +48,13 @@ public:
 	/** Set the position for the minimap. */
 	void setPosition(float x, float y);
 
+	/** Shows the selection circle. */
+	void showSelectionCircle();
+	/** Hide selection circle. */
+	void hideSelectionCicle();
+	/** Sets the screen position for the selection pointer. */
+	void setSelectionPosition(float x, float y);
+
 	void setReturnStrref(uint32 id);
 	void setReturnQueryStrref(uint32 id);
 	void setReturnEnabled(bool enabled);

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -139,6 +139,13 @@ public:
 
 	/** Open the inventory of a container. */
 	void clickObject(Object *object);
+	/** If an object is hovered. */
+	void enterObject(Object *object);
+	/** If an object is not hovered anymore. */
+	void leaveObject(Object *object);
+
+	/** Update the selected object. */
+	void updateSelection();
 
 	/** Add a single event for consideration into the event queue. */
 	void addEvent(const Events::Event &event);
@@ -171,7 +178,6 @@ private:
 
 	typedef std::list<Events::Event> EventQueue;
 	typedef std::multiset<Action> ActionQueue;
-
 
 	::Engines::Console *_console;
 
@@ -213,6 +219,8 @@ private:
 
 	EventQueue  _eventQueue;
 	ActionQueue _delayedActions;
+
+	Object *_selected;
 
 	bool _freeCamEnabled;
 	uint32 _prevTimestamp;

--- a/src/engines/kotor/placeable.cpp
+++ b/src/engines/kotor/placeable.cpp
@@ -61,6 +61,10 @@ void Placeable::load(const Aurora::GFF3Struct &placeable) {
 		warning("Placeable \"%s\" has no blueprint", _tag.c_str());
 }
 
+void Placeable::getTooltipAnchor(float &x, float &y, float &z) {
+	_model->getTooltipAnchor(x, y, z);
+}
+
 void Placeable::hide() {
 	leave();
 

--- a/src/engines/kotor/placeable.h
+++ b/src/engines/kotor/placeable.h
@@ -52,6 +52,8 @@ public:
 
 	// Basic visuals
 
+	void getTooltipAnchor(float &x, float &y, float &z);
+
 	void hide(); ///< Hide the placeable's model.
 
 	// Basic properties


### PR DESCRIPTION
This PR adds the selection circle, utilized by kotor to show, that an object is selected