### PR TITLE
Fix appveyor builds, use vcpkg to install dependencies on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,8 @@ environment:
     CONFIGURE_CMD: CC=cl CXX=cl ./configure --prefix=/
     INSTALL_CMD: make install
 
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
   matrix:
     - CMAKE_GENERATOR: Visual Studio 14 2015
       MSVC_ARCH: amd64_x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,8 @@ configuration: Debug
 
 environment:
   global:
-    BOOST_ROOT: C:\Libraries\boost_1_59_0
-    BOOST_INCLUDEDIR: C:\Libraries\boost_1_59_0
+    BOOST_ROOT: C:\Libraries\boost_1_66_0
+    BOOST_INCLUDEDIR: C:\Libraries\boost_1_66_0
     FREETYPE_DIR: C:\projects\xoreos\libs\freetype-2.3.5-1-lib
     LIBSDL2: SDL2-2.0.4
     LIBFT2: freetype-2.3.5-1
@@ -32,7 +32,7 @@ environment:
       MSBUILD_PLATFORM: Win32
       PROGRAM_FILES_DIR: C:\Program Files (x86)
 
-      BOOST_LIBRARYDIR: C:/Libraries/boost_1_59_0/lib32-msvc-14.0
+      BOOST_LIBRARYDIR: C:/Libraries/boost_1_66_0/lib32-msvc-14.0
 
       LIBOPENAL_DESTDIR: C:/Programs/OpenAL
       LIBSDL2_DESTDIR: C:/Programs/SDL2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,14 +12,7 @@ environment:
   global:
     BOOST_ROOT: C:\Libraries\boost_1_66_0
     BOOST_INCLUDEDIR: C:\Libraries\boost_1_66_0
-    FREETYPE_DIR: C:\projects\xoreos\libs\freetype-2.3.5-1-lib
-    LIBSDL2: SDL2-2.0.4
-    LIBFT2: freetype-2.3.5-1
-    LIBICONV: libiconv-1.9.2-1
-    LIBMAD: libmad-0.15.1b
     LIBFAAD: faad2-2.7
-    LIBOGG: libogg-1.3.2
-    LIBVORBIS: libvorbis-1.3.5
     LIBXVID: xvidcore-1.3.4
 
     AUTORECONF_CMD: WANT_AUTOMAKE=latest AUTOMAKE='automake --foreign' autoreconf -fi
@@ -33,16 +26,12 @@ environment:
       PROGRAM_FILES_DIR: C:\Program Files (x86)
 
       BOOST_LIBRARYDIR: C:/Libraries/boost_1_66_0/lib32-msvc-14.0
-
-      LIBOPENAL_DESTDIR: C:/Programs/OpenAL
-      LIBSDL2_DESTDIR: C:/Programs/SDL2
-      LIBMAD_DESTDIR: C:/Programs/MAD
       LIBFAAD_DESTDIR: C:/Programs/FAAD
-      LIBOGG_DESTDIR: C:/Programs/libogg
-      LIBVORBIS_DESTDIR: C:/Programs/vorbis
-      LIBXZ_DESTDIR: C:\Programs\xz
       LIBXVID_DESTDIR: C:\Programs\XviD
-      LIBXML2_DESTDIR: C:/Programs/libxml2
+
+      VCPKG_INC_DIR: C:/tools/vcpkg/installed/x86-windows/include
+      VCPKG_LIB_DIR: C:/tools/vcpkg/installed/x86-windows/lib
+      VCPKG_BIN_DIR: C:\tools\vcpkg\installed\x86-windows\bin
 
 install:
   - set PROGRAMFILES=%PROGRAM_FILES_DIR%
@@ -50,48 +39,8 @@ install:
   - mklink /d "C:\Programs" "%PROGRAM_FILES_DIR%"
 
   - cmake -E make_directory libs
-  - if not exist libs\zlib   git clone --depth 1 --branch v1.2.8             https://github.com/madler/zlib.git      libs/zlib
-  - if not exist libs\openal git clone --depth 1 --branch openal-soft-1.17.0 https://github.com/kcat/openal-soft.git libs/openal
-  - if not exist libs\xz     git clone           --branch v5.2               http://git.tukaani.org/xz.git           libs/xz
-  - if not exist libs\xml2   git clone --depth 1 --branch v2.9.4             git://git.gnome.org/libxml2             libs/xml2
-
-  - if not exist libs\%LIBSDL2%.tar.gz   cmake -E chdir libs curl -OfsSL https://www.libsdl.org/release/%LIBSDL2%.tar.gz
-  - if not exist libs\%LIBFT2%-lib.zip   cmake -E chdir libs curl -OfsSL http://sourceforge.net/projects/gnuwin32/files/freetype/2.3.5-1/%LIBFT2%-lib.zip
-  - if not exist libs\%LIBICONV%-lib.zip cmake -E chdir libs curl -OfsSL http://sourceforge.net/projects/gnuwin32/files/libiconv/1.9.2-1/%LIBICONV%-lib.zip
-  - if not exist libs\%LIBICONV%-bin.zip cmake -E chdir libs curl -OfsSL http://sourceforge.net/projects/gnuwin32/files/libiconv/1.9.2-1/%LIBICONV%-bin.zip
-  - if not exist libs\%LIBMAD%.tar.gz    cmake -E chdir libs curl -OfsSL ftp://ftp.mars.org/pub/mpeg/%LIBMAD%.tar.gz
   - if not exist libs\%LIBFAAD%.tar.bz2  cmake -E chdir libs curl -OfsSL http://downloads.sourceforge.net/faac/%LIBFAAD%.tar.bz2
-  - if not exist libs\%LIBOGG%.tar.xz    cmake -E chdir libs curl -OfsSL http://downloads.xiph.org/releases/ogg/%LIBOGG%.tar.xz
-  - if not exist libs\%LIBVORBIS%.tar.xz cmake -E chdir libs curl -OfsSL http://downloads.xiph.org/releases/vorbis/%LIBVORBIS%.tar.xz
   - if not exist libs\%LIBXVID%.tar.gz   cmake -E chdir libs curl -OfsSL http://downloads.xvid.org/downloads/%LIBXVID%.tar.gz
-
-  - cmake -Blibs/zlib/build -Hlibs/zlib -G"%CMAKE_GENERATOR%" -DBUILD_SHARED_LIBS=ON
-  - cmake --build libs/zlib/build --target install -- /p:Configuration=Release /verbosity:quiet
-
-  - cmake -E chdir libs cmake -E tar xf %LIBSDL2%.tar.gz
-  - cmake -Blibs/%LIBSDL2%/build -Hlibs/%LIBSDL2% -G"%CMAKE_GENERATOR%" -DSDL_SHARED=ON -DSDL_STATIC=OFF
-  - cmake --build libs/%LIBSDL2%/build --target install -- /p:Configuration=Release /verbosity:quiet
-
-  - cmake -Blibs/openal/build -Hlibs/openal -G"%CMAKE_GENERATOR%" -DBUILD_SHARED_LIBS=ON
-  - cmake --build libs/openal/build --target install -- /p:Configuration=Release /verbosity:quiet
-
-  - cmake -E make_directory libs\%LIBFT2%-lib
-  - cmake -E chdir libs/%LIBFT2%-lib cmake -E tar xf ../%LIBFT2%-lib.zip
-
-  - cmake -E make_directory libs\%LIBICONV%-lib
-  - cmake -E chdir libs/%LIBICONV%-lib cmake -E tar xf ../%LIBICONV%-lib.zip
-
-  - cmake -E make_directory libs\%LIBICONV%-bin
-  - cmake -E chdir libs/%LIBICONV%-bin cmake -E tar xf ../%LIBICONV%-bin.zip
-
-  - cmake -E chdir libs/xz msbuild windows\xz_win.sln /p:Configuration=Release /p:Platform=%MSBUILD_PLATFORM% /verbosity:quiet
-  - cmake -E make_directory %LIBXZ_DESTDIR%
-  - cmake -E make_directory %LIBXZ_DESTDIR%\include
-  - cmake -E make_directory %LIBXZ_DESTDIR%\lib
-  - cmake -E copy libs\xz\src\liblzma\api\lzma.h                                     %LIBXZ_DESTDIR%\include\
-  - cmake -E copy_directory libs\xz\src\liblzma\api\lzma\                            %LIBXZ_DESTDIR%\include\lzma\
-  - cmake -E copy libs\xz\windows\Release\%MSBUILD_PLATFORM%\liblzma_dll\liblzma.dll %LIBXZ_DESTDIR%\lib\lzma.dll
-  - cmake -E copy libs\xz\windows\Release\%MSBUILD_PLATFORM%\liblzma_dll\liblzma.lib %LIBXZ_DESTDIR%\lib\lzma.lib
 
   - choco install nasm
   - set PATH="C:\Program Files\NASM";%PATH%
@@ -107,63 +56,41 @@ install:
   - cmake -E copy libs\xvidcore\build\win32\bin\xvidcore.dll.exp %LIBXVID_DESTDIR%\lib\xvidcore.exp
 
   - set PATH=C:\msys64\usr\bin;%PATH%
-  - cmake -E chdir libs cmake -E tar xf %LIBMAD%.tar.gz
-  - cmake -E chdir libs/%LIBMAD% bash -c "%AUTORECONF_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBMAD% bash -c "%CONFIGURE_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBMAD% bash -c "%INSTALL_CMD% DESTDIR=%LIBMAD_DESTDIR% &>/dev/null"
-
   - cmake -E chdir libs cmake -E tar xf %LIBFAAD%.tar.bz2
   - cmake -E chdir libs/%LIBFAAD% bash -c "sed -re 's/iquote/I/' libfaad/Makefile.am -i"
   - cmake -E chdir libs/%LIBFAAD% bash -c "%AUTORECONF_CMD% &>/dev/null"
   - cmake -E chdir libs/%LIBFAAD% bash -c "%CONFIGURE_CMD% &>/dev/null"
   - cmake -E chdir libs/%LIBFAAD% bash -c "%INSTALL_CMD% DESTDIR=%LIBFAAD_DESTDIR% &>/dev/null"
 
-  - cmake -E chdir libs cmake -E tar xf %LIBOGG%.tar.xz
-  - cmake -E chdir libs/%LIBOGG% bash -c "%AUTORECONF_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBOGG% bash -c "%CONFIGURE_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBOGG% bash -c "%INSTALL_CMD% DESTDIR=%LIBOGG_DESTDIR% &>/dev/null"
-
-  - cmake -E chdir libs cmake -E tar xf %LIBVORBIS%.tar.xz
-  - cmake -E chdir libs/%LIBVORBIS% bash -c "sed -re '/AC_ADD_CFLAGS\(\[-Wdeclaration-after-statement\]\)/d' configure.ac -i"
-  - cmake -E chdir libs/%LIBVORBIS% bash -c "sed -re '/XIPH_PATH_OGG/d' configure.ac -i"
-  - cmake -E chdir libs/%LIBVORBIS% bash -c "%AUTORECONF_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBVORBIS% bash -c "OGG_CFLAGS=-I%LIBOGG_DESTDIR%/include OGG_LIBS=-l%LIBOGG_DESTDIR%/lib/ogg.lib %CONFIGURE_CMD% &>/dev/null"
-  - cmake -E chdir libs/%LIBVORBIS% bash -c "%INSTALL_CMD% DESTDIR=%LIBVORBIS_DESTDIR% &>/dev/null"
-
-  - cmake -E chdir libs/xml2 bash -c "%AUTORECONF_CMD% &>/dev/null"
-  - cmake -E chdir libs/xml2 bash -c "%CONFIGURE_CMD% --without-http --without-ftp --without-python &>/dev/null"
-  - cmake -E chdir libs/xml2 bash -c "%INSTALL_CMD% DESTDIR=%LIBXML2_DESTDIR% &>/dev/null"
+  - vcpkg install zlib:x86-windows
+  - vcpkg install bzip2:x86-windows
+  - vcpkg install libpng:x86-windows
+  - vcpkg install freetype:x86-windows
+  - vcpkg install sdl2:x86-windows
+  - vcpkg install libiconv:x86-windows
+  - vcpkg install libmad:x86-windows
+  - vcpkg install libogg:x86-windows
+  - vcpkg install libvorbis:x86-windows
+  - vcpkg install liblzma:x86-windows
+  - vcpkg install libxml2:x86-windows
+  - vcpkg install openal-soft:x86-windows
 
 build_script:
+  - set PATH=%VCPKG_BIN_DIR%;%PATH%
   - set PROGRAMFILES=%PROGRAM_FILES_DIR%
-  - cmake -Bbuild -H. -G"%CMAKE_GENERATOR%" 
+  - cmake -Bbuild -H. -G"%CMAKE_GENERATOR%"
+          -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
           -DBOOST_LIBRARYDIR=%BOOST_LIBRARYDIR%
-          -DLIBLZMA_INCLUDE_DIR=%LIBXZ_DESTDIR%/include -DLIBLZMA_LIBRARY=%LIBXZ_DESTDIR%/lib/lzma.lib
-          -DLIBXML2_INCLUDE_DIR=%LIBXML2_DESTDIR%/include/libxml2 -DLIBXML2_LIBRARIES=%LIBXML2_DESTDIR%/lib/xml2.lib
-          -DICONV_INCLUDE_DIR=C:/projects/xoreos/libs/%LIBICONV%-lib/include -DICONV_LIBRARIES=C:/projects/xoreos/libs/%LIBICONV%-lib/lib/libiconv.lib
-          -DSDL2_INCLUDE_DIR=%LIBSDL2_DESTDIR%/include/SDL2 -DSDL2_LIBRARY=%LIBSDL2_DESTDIR%/lib/SDL2.lib
-          -DOPENAL_INCLUDE_DIR=%LIBOPENAL_DESTDIR%/include -DOPENAL_LIBRARY=%LIBOPENAL_DESTDIR%/lib/OpenAL32.lib
+          -DSDL2_LIBRARY=%VCPKG_LIB_DIR%/SDL2.lib -DSDL2_INCLUDE_DIR=%VCPKG_INC_DIR%/SDL2
   - cmake --build build
-  - copy /y libs\%LIBICONV%-bin\bin\*.dll build\bin\Debug
   - copy /y %BOOST_ROOT%\lib32-msvc-14.0\*.dll build\bin\Debug
-  - copy /y %LIBXZ_DESTDIR%\lib\lzma.dll build\bin\Debug\liblzma.dll
+  - copy /y %VCPKG_BIN_DIR%\*.dll build\bin\Debug
   - cmake --build build --target check
 
 cache:
   - libs
-  - C:\Program Files\OpenAL
-  - C:\Program Files\MAD
   - C:\Program Files\FAAD
-  - C:\Program Files\libogg
-  - C:\Program Files\vorbis
-  - C:\Program Files\xz
   - C:\Program Files\XviD
-  - C:\Program Files\libxml2
-  - C:\Program Files (x86)\OpenAL
-  - C:\Program Files (x86)\MAD
   - C:\Program Files (x86)\FAAD
-  - C:\Program Files (x86)\libogg
-  - C:\Program Files (x86)\vorbis
-  - C:\Program Files (x86)\xz
   - C:\Program Files (x86)\XviD
-  - C:\Program Files (x86)\libxml2
+  - C:\tools\vcpkg\installed

--- a/src/sound/decoders/mp3.cpp
+++ b/src/sound/decoders/mp3.cpp
@@ -68,6 +68,8 @@
 
 namespace Sound {
 
+static const mad_timer_t timer_zero = {0, 0};
+
 class MP3Stream : public RewindableAudioStream {
 protected:
 	enum State {
@@ -127,7 +129,7 @@ MP3Stream::MP3Stream(Common::SeekableReadStream *inStream, bool dispose) :
 	_inStream(inStream, dispose),
 	_posInFrame(0),
 	_state(MP3_STATE_INIT),
-	_totalTime(mad_timer_zero),
+	_totalTime(timer_zero),
 	_length(kInvalidLength),
 	_samples(0) {
 
@@ -257,7 +259,7 @@ void MP3Stream::initStream() {
 
 	// Reset the stream data
 	_inStream->seek(0);
-	_totalTime = mad_timer_zero;
+	_totalTime = timer_zero;
 	_samples = 0;
 	_posInFrame = 0;
 


### PR DESCRIPTION
Hi, as the title says, this should fix the builds on Appveyor.

The dependencies are now pulled using `vcpkg` because it will probably do a better job at building these third party libraries on Windows and because it's available out of the box on Appveyor.

Also `libxvid` and `libfaad` aren't provided by `vcpkg` but if anyone wants to send https://github.com/Microsoft/vcpkg a PR with the corresponding port, they will probably be happy to integrate them.

Then there's a link error because of some global const variable in `libmad` not declared extern in `libmad` sources, so it's treated as a static. I have no clue why this was working before, maybe a different `libmad` version or compilation flags between what `xoreos` was doing and what `vcpkg` does. Anyway, i didn't really see the point of requiring this external global zero constant.