### PR TITLE
COMMON: Deflate without knowing the output size

### DIFF
--- a/src/common/deflate.h
+++ b/src/common/deflate.h
@@ -57,6 +57,20 @@ static const int kWindowBitsMaxRaw = -kWindowBitsMax;
 byte *decompressDeflate(const byte *data, size_t inputSize,
                         size_t outputSize, int windowBits);
 
+/** Decompress (inflate) using zlib's DEFLATE algorithm without knowing the output size.
+ *
+ *  @param  data       The compressed input data.
+ *  @param  inputSize  The size of the input data in bytes.
+ *  @param  outputSize The size of the decompressed output data.
+ *  @param windowBits  The base two logarithm of the window size (the size of
+ *                     the history buffer). See the zlib documentation on
+ *                     inflateInit2() for details.
+ *  @param frameSize   The size of the extracted frames, defaults to 4096.
+ *  @return The decompressed data
+ */
+byte *decompressDeflateWithoutOutputSize(const byte *data, size_t inputSize, size_t &outputSize,
+                                         int windowBits, unsigned int frameSize = 4096);
+
 /** Decompress (inflate) using zlib's DEFLATE algorithm.
  *
  *  @param  input      The compressed input data.
@@ -72,6 +86,19 @@ byte *decompressDeflate(const byte *data, size_t inputSize,
  */
 SeekableReadStream *decompressDeflate(ReadStream &input, size_t inputSize,
                                       size_t outputSize, int windowBits);
+
+/** Decompress (inflate) using zlib's DEFLATE algorithm without knowing the output size.
+ *
+ *  @param  input      The compressed input data.
+ *  @param  inputSize  The size of the input data to read in bytes.
+ *  @param windowBits  The base two logarithm of the window size (the size of
+ *                     the history buffer). See the zlib documentation on
+ *                     inflateInit2() for details.
+ *  @param frameSize   The size of the extracted frames, defaults to 4096.
+ *  @return A stream of the decompressed data.
+ */
+SeekableReadStream *decompressDeflateWithoutOutputSize(ReadStream &input, size_t inputSize,
+                                                       int windowBits, unsigned int frameSize = 4096);
 
 } // End of namespace Common
 

--- a/tests/common/deflate.cpp
+++ b/tests/common/deflate.cpp
@@ -87,6 +87,22 @@ GTEST_TEST(DEFLATE, decompressBuf) {
 	delete[] decompressed;
 }
 
+GTEST_TEST(DEFLATE, decompressBufWithoutDecompressedSize) {
+	static const size_t kSizeCompressed   = sizeof(kDataCompressed);
+	static const size_t kSizeDecompressed = strlen(kDataUncompressed);
+
+	size_t size = 0;
+	const byte *decompressed =
+		Common::decompressDeflateWithoutOutputSize(kDataCompressed, kSizeCompressed, size, Common::kWindowBitsMaxRaw, 128);
+	ASSERT_NE(decompressed, static_cast<const byte *>(0));
+	ASSERT_EQ(size, kSizeDecompressed);
+
+	for (size_t i = 0; i < kSizeDecompressed; i++)
+		EXPECT_EQ(decompressed[i], kDataUncompressed[i]) << "At index " << i;
+
+	delete[] decompressed;
+}
+
 GTEST_TEST(DEFLATE, decompressStream) {
 	static const size_t kSizeCompressed   = sizeof(kDataCompressed);
 	static const size_t kSizeDecompressed = strlen(kDataUncompressed);
@@ -95,6 +111,24 @@ GTEST_TEST(DEFLATE, decompressStream) {
 
 	Common::SeekableReadStream *decompressed =
 		Common::decompressDeflate(compressed, kSizeCompressed, kSizeDecompressed, Common::kWindowBitsMaxRaw);
+	ASSERT_NE(decompressed, static_cast<Common::SeekableReadStream *>(0));
+
+	ASSERT_EQ(decompressed->size(), kSizeDecompressed);
+
+	for (size_t i = 0; i < kSizeDecompressed; i++)
+		EXPECT_EQ(decompressed->readByte(), kDataUncompressed[i]) << "At index " << i;
+
+	delete decompressed;
+}
+
+GTEST_TEST(DEFLATE, decompressStreamWithoutDecompressedSize) {
+	static const size_t kSizeCompressed   = sizeof(kDataCompressed);
+	static const size_t kSizeDecompressed = strlen(kDataUncompressed);
+
+	Common::MemoryReadStream compressed(kDataCompressed);
+
+	Common::SeekableReadStream *decompressed =
+			Common::decompressDeflateWithoutOutputSize(compressed, kSizeCompressed, Common::kWindowBitsMaxRaw, 128);
 	ASSERT_NE(decompressed, static_cast<Common::SeekableReadStream *>(0));
 
 	ASSERT_EQ(decompressed->size(), kSizeDecompressed);


### PR DESCRIPTION
This PR adds the possibility to decompress zlib data wihout knowing the exact size.