### PR TITLE
AURORA: Fix spacing in `dumpres` console output

### DIFF
--- a/src/engines/aurora/console.cpp
+++ b/src/engines/aurora/console.cpp
@@ -1205,7 +1205,7 @@ void Console::cmdDumpRes(const CommandLine &cl) {
 	Common::UString file = Common::FilePath::getUserDataFile(cl.args);
 
 	if (dumpResource(cl.args, file))
-		printf("Dumped resource \"%s\"to \"%s\"", cl.args.c_str(), file.c_str());
+		printf("Dumped resource \"%s\" to \"%s\"", cl.args.c_str(), file.c_str());
 	else
 		printf("Failed dumping resource \"%s\"", cl.args.c_str());
 }


### PR DESCRIPTION
Quick little nitpicky thing I found