### PR TITLE
KOTOR: Prevent flickering when starting

### DIFF
--- a/src/engines/kotor/game.cpp
+++ b/src/engines/kotor/game.cpp
@@ -30,6 +30,8 @@
 #include "src/common/filelist.h"
 #include "src/common/configman.h"
 
+#include "src/graphics/graphics.h"
+
 #include "src/events/events.h"
 
 #include "src/sound/sound.h"
@@ -146,7 +148,9 @@ void Game::mainMenu() {
 	_console->disableCommand("exitmodule", "not available in the main menu");
 
 	menu.show();
-	menu.run();
+	int ret = menu.run();
+	if (ret == 2)
+		GfxMan.unlockFrame();
 	menu.hide();
 
 	_console->enableCommand("loadmodule");

--- a/src/engines/kotor/gui/chargen/quickchar.cpp
+++ b/src/engines/kotor/gui/chargen/quickchar.cpp
@@ -73,6 +73,7 @@ void QuickCharPanel::callbackActive(Widget &widget) {
 	}
 	if (widget.getTag() == "BTN_STEPNAME3") {
 		_charGen->start();
+		GfxMan.lockFrame();
 		_returnCode = 2;
 		return;
 	}

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -380,14 +380,14 @@ void Module::enter() {
 	SatelliteCam.setPitch(83);
 	SatelliteCam.update(0);
 
-	_ingame->show();
-
 	enterArea();
 
 	GfxMan.resumeAnimations();
 
 	_running = true;
 	_exit    = false;
+
+	_ingame->show();
 }
 
 bool Module::getObjectLocation(const Common::UString &object, ObjectType location,
@@ -440,11 +440,15 @@ void Module::leave() {
 }
 
 void Module::enterArea() {
+	GfxMan.lockFrame();
+
 	_area->show();
 
 	runScript(kScriptModuleLoad , this, _pc.get());
 	runScript(kScriptModuleStart, this, _pc.get());
 	runScript(kScriptEnter      , this, _pc.get());
+
+	GfxMan.unlockFrame();
 
 	_area->runScript(kScriptEnter, _area.get(), _pc.get());
 }


### PR DESCRIPTION
This PR should prevent as much as possible the flickering when entering an area to smoothly go into the video.