### PR TITLE
GRAPHICS: Add dedicated animation thread

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -259,6 +259,8 @@ void Creature::loadAppearance() {
 
 	loadBody(parts);
 	loadHead(parts);
+
+	setDefaultAnimations();
 }
 
 void Creature::getPartModels(PartModels &parts, uint32 state) {
@@ -386,6 +388,8 @@ void Creature::createPC(const CharacterGenerationInfo &info) {
 	parts.head += Common::composeString(info.getFace() + 1);
 
 	loadHead(parts);
+
+	setDefaultAnimations();
 }
 
 void Creature::enter() {
@@ -418,6 +422,15 @@ Common::ScopedPtr<Graphics::Aurora::Model> &Creature::getModel() {
 
 const Common::UString &Creature::getConversation() const {
 	return _conversation;
+}
+
+void Creature::setDefaultAnimations() {
+	if (!_model)
+		return;
+
+	_model->addDefaultAnimation("pause3", 25);
+	_model->addDefaultAnimation("pause2", 25);
+	_model->addDefaultAnimation("pause1", 50);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -136,6 +136,8 @@ private:
 	void getPartModels(PartModels &parts, uint32 state = 'b');
 	void loadBody(PartModels &parts);
 	void loadHead(PartModels &parts);
+
+	void setDefaultAnimations();
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -372,12 +372,6 @@ void Module::enter() {
 	if (!_pc)
 		throw Common::Exception("Module::enter(): Lacking a PC?!?");
 
-	Graphics::Aurora::Model *model = _pc->getModel().get();
-	model->clearDefaultAnimations();
-	model->addDefaultAnimation(Common::UString("pause3"), 25);
-	model->addDefaultAnimation(Common::UString("pause2"), 25);
-	model->addDefaultAnimation(Common::UString("pause1"), 50);
-
 	// Roughly head position
 	SatelliteCam.setTarget(entryX, entryY, entryZ + 1.8f);
 	SatelliteCam.setDistance(3.2f);

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -263,6 +263,8 @@ void Module::loadTexturePack() {
 }
 
 void Module::unload(bool completeUnload) {
+	GfxMan.pauseAnimations();
+
 	leaveArea();
 	unloadArea();
 
@@ -381,6 +383,8 @@ void Module::enter() {
 	_ingame->show();
 
 	enterArea();
+
+	GfxMan.resumeAnimations();
 
 	_running = true;
 	_exit    = false;

--- a/src/engines/kotor2/creature.cpp
+++ b/src/engines/kotor2/creature.cpp
@@ -192,6 +192,8 @@ void Creature::loadAppearance() {
 
 	loadBody(parts);
 	loadHead(parts);
+
+	setDefaultAnimations();
 }
 
 void Creature::getPartModels(PartModels &parts, uint32 state) {
@@ -264,6 +266,8 @@ void Creature::createPC(const CharacterGenerationInfo &info) {
 
 	loadBody(parts);
 	loadHead(parts);
+
+	setDefaultAnimations();
 }
 
 void Creature::enter() {
@@ -296,6 +300,15 @@ Common::ScopedPtr<Graphics::Aurora::Model> &Creature::getModel() {
 
 const Common::UString &Creature::getConversation() const {
 	return _conversation;
+}
+
+void Creature::setDefaultAnimations() {
+	if (!_model)
+		return;
+
+	_model->addDefaultAnimation("pause3", 25);
+	_model->addDefaultAnimation("pause2", 25);
+	_model->addDefaultAnimation("pause1", 50);
 }
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/creature.h
+++ b/src/engines/kotor2/creature.h
@@ -115,6 +115,8 @@ private:
 	void getPartModels(PartModels &parts, uint32 state = 'b');
 	void loadBody(PartModels &parts);
 	void loadHead(PartModels &parts);
+
+	void setDefaultAnimations();
 };
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/module.cpp
+++ b/src/engines/kotor2/module.cpp
@@ -331,12 +331,6 @@ void Module::enter() {
 		_pc->show();
 	}
 
-	Graphics::Aurora::Model *model = _pc->getModel().get();
-	model->clearDefaultAnimations();
-	model->addDefaultAnimation(Common::UString("pause3"), 25);
-	model->addDefaultAnimation(Common::UString("pause2"), 25);
-	model->addDefaultAnimation(Common::UString("pause1"), 50);
-
 	// Roughly head position
 	SatelliteCam.setTarget(entryX, entryY, entryZ + 1.8f);
 	SatelliteCam.setDistance(3.2f);

--- a/src/engines/kotor2/module.cpp
+++ b/src/engines/kotor2/module.cpp
@@ -234,6 +234,8 @@ void Module::loadTexturePack() {
 }
 
 void Module::unload(bool completeUnload) {
+	GfxMan.pauseAnimations();
+
 	leaveArea();
 	unloadArea();
 
@@ -338,6 +340,8 @@ void Module::enter() {
 	SatelliteCam.update(0);
 
 	enterArea();
+
+	GfxMan.resumeAnimations();
 
 	_running = true;
 	_exit    = false;

--- a/src/engines/nwn/module.cpp
+++ b/src/engines/nwn/module.cpp
@@ -382,6 +382,8 @@ void Module::enter() {
 	CameraMan.update();
 
 	_ingameGUI->show();
+
+	GfxMan.resumeAnimations();
 }
 
 void Module::leave() {
@@ -529,6 +531,8 @@ void Module::handleActions() {
 }
 
 void Module::unload(bool completeUnload) {
+	GfxMan.pauseAnimations();
+
 	unloadAreas();
 	unloadHAKs();
 	unloadTLK();

--- a/src/graphics/aurora/animation.h
+++ b/src/graphics/aurora/animation.h
@@ -93,22 +93,12 @@ protected:
 	float _transtime;
 
 private:
-	std::vector<glm::mat4>   _invBindPoseMatrices;
-	std::vector<glm::mat4>   _boneTransMatrices;
-	std::vector<ModelNode *> _nodeChain;
-
 	void interpolatePosition(ModelNode *animNode, ModelNode *target, float time, float scale,
 	                         bool relative) const;
 	void interpolateOrientation(ModelNode *animNode, ModelNode *target, float time) const;
 
 	/** Transform vertices for each node of the specified model based on current animation. */
 	void updateSkinnedModel(Model *model);
-
-	/** Multiplies first vector by a matrix, stores result in second vector. */
-	void multiply(const float *v, const glm::mat4 &m, float *rv);
-
-	/** Compute node transformation and inverse bind pose matrices. */
-	void computeNodeTransform(ModelNode *node, glm::mat4 &outInvBindPose, glm::mat4 &outTransform);
 };
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/animationthread.cpp
+++ b/src/graphics/aurora/animationthread.cpp
@@ -1,0 +1,167 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Dedicated animation thread.
+ */
+
+#include "src/common/threads.h"
+
+#include "src/events/events.h"
+
+#include "src/graphics/aurora/animationthread.h"
+#include "src/graphics/aurora/model.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+AnimationThread::PoolModel::PoolModel(Model *m)
+		: model(m),
+		  lastChanged(0) {
+}
+
+AnimationThread::AnimationThread()
+		: _paused(true),
+		  _flushing(false),
+		  _modelsSem(1),
+		  _registerSem(1) {
+}
+
+void AnimationThread::pause() {
+	_paused.store(true);
+	_modelsSem.lock();
+	_modelsSem.unlock();
+}
+
+void AnimationThread::resume() {
+	_paused.store(false);
+}
+
+void AnimationThread::registerModel(Model *model) {
+	if (_paused.load())
+		registerModelInternal(model);
+	else {
+		_registerSem.lock();
+		_registerQueue.push(model);
+		_registerSem.unlock();
+	}
+}
+
+void AnimationThread::unregisterModel(Model *model) {
+	if (_paused.load())
+		unregisterModelInternal(model);
+	else {
+		_modelsSem.lock();
+		unregisterModelInternal(model);
+		_modelsSem.unlock();
+	}
+}
+
+void AnimationThread::flush() {
+	_flushing.store(true);
+	_modelsSem.lock();
+
+	for (ModelList::iterator m = _models.begin();
+			m != _models.end();
+			++m) {
+		m->model->flushNodeBuffers();
+	}
+
+	_modelsSem.unlock();
+	_flushing.store(false);
+}
+
+void AnimationThread::threadMethod() {
+	while (!_killThread) {
+		if (EventMan.quitRequested())
+			break;
+
+		if (_paused.load()) {
+			EventMan.delay(100);
+			continue;
+		}
+
+		_modelsSem.lock();
+
+		// Register queued models
+		if (_registerSem.lockTry()) {
+			while (!_registerQueue.empty()) {
+				registerModelInternal(_registerQueue.front());
+				_registerQueue.pop();
+			}
+			_registerSem.unlock();
+		}
+
+		if (_models.empty()) {
+			_modelsSem.unlock();
+			EventMan.delay(100);
+			continue;
+		}
+
+		for (ModelList::iterator m = _models.begin();
+				m != _models.end();
+				++m) {
+			if (EventMan.quitRequested() || _paused.load())
+				break;
+
+			if (_flushing.load()) {
+				_modelsSem.unlock();
+				while (_flushing.load()) // Spin until flushing is complete
+					;
+				_modelsSem.lock();
+			}
+
+			uint32 now = EventMan.getTimestamp();
+			float dt = 0;
+			if (m->lastChanged > 0)
+				dt = (now - m->lastChanged) / 1000.f;
+			m->lastChanged = now;
+
+			m->model->manageAnimations(dt);
+		}
+
+		_modelsSem.unlock();
+
+		EventMan.delay(10);
+	}
+}
+
+void AnimationThread::registerModelInternal(Model *model) {
+	for (ModelList::iterator m = _models.begin(); m != _models.end(); ++m) {
+		if (m->model == model)
+			return;
+	}
+	_models.push_back(PoolModel(model));
+}
+
+void AnimationThread::unregisterModelInternal(Model *model) {
+	ModelList::iterator m;
+	for (m = _models.begin(); m != _models.end(); ++m) {
+		if (m->model == model)
+			break;
+	}
+	if (m != _models.end())
+		_models.erase(m);
+}
+
+} // End of namespace Aurora
+
+} // End of namespace Engines

--- a/src/graphics/aurora/animationthread.h
+++ b/src/graphics/aurora/animationthread.h
@@ -1,0 +1,87 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Dedicated animation thread.
+ */
+
+#ifndef GRAPHICS_AURORA_ANIMATIONTHREAD_H
+#define GRAPHICS_AURORA_ANIMATIONTHREAD_H
+
+#include <queue>
+
+#include <boost/atomic.hpp>
+
+#include "glm/vec3.hpp"
+#include "glm/vec4.hpp"
+
+#include "src/common/mutex.h"
+#include "src/common/thread.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+class Model;
+
+class AnimationThread : public Common::Thread {
+public:
+	AnimationThread();
+	void pause();
+	void resume();
+
+	// .--- Processing pool
+	/** Add a model to the processing pool. */
+	void registerModel(Model *model);
+	/** Remove a model from the processing pool. */
+	void unregisterModel(Model *model);
+	/** Apply changes to position and geometry of all models in the processing pool. */
+	void flush();
+	// '---
+private:
+	struct PoolModel {
+		Model *model;
+		uint32 lastChanged;
+
+		PoolModel(Model *m);
+	};
+
+	typedef std::list<PoolModel> ModelList;
+	typedef std::queue<Model *> ModelQueue;
+
+	ModelList _models;
+	ModelQueue _registerQueue;
+
+	boost::atomic<bool> _paused;
+	boost::atomic<bool> _flushing;
+
+	Common::Semaphore _modelsSem;   ///< Semaphore protecting access to the model list.
+	Common::Semaphore _registerSem; ///< Semaphore protecting access to the registration queue.
+
+	void threadMethod();
+	void registerModelInternal(Model *model);
+	void unregisterModelInternal(Model *model);
+};
+
+} // End of namespace Aurora
+
+} // End of namespace Engines
+
+#endif // GRAPHICS_AURORA_ANIMATIONTHREAD_H

--- a/src/graphics/aurora/model.cpp
+++ b/src/graphics/aurora/model.cpp
@@ -99,6 +99,16 @@ Model::~Model() {
 	delete _boundRenderable;
 }
 
+void Model::show() {
+	Renderable::show();
+	GfxMan.registerAnimatedModel(this);
+}
+
+void Model::hide() {
+	GfxMan.unregisterAnimatedModel(this);
+	Renderable::hide();
+}
+
 ModelType Model::getType() const {
 	return _type;
 }
@@ -640,6 +650,19 @@ void Model::calculateDistance() {
 
 void Model::advanceTime(float dt) {
 	manageAnimations(dt);
+	flushNodeBuffers();
+}
+
+void Model::flushNodeBuffers() {
+	if (!_currentState)
+		return;
+
+	NodeList &nodes = _currentState->nodeList;
+	for (NodeList::iterator n = nodes.begin();
+			n != nodes.end();
+			++n) {
+		(*n)->flushBuffers();
+	}
 }
 
 void Model::setSkinned(bool skinned) {

--- a/src/graphics/aurora/model.h
+++ b/src/graphics/aurora/model.h
@@ -52,11 +52,15 @@ namespace Graphics {
 namespace Aurora {
 
 class Animation;
+class AnimationThread;
 
 class Model : public GLContainer, public Renderable {
 public:
 	Model(ModelType type = kModelTypeObject);
 	~Model();
+
+	void show();
+	void hide();
 
 	ModelType getType() const; ///< Return the model's type.
 
@@ -187,6 +191,9 @@ public:
 	void calculateDistance();
 	void render(RenderPass pass);
 	void advanceTime(float dt);
+
+	/** Apply buffered changes to model nodes position and geometry. */
+	void flushNodeBuffers();
 
 
 protected:
@@ -325,6 +332,7 @@ public:
 
 	friend class ModelNode;
 	friend class Animation;
+	friend class AnimationThread;
 };
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/model_kotor.cpp
+++ b/src/graphics/aurora/model_kotor.cpp
@@ -390,7 +390,9 @@ void Model_KotOR::makeBoneNodeMap() {
 			for (uint16 i = 0; i < skin->boneMappingCount; ++i) {
 				int index = static_cast<int>(skin->boneMapping[i]);
 				if (index != -1) {
-					skin->boneNodeMap[index] = getNode(i);
+					ModelNode *node2 = getNode(i);
+					node2->computeInverseBindPose();
+					skin->boneNodeMap[index] = node2;
 				}
 			}
 		}
@@ -423,6 +425,15 @@ void ModelNode_KotOR::load(Model_KotOR::ParserContext &ctx) {
 	_orientation[0] = ctx.mdl->readIEEEFloatLE();
 	_orientation[1] = ctx.mdl->readIEEEFloatLE();
 	_orientation[2] = ctx.mdl->readIEEEFloatLE();
+
+	_positionBuffer[0] = _position[0];
+	_positionBuffer[1] = _position[1];
+	_positionBuffer[2] = _position[2];
+
+	_orientationBuffer[0] = _orientation[0];
+	_orientationBuffer[1] = _orientation[1];
+	_orientationBuffer[2] = _orientation[2];
+	_orientationBuffer[3] = _orientation[3];
 
 	uint32 childrenOffset, childrenCount;
 	Model::readArrayDef(*ctx.mdl, childrenOffset, childrenCount);

--- a/src/graphics/aurora/model_nwn.cpp
+++ b/src/graphics/aurora/model_nwn.cpp
@@ -998,6 +998,9 @@ void ModelNode_NWN_Binary::readNodeControllers(Model_NWN::ParserContext &ctx,
 					_position[0] = p.x;
 					_position[1] = p.y;
 					_position[2] = p.z;
+					_positionBuffer[0] = _position[0];
+					_positionBuffer[1] = _position[1];
+					_positionBuffer[2] = _position[2];
 					ctx.hasPosition = true;
 				}
 			}
@@ -1021,6 +1024,10 @@ void ModelNode_NWN_Binary::readNodeControllers(Model_NWN::ParserContext &ctx,
 					_orientation[1] = data[dataIndex + 1];
 					_orientation[2] = data[dataIndex + 2];
 					_orientation[3] = Common::rad2deg(acos(data[dataIndex + 3]) * 2.0);
+					_orientationBuffer[0] = _orientation[0];
+					_orientationBuffer[1] = _orientation[1];
+					_orientationBuffer[2] = _orientation[2];
+					_orientationBuffer[3] = _orientation[3];
 
 					ctx.hasOrientation = true;
 				}

--- a/src/graphics/aurora/modelnode.h
+++ b/src/graphics/aurora/modelnode.h
@@ -111,6 +111,9 @@ public:
 	/** Set textures to the node. */
 	void setTextures(const std::vector<Common::UString> &textures);
 
+	void computeInverseBindPose();
+	void computeAbsoluteTransform();
+
 	/** The way the environment map is applied to a model node. */
 	enum EnvironmentMapMode {
 		kModeEnvironmentBlendedUnder, ///< Environment map first, then blend the diffuse textures in.
@@ -220,6 +223,18 @@ protected:
 
 	uint16 _nodeNumber;
 
+	glm::mat4 _invBindPose;       ///< Inverse bind pose matrix used for animations.
+	glm::mat4 _absoluteTransform; ///< Absolute transformation matrix used for animations.
+
+	// .--- Node position and geometry buffers
+	float _positionBuffer[3];
+	bool _positionBuffered;
+	float _orientationBuffer[4];
+	bool _orientationBuffered;
+	std::vector<float> _vertexCoordsBuffer;
+	bool _vertexCoordsBuffered;
+	// '---
+
 
 	// Loading helpers
 	void loadTextures(const std::vector<Common::UString> &textures);
@@ -237,6 +252,10 @@ protected:
 
 	void lockFrameIfVisible();
 	void unlockFrameIfVisible();
+
+	void setBufferedPosition(float x, float y, float z);
+	void setBufferedOrientation(float x, float y, float z, float angle);
+	void flushBuffers();
 
 
 private:

--- a/src/graphics/aurora/rules.mk
+++ b/src/graphics/aurora/rules.mk
@@ -59,6 +59,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/model_sonic.h \
     src/graphics/aurora/model_dragonage.h \
     src/graphics/aurora/kotordialogframe.h \
+    src/graphics/aurora/animationthread.h \
     $(EMPTY)
 
 src_graphics_aurora_libaurora_la_SOURCES += \
@@ -97,4 +98,5 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/model_sonic.cpp \
     src/graphics/aurora/model_dragonage.cpp \
     src/graphics/aurora/kotordialogframe.cpp \
+    src/graphics/aurora/animationthread.cpp \
     $(EMPTY)

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -41,9 +41,15 @@
 #include "src/graphics/types.h"
 #include "src/graphics/windowman.h"
 
+#include "src/graphics/aurora/animationthread.h"
+
 #include "src/events/notifyable.h"
 
 namespace Graphics {
+
+namespace Aurora {
+	class Model;
+}
 
 class FPSCounter;
 class Cursor;
@@ -165,6 +171,16 @@ public:
 	/** Return the inverse modelview matrix (camera view). */
 	const glm::mat4 &getModelviewInverseMatrix() const;
 
+	/** Pause animation thread. */
+	void pauseAnimations();
+	/** Resume animation thread. */
+	void resumeAnimations();
+
+	/** Register a model with the animation thread. */
+	void registerAnimatedModel(Aurora::Model *model);
+	/** Unregister a model from the animation thread. */
+	void unregisterAnimatedModel(Aurora::Model *model);
+
 private:
 	enum ProjectType {
 		kProjectTypePerspective,
@@ -222,6 +238,9 @@ private:
 	std::list<ListID>      _abandonLists;    ///< Abandoned lists.
 
 	Common::Mutex _abandonMutex; ///< A mutex protecting abandoned structures.
+
+	Aurora::AnimationThread _animationThread;
+	bool _dedicatedAnimThread; ///< Use dedicated thread for animations?
 
 	void setupScene();
 


### PR DESCRIPTION
This PR adds a dedicated animation thread for all supported games. Currently NWN, KotOR and KotOR II are enabled to use it. Using a separate thread drastically improves performance when every creature in a module is animated. To disable it use --animthread=0 on the command line.