### PR TITLE
KOTOR2: Fix a graphical glitch in kotor2 borders

### DIFF
--- a/src/graphics/aurora/borderquad.h
+++ b/src/graphics/aurora/borderquad.h
@@ -54,6 +54,8 @@ public:
 private:
 	TextureHandle _edge, _corner;
 
+	bool _verticalCut;
+
 	int _edgeWidth, _edgeHeight;
 	int _cornerWidth, _cornerHeight;
 


### PR DESCRIPTION
This PR fixes a bug for small borders, where upper and lower elements overlap.