### PR TITLE
KOTOR: Replace static checkbox images

### DIFF
--- a/src/engines/kotor/gui/widgets/checkbox.cpp
+++ b/src/engines/kotor/gui/widgets/checkbox.cpp
@@ -58,6 +58,11 @@ void WidgetCheckBox::load(const Aurora::GFF3Struct &gff) {
 	Border border = createBorder(gff);
 	Graphics::Aurora::TextureHandle texture = TextureMan.get(border.fill);
 
+	_selected = gff.getStruct("SELECTED").getString("FILL");
+	_unselected = gff.getStruct("BORDER").getString("FILL");
+	_selectedHighlighted = gff.getStruct("HILIGHTSELECTED").getString("FILL");
+	_unselectedHighlighted = gff.getStruct("HILIGHT").getString("FILL");
+
 	float squareLength = _quad->getHeight();
 	float _quadPosCorrect = (squareLength - (texture.getTexture().getHeight() * 0.625f)) / 2;
 	float x, y, z;
@@ -94,7 +99,8 @@ void WidgetCheckBox::setState(bool state) {
 	_text->getColor(textR, textG, textB, textA);
 	_quad->getColor(quadR, quadG, quadB, quadA);
 
-	setFill(_state ? "i_checkbox02" : "i_checkbox01");
+	setFill(_state ? _selected : _unselected);
+	setHighlight(_state ? _selectedHighlighted : _unselectedHighlighted);
 
 	_text->setColor(textR, textG, textB, textA);
 	_quad->setColor(quadR, quadG, quadB, quadA);

--- a/src/engines/kotor/gui/widgets/checkbox.h
+++ b/src/engines/kotor/gui/widgets/checkbox.h
@@ -49,6 +49,8 @@ public:
 	virtual void leave();
 
 private:
+	Common::UString _selected, _unselected;
+	Common::UString _selectedHighlighted,  _unselectedHighlighted;
 	bool _state;
 
 	Sound::ChannelHandle _sound;

--- a/src/engines/kotor/gui/widgets/kotorwidget.cpp
+++ b/src/engines/kotor/gui/widgets/kotorwidget.cpp
@@ -328,6 +328,30 @@ void KotORWidget::setFill(const Common::UString &fill) {
 	_quad->setColor(1.0f, 1.0f, 1.0f, 1.0f);
 }
 
+void KotORWidget::setHighlight(const Common::UString &hilight) {
+	if (hilight.empty()) {
+		_highlight->hide();
+		_highlight.release();
+		return;
+	}
+
+	if (!_highlight) {
+		float x, y, z;
+		getPosition(x, y, z);
+
+		_highlight.reset(new Graphics::Aurora::GUIQuad("", 0.0f, 0.0f, _width, _height));
+		_highlight->setPosition(x, y, z);
+		_highlight->setTag(getTag());
+		_highlight->setClickable(true);
+
+		if (isVisible())
+			_highlight->show();
+	}
+
+	_highlight->setTexture(hilight);
+	_highlight->setColor(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
 void KotORWidget::setClickable(bool clickable) {
 	if (_quad)
 		_quad->setClickable(clickable);

--- a/src/engines/kotor/gui/widgets/kotorwidget.h
+++ b/src/engines/kotor/gui/widgets/kotorwidget.h
@@ -89,6 +89,7 @@ public:
 	float getTextHeight(const Common::UString &text) const;
 
 	void setFill(const Common::UString &fill);
+	void setHighlight(const Common::UString &hilight);
 	void setColor(float r, float g, float b, float a);
 	void setText(const Common::UString &text);
 	void setHorizontalTextAlign(float halign);


### PR DESCRIPTION
This PR replaces the static checkbox images with the ones defines in the gff file. This should fix #265.