### PR TITLE
JADE: Don't attempt to loadmodule() the current module

### DIFF
--- a/src/engines/jade/module.cpp
+++ b/src/engines/jade/module.cpp
@@ -169,6 +169,11 @@ void Module::unloadPC() {
 }
 
 void Module::changeModule(const Common::UString &module) {
+	if (module == getName()) {
+		warning("Module \"%s\" is already currently loaded", module.c_str());
+		return;
+	}
+
 	_newModule = module;
 }
 


### PR DESCRIPTION
We shut down otherwise.

```
ERROR: Failed loading module "j01_town"
    Because: Failed to index mandatory archive "j01_town/a010.rim"
    Because: Archive "/Users/charlotte/Documents/jadehacking/data/app/data/j01_town/a010.rim" already opened
Shutting down
Cleaning up shaders...
```