### PR TITLE
GRAPHICS: Remove option to disable animation thread

### DIFF
--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -146,10 +146,7 @@ void GraphicsManager::init() {
 	MaterialMan.init();
 	MeshMan.init();
 
-	_dedicatedAnimThread = ConfigMan.getBool("animthread", true);
-
-	if (_dedicatedAnimThread)
-		_animationThread.createThread();
+	_animationThread.createThread();
 
 	_ready = true;
 }
@@ -162,10 +159,8 @@ void GraphicsManager::deinit() {
 
 	QueueMan.clearAllQueues();
 
-	if (_dedicatedAnimThread) {
-		_animationThread.pause();
-		_animationThread.destroyThread();
-	}
+	_animationThread.pause();
+	_animationThread.destroyThread();
 
 	MeshMan.deinit();
 	MaterialMan.deinit();
@@ -963,26 +958,7 @@ bool GraphicsManager::renderWorld() {
 
 	buildNewTextures();
 
-	if (_dedicatedAnimThread)
-		_animationThread.flush();
-	else {
-		// Get the current time
-		uint32 now = EventMan.getTimestamp();
-		if (_lastSampled == 0)
-			_lastSampled = now;
-
-		// Calc elapsed time
-		float elapsedTime = (now - _lastSampled) / 1000.0f;
-		_lastSampled = now;
-
-		// If game paused, skip the advanceTime loop below
-
-		// Advance time for animation queues
-		for (std::list<Queueable *>::const_reverse_iterator o = objects.rbegin();
-				o != objects.rend(); ++o) {
-			static_cast<Renderable *>(*o)->advanceTime(elapsedTime);
-		}
-	}
+	_animationThread.flush();
 
 	// Draw opaque objects
 	for (std::list<Queueable *>::const_reverse_iterator o = objects.rbegin();
@@ -1150,23 +1126,19 @@ const glm::mat4 &GraphicsManager::getModelviewInverseMatrix() const {
 }
 
 void GraphicsManager::pauseAnimations() {
-	if (_dedicatedAnimThread)
-		_animationThread.pause();
+	_animationThread.pause();
 }
 
 void GraphicsManager::resumeAnimations() {
-	if (_dedicatedAnimThread)
-		_animationThread.resume();
+	_animationThread.resume();
 }
 
 void GraphicsManager::registerAnimatedModel(Aurora::Model *model) {
-	if (_dedicatedAnimThread)
-		_animationThread.registerModel(model);
+	_animationThread.registerModel(model);
 }
 
 void GraphicsManager::unregisterAnimatedModel(Aurora::Model *model) {
-	if (_dedicatedAnimThread)
-		_animationThread.unregisterModel(model);
+	_animationThread.unregisterModel(model);
 }
 
 bool GraphicsManager::isGL3() const {

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -240,7 +240,6 @@ private:
 	Common::Mutex _abandonMutex; ///< A mutex protecting abandoned structures.
 
 	Aurora::AnimationThread _animationThread;
-	bool _dedicatedAnimThread; ///< Use dedicated thread for animations?
 
 	void setupScene();
 


### PR DESCRIPTION
Animation thread seems to be stable enough. KotOR isn't really playable w/o it and I don't see it having a negative effect on other games. Therefore there isn't really any reason to have that option anymore.