### PR TITLE
JADE: Remove dependency on KotOR GUI

### DIFF
--- a/src/engines/jade/gui/gui.cpp
+++ b/src/engines/jade/gui/gui.cpp
@@ -1,0 +1,309 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire GUI.
+ */
+
+#include "src/common/error.h"
+#include "src/common/util.h"
+
+#include "src/aurora/gff3file.h"
+#include "src/aurora/resman.h"
+
+#include "src/graphics/aurora/cursorman.h"
+
+#include "src/engines/jade/gui/widgets/panel.h"
+#include "src/engines/jade/gui/widgets/label.h"
+#include "src/engines/jade/gui/widgets/protoitem.h"
+#include "src/engines/jade/gui/widgets/button.h"
+#include "src/engines/jade/gui/widgets/checkbox.h"
+#include "src/engines/jade/gui/widgets/slider.h"
+#include "src/engines/jade/gui/widgets/scrollbar.h"
+#include "src/engines/jade/gui/widgets/progressbar.h"
+#include "src/engines/jade/gui/widgets/listbox.h"
+
+#include "src/engines/jade/gui/gui.h"
+
+namespace Engines {
+
+namespace Jade {
+
+GUI::WidgetContext::WidgetContext(const Aurora::GFF3Struct &s, Widget *p) {
+	strct = &s;
+
+	widget = 0;
+	parent = p;
+
+	type = (WidgetType) strct->getUint("CONTROLTYPE", kWidgetTypeInvalid);
+	if (type == kWidgetTypeInvalid)
+		throw Common::Exception("Widget without a type");
+
+	tag = strct->getString("TAG");
+}
+
+
+GUI::GUI(::Engines::Console *console) : ::Engines::GUI(console), _widgetZ(0), _guiHeight(0.0f), _guiWidth(0.0f) {
+}
+
+GUI::~GUI() {
+}
+
+void GUI::show() {
+	if (_background)
+		_background->show();
+	::Engines::GUI::show();
+}
+
+void GUI::hide() {
+	if (_background)
+		_background->hide();
+	::Engines::GUI::hide();
+}
+
+void GUI::convertToXoreos(float &x, float &y, const float widgetHeight) const {
+	x = x - (_guiWidth / 2.0f);
+	y = (_guiHeight / 2.0f) - y - widgetHeight;
+}
+
+void GUI::convertToGUI(float &x, float &y, const float widgetHeight) const {
+	x = x + (_guiWidth / 2.0f);
+	y = widgetHeight + (-1.0f * (y - (_guiHeight / 2.0f)));
+}
+
+Common::UString GUI::getName() const {
+	return _name;
+}
+
+void GUI::mouseDown() {
+	CursorMan.setState("down");
+}
+
+void GUI::mouseUp() {
+	CursorMan.setState("up");
+}
+
+void GUI::load(const Common::UString &resref) {
+	// This is only relevant to Jade Empire.
+	// LTI prefixed GUI definitions for the Windows version of Jade Empire
+	// with lti_ to support mouse and keyboard control.
+	_name = ResMan.hasResource("lti_" + resref, Aurora::kFileTypeGUI) ? _name = "lti_" + resref : resref;
+
+	try {
+		_gff.reset(new Aurora::GFF3File(_name, Aurora::kFileTypeGUI, MKTAG('G', 'U', 'I', ' ')));
+
+		loadWidget(_gff->getTopLevel(), 0);
+
+	} catch (Common::Exception &e) {
+		e.add("Can't load GUI \"%s\"", _name.c_str());
+		throw;
+	}
+}
+
+void GUI::loadWidget(const Aurora::GFF3Struct &strct, Widget *parent) {
+
+	WidgetContext ctx(strct, parent);
+
+	createWidget(ctx);
+
+	if (_guiWidth  <= 0.0f)
+		_guiWidth  = ctx.widget->getWidth();
+	if (_guiHeight <= 0.0f)
+		_guiHeight = ctx.widget->getHeight();
+
+	float wX, wY, wZ;
+	ctx.widget->getPosition(wX, wY, wZ);
+
+	convertToXoreos(wX, wY, ctx.widget->getHeight());
+	wZ = _widgetZ + wZ;
+
+	ctx.widget->setPosition(wX, wY, wZ);
+
+	_widgetZ -= 1.0f;
+
+	addWidget(ctx.widget);
+
+	// Go down to the children
+	if (ctx.strct->hasField("CONTROLS")) {
+		const Aurora::GFF3List &children = ctx.strct->getList("CONTROLS");
+
+		for (Aurora::GFF3List::const_iterator c = children.begin(); c != children.end(); ++c)
+			loadWidget(**c, ctx.widget);
+	}
+}
+
+void GUI::createWidget(WidgetContext &ctx) {
+	if      (ctx.type == kWidgetTypePanel)
+		ctx.widget = new WidgetPanel(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeLabel)
+		ctx.widget = new WidgetLabel(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeProtoItem)
+		ctx.widget = new WidgetProtoItem(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeButton)
+		ctx.widget = new WidgetButton(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeCheckBox)
+		ctx.widget = new WidgetCheckBox(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeSlider)
+		ctx.widget = new WidgetSlider(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeScrollbar)
+		ctx.widget = new WidgetScrollbar(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeProgressbar)
+		ctx.widget = new WidgetProgressbar(*this, ctx.tag);
+	else if (ctx.type == kWidgetTypeListBox)
+		ctx.widget = new WidgetListBox(*this, ctx.tag);
+	else
+		throw Common::Exception("No such widget type %d", ctx.type);
+
+	ctx.widget->load(*ctx.strct);
+
+	initWidget(*ctx.widget);
+}
+
+void GUI::initWidget(Widget &UNUSED(widget)) {
+}
+
+WidgetPanel *GUI::getPanel(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetPanel *panel = dynamic_cast<WidgetPanel *>(widget);
+	if (!panel && vital)
+		throw Common::Exception("Vital panel widget \"%s\" doesn't exist", tag.c_str());
+
+	return panel;
+}
+
+WidgetLabel *GUI::getLabel(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetLabel *label = dynamic_cast<WidgetLabel *>(widget);
+	if (!label && vital)
+		throw Common::Exception("Vital label widget \"%s\" doesn't exist", tag.c_str());
+
+	return label;
+}
+
+WidgetProtoItem *GUI::getProtoItem(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetProtoItem *protoItem = dynamic_cast<WidgetProtoItem *>(widget);
+	if (!protoItem && vital)
+		throw Common::Exception("Vital protoItem widget \"%s\" doesn't exist", tag.c_str());
+
+	return protoItem;
+}
+
+WidgetButton *GUI::getButton(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetButton *button = dynamic_cast<WidgetButton *>(widget);
+	if (!button && vital)
+		throw Common::Exception("Vital button widget \"%s\" doesn't exist", tag.c_str());
+
+	return button;
+}
+
+WidgetCheckBox *GUI::getCheckBox(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetCheckBox *checkBox = dynamic_cast<WidgetCheckBox *>(widget);
+	if (!checkBox && vital)
+		throw Common::Exception("Vital checkBox widget \"%s\" doesn't exist", tag.c_str());
+
+	return checkBox;
+}
+
+WidgetSlider *GUI::getSlider(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetSlider *slider = dynamic_cast<WidgetSlider *>(widget);
+	if (!slider && vital)
+		throw Common::Exception("Vital slider widget \"%s\" doesn't exist", tag.c_str());
+
+	return slider;
+}
+
+WidgetScrollbar *GUI::getScrollbar(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetScrollbar *scrollbar = dynamic_cast<WidgetScrollbar *>(widget);
+	if (!scrollbar && vital)
+		throw Common::Exception("Vital scrollbar widget \"%s\" doesn't exist", tag.c_str());
+
+	return scrollbar;
+}
+
+WidgetProgressbar *GUI::getProgressbar(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetProgressbar *progressbar = dynamic_cast<WidgetProgressbar *>(widget);
+	if (!progressbar && vital)
+		throw Common::Exception("Vital progressbar widget \"%s\" doesn't exist", tag.c_str());
+
+	return progressbar;
+}
+
+WidgetListBox *GUI::getListBox(const Common::UString &tag, bool vital) {
+	Widget *widget = getWidget(tag, vital);
+	if (!widget)
+		return 0;
+
+	WidgetListBox *listBox = dynamic_cast<WidgetListBox *>(widget);
+	if (!listBox && vital)
+		throw Common::Exception("Vital listBox widget \"%s\" doesn't exist", tag.c_str());
+
+	return listBox;
+}
+
+void GUI::addBackground(const Common::UString &background, bool front) {
+	if (!_background)
+		_background.reset(new GUIBackground(background, front));
+	else
+		_background->setType(background);
+}
+
+void GUI::setCheckBoxState(const Common::UString &tag, bool state) {
+	WidgetCheckBox &checkbox = *getCheckBox(tag, true);
+	checkbox.setState(state);
+}
+
+bool GUI::getCheckBoxState(const Common::UString &tag) {
+	WidgetCheckBox &checkbox = *getCheckBox(tag, true);
+	return checkbox.getState();
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/gui.h
+++ b/src/engines/jade/gui/gui.h
@@ -1,0 +1,150 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire GUI.
+ */
+
+#ifndef ENGINES_JADE_GUI_GUI_H
+#define ENGINES_JADE_GUI_GUI_H
+
+#include "src/common/scopedptr.h"
+
+#include "src/aurora/types.h"
+#include "src/aurora/gff3file.h"
+
+#include "src/graphics/aurora/types.h"
+#include "src/graphics/aurora/highlightable.h"
+
+#include "src/engines/aurora/gui.h"
+
+#include "src/engines/jade/gui/guibackground.h"
+
+namespace Engines {
+
+namespace Jade {
+
+class JadeWidget;
+
+class WidgetPanel;
+class WidgetLabel;
+class WidgetProtoItem;
+class WidgetButton;
+class WidgetCheckBox;
+class WidgetSlider;
+class WidgetScrollbar;
+class WidgetProgressbar;
+class WidgetListBox;
+
+/** A Jade Empire GUI. */
+class GUI : public Engines::GUI {
+public:
+	GUI(::Engines::Console *console = 0);
+	~GUI();
+
+	virtual void show(); ///< Show the GUI.
+	virtual void hide(); ///< Hide the GUI.
+
+	/**
+	 * Converts Jade Empire' GUI coordinates with a coordinate origin
+	 * in the upper left corner to the Xoreos coordinate system
+	 * with the coordinate origin in the center.
+	 */
+	void convertToXoreos(float &x, float &y, const float widgetHeight) const;
+	/**
+	 * Converts Xoreos' coordinates with a coordinate origin
+	 * in the center to Jade Empire's GUI coordinates
+	 * with the coordinate origin in the the upper left corner.
+	 */
+	void convertToGUI(float &x, float &y, const float widgetHeight) const;
+
+	Common::UString getName() const;
+
+protected:
+	enum WidgetType {
+		kWidgetTypeInvalid     = - 1,
+		kWidgetTypePanel       =   2,
+		kWidgetTypeLabel       =   4,
+		kWidgetTypeProtoItem   =   5,
+		kWidgetTypeButton      =   6,
+		kWidgetTypeCheckBox    =   7,
+		kWidgetTypeSlider      =   8,
+		kWidgetTypeScrollbar   =   9,
+		kWidgetTypeProgressbar =  10,
+		kWidgetTypeListBox     =  11
+	};
+
+	virtual void mouseUp();
+	virtual void mouseDown();
+
+	void load(const Common::UString &resref);
+
+	virtual void initWidget(Widget &widget);
+
+	WidgetPanel       *getPanel      (const Common::UString &tag, bool vital = false);
+	WidgetLabel       *getLabel      (const Common::UString &tag, bool vital = false);
+	WidgetProtoItem   *getProtoItem  (const Common::UString &tag, bool vital = false);
+	WidgetButton      *getButton     (const Common::UString &tag, bool vital = false);
+	WidgetCheckBox    *getCheckBox   (const Common::UString &tag, bool vital = false);
+	WidgetSlider      *getSlider     (const Common::UString &tag, bool vital = false);
+	WidgetScrollbar   *getScrollbar  (const Common::UString &tag, bool vital = false);
+	WidgetProgressbar *getProgressbar(const Common::UString &tag, bool vital = false);
+	WidgetListBox     *getListBox    (const Common::UString &tag, bool vital = false);
+
+	void addBackground(const Common::UString &background, bool front = false);
+
+	void setCheckBoxState(const Common::UString &tag, bool state);
+	bool getCheckBoxState(const Common::UString &tag);
+
+private:
+	struct WidgetContext {
+		const Aurora::GFF3Struct *strct;
+
+		WidgetType type;
+
+		Common::UString tag;
+		JadeWidget *widget;
+
+		Widget *parent;
+
+		WidgetContext(const Aurora::GFF3Struct &s, Widget *p);
+	};
+
+	float _widgetZ;
+
+	float _guiHeight;
+	float _guiWidth;
+
+	Common::ScopedPtr<GUIBackground> _background;
+
+	Common::ScopedPtr<Aurora::GFF3File> _gff;
+
+	Common::UString _name;
+
+	void loadWidget(const Aurora::GFF3Struct &strct, Widget *parent);
+
+	void createWidget(WidgetContext &ctx);
+};
+
+} // End of namespace Jade
+
+} // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_GUI_H

--- a/src/engines/jade/gui/guibackground.cpp
+++ b/src/engines/jade/gui/guibackground.cpp
@@ -1,0 +1,149 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu background.
+ */
+
+#include <cfloat>
+
+#include "src/common/debug.h"
+#include "src/common/util.h"
+#include "src/common/ustring.h"
+
+#include "src/aurora/resman.h"
+#include "src/aurora/types.h"
+
+#include "src/graphics/graphics.h"
+#include "src/graphics/resolution.h"
+#include "src/graphics/aurora/textureman.h"
+
+#include "src/engines/jade/gui/guibackground.h"
+
+namespace Engines {
+
+namespace Jade {
+
+GUIBackground::GUIBackground(const Common::UString &type, bool front) :
+	Graphics::GUIElement(front ? Graphics::GUIElement::kGUIElementFront : Graphics::GUIElement::kGUIElementBack), _type(type) {
+
+	_distance = FLT_MAX;
+
+	_screenWidth = WindowMan.getWindowWidth();
+	_screenHeight = WindowMan.getWindowHeight();
+
+	update();
+}
+
+GUIBackground::~GUIBackground() {
+	hide();
+}
+
+void GUIBackground::setType(const Common::UString &type) {
+	_type = type;
+}
+
+void GUIBackground::calculateDistance() {
+}
+
+void GUIBackground::render(Graphics::RenderPass pass) {
+	if (pass == Graphics::kRenderPassTransparent || !_render)
+		return;
+
+	TextureMan.set(_texture);
+
+	glDisable(GL_DEPTH_TEST);
+	glDepthMask(GL_FALSE);
+
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glLoadIdentity();
+	glOrtho(0.0, _screenWidth, 0.0, _screenHeight, -1.0, 1.0);
+
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+
+	glPushMatrix();
+
+	glBegin(GL_QUADS);
+		glTexCoord2f(0.0, 0.0);
+		glVertex2i(_vertexX1, _vertexY1);
+		glTexCoord2f(1.0, 0.0);
+		glVertex2i(_vertexX2, _vertexY1);
+		glTexCoord2f(1.0, 1.0);
+		glVertex2i(_vertexX2, _vertexY2);
+		glTexCoord2f(0.0, 1.0);
+		glVertex2i(_vertexX1, _vertexY2);
+	glEnd();
+
+	glPopMatrix();
+
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+
+	glMatrixMode(GL_MODELVIEW);
+
+	glDepthMask(GL_TRUE);
+	glEnable(GL_DEPTH_TEST);
+}
+
+void GUIBackground::update() {
+	if (tryBackground(_screenWidth, _screenHeight)) {
+		return;
+	}
+
+	for (size_t i = 0; i < ARRAYSIZE(Graphics::kResolutions); i++) {
+		if (Graphics::kResolutions[i].width <= _screenWidth && Graphics::kResolutions[i].height <= _screenHeight) {
+			if (tryBackground(Graphics::kResolutions[i].width, Graphics::kResolutions[i].height)) {
+				return;
+			}
+		}
+	}
+}
+
+bool GUIBackground::tryBackground(int width, int height) {
+	Common::UString name = Common::UString::format("%ux%u%s", width, height, _type.c_str());
+	if (ResMan.hasResource(name, Aurora::kResourceImage)) {
+		_texture = TextureMan.get(name);
+
+		_vertexX1 = (_screenWidth - width) / 2;
+		_vertexX2 = _vertexX1 + width;
+		_vertexY1 = (_screenHeight - height) / 2;
+		_vertexY2 = _vertexY1 + height;
+
+		_render = true;
+		debugC(Common::kDebugEngineGraphics, 1, "found background %s", _texture.getName().c_str());
+	} else {
+		_render = false;
+		debugC(Common::kDebugEngineGraphics, 1, "no background %s", name.c_str());
+	}
+	return _render;
+}
+
+void GUIBackground::notifyResized(int UNUSED(oldWidth), int UNUSED(oldHeight), int newWidth, int newHeight) {
+	_screenHeight = newHeight;
+	_screenWidth = newWidth;
+
+	update();
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/guibackground.h
+++ b/src/engines/jade/gui/guibackground.h
@@ -1,0 +1,86 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The menu background.
+ */
+
+#ifndef ENGINES_JADE_GUI_GUIBACKGROUND_H
+#define ENGINES_JADE_GUI_GUIBACKGROUND_H
+
+#include "src/graphics/guielement.h"
+
+#include "src/graphics/aurora/texturehandle.h"
+
+#include "src/events/notifyable.h"
+
+namespace Common {
+	class UString;
+}
+
+namespace Engines {
+
+namespace Jade {
+
+static const Common::UString &kBackgroundTypeMenu   = "back";
+static const Common::UString &kBackgroundTypeComp0  = "comp0";
+static const Common::UString &kBackgroundTypeComp1  = "comp1";
+static const Common::UString &kBackgroundTypeLoad   = "load";
+static const Common::UString &kBackgroundTypeMap    = "map";
+static const Common::UString &kBackgroundTypePazaak = "pazaak";
+static const Common::UString &kBackgroundTypeStore  = "store";
+
+class GUIBackground : public Graphics::GUIElement, public Events::Notifyable {
+public:
+	GUIBackground(const Common::UString &type = kBackgroundTypeMenu, bool front = false);
+	~GUIBackground();
+
+	void setType(const Common::UString &type);
+
+	// Renderable
+	void calculateDistance();
+	void render(Graphics::RenderPass pass);
+
+private:
+	Graphics::Aurora::TextureHandle _texture;
+
+	Common::UString _type;
+
+	int _screenWidth;
+	int _screenHeight;
+
+	int _vertexX1;
+	int _vertexX2;
+	int _vertexY1;
+	int _vertexY2;
+
+	bool _render;
+
+	void update();
+	bool tryBackground(int x, int y);
+
+	void notifyResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
+};
+
+} // End of namespace Jade
+
+} // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_GUIBACKGROUND_H

--- a/src/engines/jade/gui/main/main.cpp
+++ b/src/engines/jade/gui/main/main.cpp
@@ -40,15 +40,15 @@
 #include "src/engines/jade/gui/main/main.h"
 #include "src/engines/jade/gui/main/options.h"
 
-#include "src/engines/kotor/gui/widgets/label.h"
-#include "src/engines/kotor/gui/widgets/listbox.h"
-#include "src/engines/kotor/gui/widgets/button.h"
+#include "src/engines/jade/gui/widgets/label.h"
+#include "src/engines/jade/gui/widgets/listbox.h"
+#include "src/engines/jade/gui/widgets/button.h"
 
 namespace Engines {
 
 namespace Jade {
 
-MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::KotOR::GUI(console),
+MainMenu::MainMenu(Module &module, ::Engines::Console *console) : ::Engines::Jade::GUI(console),
 	_module(&module), _background(0) {
 
 	load("maingame");
@@ -95,13 +95,13 @@ MainMenu::~MainMenu() {
 void MainMenu::show() {
 	if (_background)
 		_background->show();
-	::Engines::KotOR::GUI::show();
+	::Engines::Jade::GUI::show();
 }
 
 void MainMenu::hide() {
 	if (_background)
 		_background->hide();
-	::Engines::KotOR::GUI::hide();
+	::Engines::Jade::GUI::hide();
 }
 
 void MainMenu::callbackActive(Widget &widget) {

--- a/src/engines/jade/gui/main/main.h
+++ b/src/engines/jade/gui/main/main.h
@@ -25,7 +25,7 @@
 #ifndef ENGINES_JADE_GUI_MAIN_MAIN_H
 #define ENGINES_JADE_GUI_MAIN_MAIN_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
@@ -34,7 +34,7 @@ namespace Jade {
 class AreaLayout;
 class Module;
 
-class MainMenu : public ::Engines::KotOR::GUI {
+class MainMenu : public ::Engines::Jade::GUI {
 public:
 	MainMenu(Module &module, ::Engines::Console *console = 0);
 	~MainMenu();

--- a/src/engines/jade/gui/main/options.cpp
+++ b/src/engines/jade/gui/main/options.cpp
@@ -34,8 +34,8 @@
 #include "src/engines/jade/gui/options/feed.h"
 #include "src/engines/jade/gui/options/control.h"
 
-#include "src/engines/kotor/gui/widgets/listbox.h"
-#include "src/engines/kotor/gui/widgets/label.h"
+#include "src/engines/jade/gui/widgets/listbox.h"
+#include "src/engines/jade/gui/widgets/label.h"
 
 namespace Engines {
 
@@ -49,7 +49,7 @@ OptionsMenu::OptionsMenu(Console *console) : GUI(console) {
 	getWidget("Lopt")->getPosition(x, y, z);
 	getWidget("Lopt")->setPosition(x, y, z + 10);
 
-	Engines::KotOR::WidgetListBox *optionsListBox = getListBox("OptionsListBox");
+	Engines::Jade::WidgetListBox *optionsListBox = getListBox("OptionsListBox");
 
 	addWidget(optionsListBox->createItem("AUDIO_SETTINGS"), true);
 	addWidget(optionsListBox->createItem("GRAPHIC_SETTINGS"), true);

--- a/src/engines/jade/gui/main/options.h
+++ b/src/engines/jade/gui/main/options.h
@@ -27,9 +27,9 @@
 
 #include "src/common/ustring.h"
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
-#include "src/engines/kotor/gui/widgets/button.h"
+#include "src/engines/jade/gui/widgets/button.h"
 
 namespace Engines {
 
@@ -37,7 +37,7 @@ namespace Jade {
 
 class Module;
 
-class OptionsMenu : public Engines::KotOR::GUI {
+class OptionsMenu : public Engines::Jade::GUI {
 public:
 	OptionsMenu(::Engines::Console *console = 0);
 
@@ -54,17 +54,17 @@ private:
 	Common::ScopedPtr<GUI> _gameInfoOptions;
 	Common::ScopedPtr<GUI> _controlOptions;
 
-	Engines::KotOR::WidgetButton *_audioOptionsButton;
-	Engines::KotOR::WidgetButton *_videoOptionsButton;
-	Engines::KotOR::WidgetButton *_difficultyOptionsButton;
-	Engines::KotOR::WidgetButton *_gameInfoOptionsButton;
-	Engines::KotOR::WidgetButton *_controlOptionsButton;
-	Engines::KotOR::WidgetButton *_creditsButton;
+	Engines::Jade::WidgetButton *_audioOptionsButton;
+	Engines::Jade::WidgetButton *_videoOptionsButton;
+	Engines::Jade::WidgetButton *_difficultyOptionsButton;
+	Engines::Jade::WidgetButton *_gameInfoOptionsButton;
+	Engines::Jade::WidgetButton *_controlOptionsButton;
+	Engines::Jade::WidgetButton *_creditsButton;
 
-	Engines::KotOR::WidgetButton *_backButton;
-	Engines::KotOR::WidgetButton *_currentButton;
+	Engines::Jade::WidgetButton *_backButton;
+	Engines::Jade::WidgetButton *_currentButton;
 
-	Engines::KotOR::WidgetLabel *_optionsDescription;
+	Engines::Jade::WidgetLabel *_optionsDescription;
 
 	Common::UString _audioOptionsDescription;
 	Common::UString _videoOptionsDescription;

--- a/src/engines/jade/gui/options/audio.cpp
+++ b/src/engines/jade/gui/options/audio.cpp
@@ -24,7 +24,7 @@
 
 #include "src/engines/jade/gui/options/audio.h"
 
-#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/jade/gui/widgets/jadewidget.h"
 
 namespace Engines {
 

--- a/src/engines/jade/gui/options/audio.h
+++ b/src/engines/jade/gui/options/audio.h
@@ -25,13 +25,13 @@
 #ifndef ENGINES_JADE_GUI_OPTIONS_AUDIO_H
 #define ENGINES_JADE_GUI_OPTIONS_AUDIO_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
 namespace Jade {
 
-class AudioOptionsMenu : public Engines::KotOR::GUI {
+class AudioOptionsMenu : public Engines::Jade::GUI {
 public:
 	AudioOptionsMenu(::Engines::Console *console = 0);
 

--- a/src/engines/jade/gui/options/control.cpp
+++ b/src/engines/jade/gui/options/control.cpp
@@ -24,7 +24,7 @@
 
 #include "src/engines/jade/gui/options/control.h"
 
-#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/jade/gui/widgets/jadewidget.h"
 
 namespace Engines {
 

--- a/src/engines/jade/gui/options/control.h
+++ b/src/engines/jade/gui/options/control.h
@@ -25,13 +25,13 @@
 #ifndef ENGINES_JADE_GUI_OPTIONS_CONTROL_H
 #define ENGINES_JADE_GUI_OPTIONS_CONTROL_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
 namespace Jade {
 
-class ControlOptionsMenu : public Engines::KotOR::GUI {
+class ControlOptionsMenu : public Engines::Jade::GUI {
 public:
 	ControlOptionsMenu(::Engines::Console *console = 0);
 

--- a/src/engines/jade/gui/options/diff.cpp
+++ b/src/engines/jade/gui/options/diff.cpp
@@ -24,7 +24,7 @@
 
 #include "src/engines/jade/gui/options/diff.h"
 
-#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/jade/gui/widgets/jadewidget.h"
 
 namespace Engines {
 

--- a/src/engines/jade/gui/options/diff.h
+++ b/src/engines/jade/gui/options/diff.h
@@ -25,13 +25,13 @@
 #ifndef ENGINES_JADE_GUI_OPTIONS_DIFF_H
 #define ENGINES_JADE_GUI_OPTIONS_DIFF_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
 namespace Jade {
 
-class DifficultyOptionsMenu : public Engines::KotOR::GUI {
+class DifficultyOptionsMenu : public Engines::Jade::GUI {
 public:
 	DifficultyOptionsMenu(::Engines::Console *console = 0);
 

--- a/src/engines/jade/gui/options/feed.h
+++ b/src/engines/jade/gui/options/feed.h
@@ -25,13 +25,13 @@
 #ifndef ENGINES_JADE_GUI_OPTIONS_FEED_H
 #define ENGINES_JADE_GUI_OPTIONS_FEED_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
 namespace Jade {
 
-class GameInfoOptionsMenu : public Engines::KotOR::GUI {
+class GameInfoOptionsMenu : public Engines::Jade::GUI {
 public:
 	GameInfoOptionsMenu(::Engines::Console *console = 0);
 

--- a/src/engines/jade/gui/options/video.cpp
+++ b/src/engines/jade/gui/options/video.cpp
@@ -24,7 +24,7 @@
 
 #include "src/engines/jade/gui/options/video.h"
 
-#include "src/engines/kotor/gui/widgets/kotorwidget.h"
+#include "src/engines/jade/gui/widgets/jadewidget.h"
 
 namespace Engines {
 

--- a/src/engines/jade/gui/options/video.h
+++ b/src/engines/jade/gui/options/video.h
@@ -25,13 +25,13 @@
 #ifndef ENGINES_JADE_GUI_OPTIONS_VIDEO_H
 #define ENGINES_JADE_GUI_OPTIONS_VIDEO_H
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/jade/gui/gui.h"
 
 namespace Engines {
 
 namespace Jade {
 
-class VideoOptionsMenu : public Engines::KotOR::GUI {
+class VideoOptionsMenu : public Engines::Jade::GUI {
 public:
 	VideoOptionsMenu(::Engines::Console *console = 0);
 

--- a/src/engines/jade/gui/rules.mk
+++ b/src/engines/jade/gui/rules.mk
@@ -20,10 +20,15 @@
 # GUI system in Jade Empire.
 
 src_engines_jade_libjade_la_SOURCES += \
+    src/engines/jade/gui/gui.h \
+    src/engines/jade/gui/guibackground.h \
     $(EMPTY)
 
 src_engines_jade_libjade_la_SOURCES += \
+    src/engines/jade/gui/gui.cpp \
+    src/engines/jade/gui/guibackground.cpp \
     $(EMPTY)
 
 include src/engines/jade/gui/main/rules.mk
 include src/engines/jade/gui/options/rules.mk
+include src/engines/jade/gui/widgets/rules.mk

--- a/src/engines/jade/gui/widgets/button.cpp
+++ b/src/engines/jade/gui/widgets/button.cpp
@@ -1,0 +1,134 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire button widget.
+ */
+
+#include "src/common/system.h"
+
+#include "src/aurora/gff3file.h"
+
+#include "src/sound/sound.h"
+
+#include "src/graphics/aurora/guiquad.h"
+#include "src/graphics/aurora/text.h"
+#include "src/graphics/aurora/highlightabletext.h"
+
+#include "src/engines/aurora/util.h"
+#include "src/engines/jade/gui/widgets/button.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetButton::WidgetButton(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag), _permanentHighlight(false), _disableHighlight(false),
+	_disableHoverSound(false),  _hovered(false) {
+}
+
+WidgetButton::~WidgetButton() {
+}
+
+void WidgetButton::setPermanentHighlight(bool permanentHighlight) {
+	_permanentHighlight = permanentHighlight;
+
+	if (_permanentHighlight) {
+		setHighlight(true);
+	} else {
+		setHighlight(false);
+	}
+}
+
+void WidgetButton::setStaticHighlight() {
+	getQuadHighlightableComponent()->setHighlightLowerBound(1, 1, 0, 1);
+}
+
+void WidgetButton::setDisableHighlight(bool disableHighlight) {
+	_disableHighlight = disableHighlight;
+
+	if (_disableHighlight) {
+		setHighlight(false);
+	} else {
+		if (_hovered)
+			setHighlight(true);
+	}
+}
+
+void WidgetButton::setDisableHoverSound(bool disableHoverSound) {
+	_disableHoverSound = disableHoverSound;
+}
+
+void WidgetButton::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+	if (getTextHighlightableComponent() != 0) {
+		  setDefaultHighlighting(getTextHighlightableComponent());
+	}
+	if (getQuadHighlightableComponent() != 0) {
+		  setDefaultHighlighting(getQuadHighlightableComponent());
+	}
+}
+
+bool WidgetButton::isHovered() {
+	return _hovered;
+}
+
+void WidgetButton::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)) {
+	if (isDisabled())
+		return;
+
+	playSound("gui_actuse", Sound::kSoundTypeSFX);
+	setActive(true);
+}
+
+void WidgetButton::enter() {
+	if (!_disableHoverSound)
+		_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
+
+	if (!_permanentHighlight && !_disableHighlight) {
+		setHighlight(true);
+	}
+
+	// The button is hovered at the moment
+	_hovered = true;
+}
+
+void WidgetButton::leave() {
+	if (!_disableHoverSound)
+		SoundMan.stopChannel(_sound);
+
+	if (!_permanentHighlight && !_disableHighlight) {
+		setHighlight(false);
+	}
+
+	// The buttone is not hovered anymore
+	_hovered = false;
+}
+
+void WidgetButton::setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable) {
+	highlightable->setHighlightable(true);
+	highlightable->setHighlightDelta(0, 0, 0, .05);
+	highlightable->setHighlightLowerBound(1, 1, 0, .2);
+	highlightable->setHighlightUpperBound(1, 1, 0, 1);
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/button.h
+++ b/src/engines/jade/gui/widgets/button.h
@@ -19,10 +19,13 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire button widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_BUTTON_H
+#define ENGINES_JADE_GUI_WIDGETS_BUTTON_H
+
+#include "src/sound/types.h"
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +33,40 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetButton : public JadeWidget {
+public:
+	WidgetButton(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetButton();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void setPermanentHighlight(bool);
+	void setStaticHighlight();
+	void setDisableHighlight(bool);
+	void setDisableHoverSound(bool);
+
+	virtual void load(const Aurora::GFF3Struct &gff);
+
+	void mouseUp(uint8 state, float x, float y);
+
+	bool isHovered();
+
+	virtual void enter();
+
+	virtual void leave();
+
+private:
+	bool _permanentHighlight;
+	bool _disableHighlight;
+	bool _disableHoverSound;
+
+	Sound::ChannelHandle _sound;
+
+	bool _hovered;
+
+	void setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_BUTTON_H

--- a/src/engines/jade/gui/widgets/checkbox.cpp
+++ b/src/engines/jade/gui/widgets/checkbox.cpp
@@ -1,0 +1,165 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire checkbox widget.
+ */
+
+#include "src/common/system.h"
+
+#include "src/aurora/gff3file.h"
+
+#include "src/sound/sound.h"
+
+#include "src/graphics/aurora/fontman.h"
+#include "src/graphics/aurora/guiquad.h"
+#include "src/graphics/aurora/text.h"
+#include "src/graphics/aurora/highlightabletext.h"
+#include "src/graphics/aurora/highlightableguiquad.h"
+#include "src/graphics/aurora/textureman.h"
+#include "src/graphics/aurora/texture.h"
+
+#include "src/engines/aurora/util.h"
+#include "src/engines/jade/gui/widgets/checkbox.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetCheckBox::WidgetCheckBox(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag), _state(false),
+	_unselectedR(1.0f), _unselectedG(1.0f), _unselectedB(1.0f), _unselectedA(1.0f) {
+
+}
+
+WidgetCheckBox::~WidgetCheckBox() {
+}
+
+void WidgetCheckBox::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+
+	Border border = createBorder(gff);
+	Graphics::Aurora::TextureHandle texture = TextureMan.get(border.fill);
+
+	_selected = gff.getStruct("SELECTED").getString("FILL");
+	_unselected = gff.getStruct("BORDER").getString("FILL");
+	_selectedHighlighted = gff.getStruct("HILIGHTSELECTED").getString("FILL");
+	_unselectedHighlighted = gff.getStruct("HILIGHT").getString("FILL");
+
+	float squareLength = _quad->getHeight();
+	float _quadPosCorrect = (squareLength - (texture.getTexture().getHeight() * 0.625f)) / 2;
+	float x, y, z;
+	if (_quad) {
+		_quad->getPosition(x, y, z);
+		_quad->setPosition(x + _quadPosCorrect, y + _quadPosCorrect, z);
+		_quad->setHeight(texture.getTexture().getHeight() * 0.625f);
+		_quad->setWidth(texture.getTexture().getWidth() * 0.625f);
+	}
+	if (_text) {
+		_text->getPosition(x, y, z);
+		_text->setPosition(x + squareLength, y, z);
+		_text->setSize(_text->getWidth() - squareLength, _text->getHeight());
+	}
+
+	if (getTextHighlightableComponent() != 0) {
+		setTextHighlighting(getTextHighlightableComponent());
+	}
+	if (getQuadHighlightableComponent() != 0) {
+		setQuadHighlighting(getQuadHighlightableComponent());
+	}
+}
+
+bool WidgetCheckBox::getState() const {
+	return _state;
+}
+
+void WidgetCheckBox::setState(bool state) {
+	_state = state;
+
+	// Preserve the current color after replacing the texture
+	float textR, textG, textB, textA;
+	float quadR, quadG, quadB, quadA;
+	_text->getColor(textR, textG, textB, textA);
+	_quad->getColor(quadR, quadG, quadB, quadA);
+
+	setFill(_state ? _selected : _unselected);
+	setHighlight(_state ? _selectedHighlighted : _unselectedHighlighted);
+
+	_text->setColor(textR, textG, textB, textA);
+	_quad->setColor(quadR, quadG, quadB, quadA);
+
+	setActive(true);
+}
+
+void WidgetCheckBox::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)) {
+	if (isDisabled())
+		return;
+
+	setState(!_state);
+	playSound("gui_check", Sound::kSoundTypeSFX);
+	setActive(true);
+}
+
+void WidgetCheckBox::enter() {
+	float r, g, b, a;
+	_sound = playSound("gui_actscroll", Sound::kSoundTypeSFX);
+	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+		_text->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+		_text->getHighlightedLowerBound(r, g, b, a);
+		_text->setColor(r, g, b, a);
+		_text->setHighlighted(true);
+	}
+
+	if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+		_quad->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+		getQuadHighlightableComponent()->getHighlightedLowerBound(r, g, b, a);
+		_quad->setColor(r, g, b, a);
+		getQuadHighlightableComponent()->setHighlighted(true);
+	}
+
+}
+
+void WidgetCheckBox::leave() {
+	SoundMan.stopChannel(_sound);
+	if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+		_text->setHighlighted(false);
+		_text->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+	}
+	if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+		getQuadHighlightableComponent()->setHighlighted(false);
+		_quad->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+	}
+}
+
+void WidgetCheckBox::setTextHighlighting(Graphics::Aurora::Highlightable *highlightable) {
+	highlightable->setHighlightable(true);
+	highlightable->setHighlightDelta(0, 0, 0, .05);
+	highlightable->setHighlightLowerBound(1, 1, 0, .2);
+	highlightable->setHighlightUpperBound(1, 1, 0, 1);
+}
+
+void WidgetCheckBox::setQuadHighlighting(Graphics::Aurora::Highlightable *highlightable) {
+	highlightable->setHighlightable(true);
+	highlightable->setHighlightLowerBound(1, 1, 0, 1);
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/checkbox.h
+++ b/src/engines/jade/gui/widgets/checkbox.h
@@ -19,10 +19,13 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire checkbox widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_CHECKBOX_H
+#define ENGINES_JADE_GUI_WIDGETS_CHECKBOX_H
+
+#include "src/sound/types.h"
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +33,35 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetCheckBox : public JadeWidget {
+public:
+	WidgetCheckBox(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetCheckBox();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void load(const Aurora::GFF3Struct &gff);
+
+	void setState(bool state);
+	bool getState() const;
+
+	virtual void mouseUp(uint8 state, float x, float y);
+
+	virtual void enter();
+	virtual void leave();
+
+private:
+	Common::UString _selected, _unselected;
+	Common::UString _selectedHighlighted,  _unselectedHighlighted;
+	bool _state;
+
+	Sound::ChannelHandle _sound;
+	float _unselectedR, _unselectedG, _unselectedB, _unselectedA;
+
+	void setTextHighlighting(Graphics::Aurora::Highlightable *highlightable);
+	void setQuadHighlighting(Graphics::Aurora::Highlightable *highlightable);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_CHECKBOX_H

--- a/src/engines/jade/gui/widgets/jadewidget.cpp
+++ b/src/engines/jade/gui/widgets/jadewidget.cpp
@@ -1,0 +1,641 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire widget.
+ */
+
+#include "src/common/util.h"
+
+#include "src/aurora/types.h"
+#include "src/aurora/gff3file.h"
+#include "src/aurora/talkman.h"
+
+#include "src/graphics/font.h"
+#include "src/graphics/windowman.h"
+
+#include "src/graphics/aurora/fontman.h"
+#include "src/graphics/aurora/guiquad.h"
+#include "src/graphics/aurora/text.h"
+#include "src/graphics/aurora/highlightabletext.h"
+#include "src/graphics/aurora/highlightableguiquad.h"
+#include "src/graphics/aurora/types.h"
+#include "src/graphics/aurora/textureman.h"
+
+#include "src/engines/jade/gui/widgets/jadewidget.h"
+
+namespace Engines {
+
+namespace Jade {
+
+JadeWidget::Extend::Extend() : x(0.0f), y(0.0f), w(0.0f), h(0.0f) {
+}
+
+
+JadeWidget::Border::Border() : fillStyle(0), dimension(0), innerOffset(0), hasColor(false),
+	r(0.0f), g(0.0f), b(0.0f), pulsing(false) {
+
+}
+
+
+JadeWidget::Text::Text() : strRef(Aurora::kStrRefInvalid), halign(0.0f), valign(0.0f),
+	r(1.0f), g(1.0f), b(1.0f), pulsing(false) {
+
+}
+
+JadeWidget::Hilight::Hilight() : fill("") {
+
+}
+
+JadeWidget::JadeWidget(::Engines::GUI &gui, const Common::UString &tag)
+		: Widget(gui, tag),
+		  _width(0.0f),
+		  _height(0.0f),
+		  _borderDimension(0),
+		  _r(1.0f),
+		  _g(1.0f),
+		  _b(1.0f),
+		  _a(1.0f),
+		  _unselectedR(1.0f),
+		  _unselectedG(1.0f),
+		  _unselectedB(1.0f),
+		  _unselectedA(1.0f),
+		  _wrapped(false),
+		  _subScene(NULL),
+		  _highlighted(false),
+		  _arrowHeight(0) {
+
+}
+
+JadeWidget::~JadeWidget() {
+}
+
+void JadeWidget::show() {
+	if (isInvisible())
+		return;
+
+	Widget::show();
+
+	if (_quad)
+		_quad->show();
+	if (_text)
+		_text->show();
+	if (_border)
+		_border->show();
+	if (_subScene)
+		_subScene->show();
+	if (_upArrow)
+		_upArrow->show();
+	if (_downArrow)
+		_downArrow->show();
+	if (_thumb)
+		_thumb->show();
+	if (_iconFrame)
+		_iconFrame->show();
+	if (_icon)
+		_icon->show();
+	if (_countText)
+		_countText->show();
+}
+
+void JadeWidget::hide() {
+	if (isInvisible())
+		return;
+
+	if (_countText)
+		_countText->hide();
+	if (_icon)
+		_icon->hide();
+	if (_iconFrame)
+		_iconFrame->hide();
+	if (_thumb)
+		_thumb->hide();
+	if (_downArrow)
+		_downArrow->hide();
+	if (_upArrow)
+		_upArrow->hide();
+	if (_subScene)
+		_subScene->hide();
+	if (_border)
+		_border->hide();
+	if (_highlight)
+		_highlight->hide();
+	if (_quad)
+		_quad->hide();
+	if (_text)
+		_text->hide();
+
+	Widget::hide();
+}
+
+void JadeWidget::setWrapped(bool wrapped) {
+	_wrapped = wrapped;
+}
+
+void JadeWidget::setTag(const Common::UString &tag) {
+	Widget::setTag(tag);
+
+	if (_quad)
+		_quad->setTag(getTag());
+	if (_text)
+		_text->setTag(getTag());
+}
+
+void JadeWidget::setPosition(float x, float y, float z) {
+	float oX, oY, oZ;
+	getPosition(oX, oY, oZ);
+
+	Widget::setPosition(x, y, z);
+	getPosition(x, y, z);
+
+	if (_quad) {
+		float qX, qY, qZ;
+		_quad->getPosition(qX, qY, qZ);
+
+		_quad->setPosition(qX - oX + x, qY - oY + y, qZ - oZ + z);
+	}
+
+	if (_text) {
+		float tX, tY, tZ;
+		_text->getPosition(tX, tY, tZ);
+
+		_text->setPosition(tX - oX + x, tY - oY + y, tZ - oZ + z);
+	}
+
+	if (_highlight) {
+		float hX, hY, hZ;
+		_highlight->getPosition(hX, hY, hZ);
+
+		_highlight->setPosition(hX - oX + x, hY - oY + y, hZ - oZ + z);
+	}
+
+	if (_border) {
+		_border->setPosition(x, y, z);
+	}
+
+	if (_icon) {
+		float iX, iY, iZ;
+		_icon->getPosition(iX, iY, iZ);
+		_icon->setPosition(iX - oX + x, iY - oY + y, iZ - oZ + z);
+	}
+
+	if (_iconFrame) {
+		float iX, iY, iZ;
+		_iconFrame->getPosition(iX, iY, iZ);
+		_iconFrame->setPosition(iX - oX + x, iY - oY + y, iZ - oZ + z);
+	}
+
+	if (_countText) {
+		float cX, cY, cZ;
+		_countText->getPosition(cX, cY, cZ);
+		_countText->setPosition(cX - oX + x, cY - oY + y, cZ - oZ + z);
+	}
+}
+
+void JadeWidget::setSubScene(Graphics::Aurora::SubSceneQuad *subscene) {
+	if (!subscene) {
+		_subScene = NULL;
+		return;
+	}
+
+	_subScene = subscene;
+	_subScene->setSize(_width, _height);
+
+	float wWidth, wHeight;
+	wWidth = WindowMan.getWindowWidth();
+	wHeight = WindowMan.getWindowHeight();
+
+	float x, y, z;
+	getPosition(x, y, z);
+	_subScene->setPosition(x + wWidth/2, y + wHeight/2);
+}
+
+void JadeWidget::setScissor(int x, int y, int width, int height) {
+	if (_quad) {
+		_quad->setScissor(true);
+		_quad->setScissor(x, y, width, height);
+	}
+}
+
+void JadeWidget::setHighlight(bool highlight) {
+	float r, g, b, a;
+
+	if (_highlighted == highlight)
+		return;
+
+	if (highlight) {
+		if (_highlight) {
+			_quad->hide();
+			_highlight->show();
+		} else {
+			if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+				_text->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+				_text->getHighlightedLowerBound(r, g, b, a);
+				_text->setColor(r, g, b, a);
+				_text->setHighlighted(true);
+			}
+
+			if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+				_quad->getColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+				getQuadHighlightableComponent()->getHighlightedLowerBound(r, g, b, a);
+				_quad->setColor(r, g, b, a);
+				getQuadHighlightableComponent()->setHighlighted(true);
+			}
+		}
+	} else {
+		if (_highlight) {
+			_quad->show();
+			_highlight->hide();
+		} else {
+			if (getTextHighlightableComponent() && getTextHighlightableComponent()->isHighlightable()) {
+				_text->setHighlighted(false);
+				_text->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+			}
+			if (getQuadHighlightableComponent() && getQuadHighlightableComponent()->isHighlightable()) {
+				getQuadHighlightableComponent()->setHighlighted(false);
+				_quad->setColor(_unselectedR, _unselectedG, _unselectedB, _unselectedA);
+			}
+		}
+	}
+
+	_highlighted = highlight;
+}
+
+bool JadeWidget::isHighlight() {
+	return _highlighted;
+}
+
+void JadeWidget::setSize(float width, float height) {
+	if (_upArrow) {
+		float x, y, z;
+		getPosition(x, y, z);
+
+		float oX, oY, oZ;
+		_upArrow->getPosition(oX, oY, oZ);
+		_upArrow->setPosition(oX, y + height - _arrowHeight, oZ);
+	}
+	if (_thumb) {
+		_thumb->setWidth(width - 2 * _borderDimension);
+		_thumb->setHeight(height - 2 * (_borderDimension + _arrowHeight));
+	}
+	if (_border)
+		_border->setSize(width, height - 2 * _arrowHeight);
+	if (_quad) {
+		_quad->setWidth(width);
+		_quad->setHeight(height);
+	}
+	if (_text)
+		_text->setSize(width, height);
+	_width = width;
+	_height = height;
+}
+
+void JadeWidget::setWidth(float width) {
+	if (_quad)
+		_quad->setWidth(width);
+}
+
+void JadeWidget::setHeight(float height) {
+	if (_quad)
+		_quad->setHeight(height);
+}
+
+float JadeWidget::getWidth() const {
+	return _width;
+}
+
+float JadeWidget::getHeight() const {
+	return _height;
+}
+
+float JadeWidget::getTextHeight(const Common::UString &text) const {
+	return _text ? _text->getHeight(text) : 0.0f;
+}
+
+void JadeWidget::setFont(const Common::UString &fnt) {
+	if (_text)
+		_text->setFont(fnt);
+}
+
+void JadeWidget::setFill(const Common::UString &fill) {
+	if (fill.empty()) {
+		_quad->hide();
+		_quad.release();
+		return;
+	}
+
+	if (!_quad) {
+		float x, y, z;
+		getPosition(x, y, z);
+
+		_quad.reset(new Graphics::Aurora::GUIQuad("", 0.0f, 0.0f, _width, _height));
+		_quad->setPosition(x, y, z);
+		_quad->setTag(getTag());
+		_quad->setClickable(true);
+
+		if (isVisible())
+			_quad->show();
+	}
+
+	_quad->setTexture(fill);
+	_quad->setColor(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+void JadeWidget::setHighlight(const Common::UString &hilight) {
+	if (hilight.empty()) {
+		_highlight->hide();
+		_highlight.release();
+		return;
+	}
+
+	if (!_highlight) {
+		float x, y, z;
+		getPosition(x, y, z);
+
+		_highlight.reset(new Graphics::Aurora::GUIQuad("", 0.0f, 0.0f, _width, _height));
+		_highlight->setPosition(x, y, z);
+		_highlight->setTag(getTag());
+		_highlight->setClickable(true);
+
+		if (isVisible())
+			_highlight->show();
+	}
+
+	_highlight->setTexture(hilight);
+	_highlight->setColor(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+void JadeWidget::setClickable(bool clickable) {
+	if (_quad)
+		_quad->setClickable(clickable);
+	if (_text)
+		_text->setClickable(clickable);
+	if (_highlight)
+		_highlight->setClickable(clickable);
+}
+
+void JadeWidget::load(const Aurora::GFF3Struct &gff) {
+	gff.getVector("COLOR", _r, _g, _b);
+	_a = gff.getDouble("ALPHA", 1.0);
+
+	Extend extend = createExtend(gff);
+
+	_width  = extend.w;
+	_height = extend.h;
+
+	Widget::setPosition(extend.x, extend.y, 0.0f);
+
+	Border border = createBorder(gff);
+	Hilight hilight = createHilight(gff);
+
+	// Scroll bar properties
+
+	if (gff.hasField("DIR")) {
+		const Aurora::GFF3Struct &dir = gff.getStruct("DIR");
+		Graphics::Aurora::TextureHandle arrowTex = TextureMan.get(dir.getString("IMAGE"));
+		_arrowHeight = arrowTex.getTexture().getHeight();
+
+		_upArrow.reset(new Graphics::Aurora::GUIQuad(arrowTex, 0.0f, 0.0f, _width, _arrowHeight));
+		_upArrow->setPosition(extend.x, extend.y + _height - _arrowHeight, 0.0f);
+
+		_downArrow.reset(new Graphics::Aurora::GUIQuad(arrowTex, 0.0f, 0.0f, _width, _arrowHeight, 0.0f, 1.0f, 1.0f, 0.0f));
+		_downArrow->setPosition(extend.x, extend.y, 0.0f);
+	}
+
+	if (gff.hasField("THUMB")) {
+		const Aurora::GFF3Struct &thumb = gff.getStruct("THUMB");
+
+		_thumb.reset(new Graphics::Aurora::GUIQuad(thumb.getString("IMAGE"), 0.0f, 0.0f,
+				_width - 2 * border.dimension,
+				_height - 2 * (border.dimension + _arrowHeight)));
+
+		_thumb->setPosition(extend.x + border.dimension, extend.y + _arrowHeight + border.dimension, 0.0f);
+	}
+
+	//-
+
+	if (!hilight.fill.empty()) {
+		_highlight.reset(new Graphics::Aurora::GUIQuad(hilight.fill, 0, 0, extend.w, extend.h - 2*_arrowHeight));
+		_highlight->setPosition(extend.x, extend.y + _arrowHeight, 0.0f);
+		_highlight->setTag(getTag());
+		_highlight->setClickable(true);
+	}
+
+	if (!border.edge.empty() && !border.corner.empty()) {
+		_border.reset(new Graphics::Aurora::BorderQuad(border.edge, border.corner,
+		                                               extend.x,
+		                                               extend.y + _arrowHeight,
+		                                               extend.w,
+		                                               extend.h - 2*_arrowHeight,
+		                                               border.dimension));
+
+		_border->setColor(border.r, border.g, border.b);
+		if (!border.fill.empty()) {
+			_quad.reset(new Graphics::Aurora::HighlightableGUIQuad(border.fill, 0.0f, 0.0f,
+			                                                       extend.w - 2 * border.dimension,
+			                                                       extend.h - 2 * (border.dimension - _arrowHeight)));
+		} else {
+			_quad.reset(new Graphics::Aurora::GUIQuad(border.fill, 0.0f, 0.0f,
+			                                          extend.w - 2 * border.dimension,
+			                                          extend.h - 2 * (border.dimension - _arrowHeight)));
+		}
+		_quad->setPosition(extend.x + border.dimension, extend.y + border.dimension + _arrowHeight, 0.0f);
+	} else {
+		if (!border.fill.empty()) {
+			_quad.reset(new Graphics::Aurora::HighlightableGUIQuad(border.fill, 0.0f, 0.0f, extend.w, extend.h - 2*_arrowHeight));
+		} else {
+			_quad.reset(new Graphics::Aurora::GUIQuad(border.fill, 0.0f, 0.0f, extend.w, extend.h - 2*_arrowHeight));
+		}
+		_quad->setPosition(extend.x, extend.y + _arrowHeight, 0.0f);
+	}
+
+	_quad->setTag(getTag());
+	_quad->setClickable(true);
+
+	if (border.fill.empty())
+		_quad->setColor(0.0f, 0.0f, 0.0f, 0.0f);
+	else if (!border.hasColor)
+		_quad->setColor(1.0f, 1.0f, 1.0f, 1.0f);
+	else
+		_quad->setColor(border.r, border.g, border.b, 1.0f);
+
+	Text text = createText(gff);
+
+	if (!text.font.empty()) {
+		// Buttons in Jade are too small for their text
+		// If widget height is less than the font needs
+		// increase to font height and reposition
+		float fontHeight = FontMan.get(text.font).getFont().getHeight();
+		float tY = extend.y;
+		float tH = extend.h;
+		if (extend.h < fontHeight) {
+			tH = fontHeight;
+			tY = extend.y - (fontHeight - extend.h);
+		}
+		_text.reset(new Graphics::Aurora::HighlightableText(FontMan.get(text.font), extend.w, tH,
+		            text.text, text.r, text.g, text.b, 1.0f, text.halign, text.valign));
+
+		_text->setPosition(extend.x, tY, -1.0f);
+		_text->setTag(getTag());
+		_text->setClickable(true);
+	}
+
+	_borderDimension = border.dimension;
+}
+
+void JadeWidget::setColor(float r, float g, float b, float a) {
+	if (_quad)
+		_quad->setColor(r, g, b, a);
+}
+
+void JadeWidget::setText(const Common::UString &text) {
+	if (_text)
+		_text->setText(text);
+}
+
+void JadeWidget::setHorizontalTextAlign(float halign) {
+	if (_text)
+		_text->setHorizontalAlign(halign);
+}
+
+void JadeWidget::setVerticalTextAlign(float valign) {
+	if (_text)
+		_text->setVerticalAlign(valign);
+}
+
+void JadeWidget::setTextColor(float r, float g, float b, float a) {
+	if (_text)
+		_text->setColor(r, g, b, a);
+}
+
+void JadeWidget::setBorderColor(float r, float g, float b, float a) {
+	if (_border)
+		_border->setColor(r, g, b, a);
+}
+
+void JadeWidget::setIconTexture(const Common::UString &texture) {
+	if (_icon)
+		_icon->setTexture(texture);
+}
+
+void JadeWidget::setCount(int UNUSED(count)) {
+}
+
+JadeWidget::Extend JadeWidget::createExtend(const Aurora::GFF3Struct &gff) {
+	Extend extend;
+
+	if (gff.hasField("EXTENT")) {
+		const Aurora::GFF3Struct &e = gff.getStruct("EXTENT");
+
+		extend.x = (float) e.getSint("LEFT");
+		extend.y = (float) e.getSint("TOP");
+		extend.w = (float) e.getSint("WIDTH");
+		extend.h = (float) e.getSint("HEIGHT");
+	}
+
+	return extend;
+}
+
+JadeWidget::Border JadeWidget::createBorder(const Aurora::GFF3Struct &gff) {
+	Border border;
+
+	if (gff.hasField("BORDER")) {
+		const Aurora::GFF3Struct &b = gff.getStruct("BORDER");
+
+		border.corner = b.getString("CORNER");
+		border.edge   = b.getString("EDGE");
+		border.fill   = b.getString("FILL");
+
+		border.fillStyle   = b.getUint("FILLSTYLE");
+		border.dimension   = b.getUint("DIMENSION");
+		border.innerOffset = b.getUint("INNEROFFSET");
+
+		border.hasColor = b.hasField("COLOR");
+		b.getVector("COLOR", border.r, border.g, border.b);
+
+		border.pulsing = b.getBool("PULSING");
+	}
+	return border;
+}
+
+JadeWidget::Text JadeWidget::createText(const Aurora::GFF3Struct &gff) {
+	Text text;
+
+	if (gff.hasField("TEXT")) {
+		const Aurora::GFF3Struct &t = gff.getStruct("TEXT");
+
+		text.font   = t.getString("FONT");
+		text.text   = t.getString("TEXT");
+		text.strRef = t.getUint("STRREF", Aurora::kStrRefInvalid);
+
+		const uint32 alignment = t.getUint("ALIGNMENT");
+
+		t.getVector("COLOR", text.r, text.g, text.b);
+
+		text.pulsing = t.getBool("PULSING");
+
+
+		if (text.text == "(Unitialized)")
+			text.text.clear();
+
+		if (text.strRef != Aurora::kStrRefInvalid)
+			text.text = TalkMan.getString(text.strRef);
+
+		if (alignment == 10) {
+			text.halign = Graphics::Aurora::kHAlignCenter;
+			text.valign = Graphics::Aurora::kVAlignTop;
+		} else if (alignment == 18) {
+			text.halign = Graphics::Aurora::kHAlignCenter;
+			text.valign = Graphics::Aurora::kVAlignMiddle;
+		}
+	}
+
+	return text;
+}
+
+JadeWidget::Hilight JadeWidget::createHilight(const Aurora::GFF3Struct &gff) {
+	Hilight hilight;
+
+	if (gff.hasField("HILIGHT")) {
+		const Aurora::GFF3Struct &h = gff.getStruct("HILIGHT");
+
+		hilight.fill   = h.getString("FILL");
+	}
+
+	return hilight;
+}
+
+Graphics::Aurora::Highlightable* JadeWidget::getTextHighlightableComponent() const {
+	return static_cast<Graphics::Aurora::Highlightable*>(_text.get());
+}
+
+Graphics::Aurora::Highlightable* JadeWidget::getQuadHighlightableComponent() const {
+	return dynamic_cast<Graphics::Aurora::Highlightable*>(_quad.get());
+}
+
+void JadeWidget::setInvisible(bool invisible) {
+	Widget::setInvisible(invisible);
+
+	setClickable(!invisible);
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/jadewidget.h
+++ b/src/engines/jade/gui/widgets/jadewidget.h
@@ -1,0 +1,199 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire widget.
+ */
+
+#ifndef ENGINES_JADE_GUI_WIDGETS_JADEWIDGET_H
+#define ENGINES_JADE_GUI_WIDGETS_JADEWIDGET_H
+
+#include "src/common/scopedptr.h"
+#include "src/common/ustring.h"
+
+#include "src/aurora/types.h"
+
+#include "src/graphics/aurora/types.h"
+#include "src/graphics/aurora/highlightable.h"
+#include "src/graphics/aurora/highlightabletext.h"
+#include "src/graphics/aurora/borderquad.h"
+#include "src/graphics/aurora/subscenequad.h"
+
+#include "src/engines/aurora/widget.h"
+
+namespace Engines {
+
+namespace Jade {
+
+/** Base class for all widgets in Jade Empire. */
+class JadeWidget : public Widget {
+public:
+	JadeWidget(::Engines::GUI &gui, const Common::UString &tag);
+	~JadeWidget();
+
+	virtual void load(const Aurora::GFF3Struct &gff);
+
+	void show();
+	void hide();
+
+	void setWrapped(bool wrapped);
+
+	void setTag(const Common::UString &tag);
+
+	virtual void setPosition(float x, float y, float z);
+	void setSubScene(Graphics::Aurora::SubSceneQuad *subscene);
+
+	virtual void setInvisible(bool invisible);
+
+	/** Create a scissor test over this widget. */
+	void setScissor(int x, int y, int width, int height);
+
+	/** Change the font for this widget. */
+	void setFont(const Common::UString &fnt);
+
+	/** Set the widget clickable, or not clickable. */
+	void setClickable(bool clickable);
+
+	/** Set if the widget should be highlighted. */
+	void setHighlight(bool highlight);
+	/** If the widget is highlighted. */
+	bool isHighlight();
+
+	/** Set size of the widget. */
+	void setSize(float width, float height);
+	/** Set the width of the widget. */
+	void setWidth(float width);
+	/** Set the height of the widget. */
+	void setHeight(float height);
+
+	float getWidth () const;
+	float getHeight() const;
+
+	float getTextHeight(const Common::UString &text) const;
+
+	void setFill(const Common::UString &fill);
+	void setHighlight(const Common::UString &hilight);
+	void setColor(float r, float g, float b, float a);
+	void setText(const Common::UString &text);
+	void setHorizontalTextAlign(float halign);
+	void setVerticalTextAlign(float valign);
+	void setTextColor(float r, float g, float b, float a);
+	void setBorderColor(float r, float g, float b, float a);
+	void setIconTexture(const Common::UString &texture);
+
+	virtual void setCount(int count);
+
+protected:
+	struct Extend {
+		float x;
+		float y;
+		float w;
+		float h;
+
+		Extend();
+	};
+
+	struct Border {
+		Common::UString corner;
+		Common::UString edge;
+		Common::UString fill;
+
+		uint32 fillStyle;
+		uint32 dimension;
+		uint32 innerOffset;
+
+		bool hasColor;
+		float r, g, b;
+
+		bool pulsing;
+
+		Border();
+	};
+
+	struct Text {
+		Common::UString font;
+		Common::UString text;
+		uint32 strRef;
+
+		float halign;
+		float valign;
+
+		float r, g, b;
+
+		bool pulsing;
+
+		Text();
+	};
+
+	struct Hilight {
+		Common::UString fill;
+
+		Hilight();
+	};
+
+	Graphics::Aurora::Highlightable *getTextHighlightableComponent() const;
+	Graphics::Aurora::Highlightable *getQuadHighlightableComponent() const;
+
+	float _width;
+	float _height;
+	uint32 _borderDimension;
+
+	float _r;
+	float _g;
+	float _b;
+	float _a;
+
+	float _unselectedR, _unselectedG, _unselectedB, _unselectedA;
+
+	bool _wrapped;
+
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _quad;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad>           _highlight;
+	Common::ScopedPtr<Graphics::Aurora::HighlightableText> _text;
+	Common::ScopedPtr<Graphics::Aurora::BorderQuad>        _border;
+
+	Graphics::Aurora::SubSceneQuad *_subScene;
+
+	bool _highlighted;
+
+	/// .--- Scroll bar elements
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _upArrow;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _downArrow;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _thumb;
+	float _arrowHeight;
+	/// '---
+
+	/// .--- Inventory item
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _icon;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _iconFrame;
+	Common::ScopedPtr<Graphics::Aurora::Text>    _countText;
+	/// '---
+
+	Extend  createExtend (const Aurora::GFF3Struct &gff);
+	Border  createBorder (const Aurora::GFF3Struct &gff);
+	Text    createText   (const Aurora::GFF3Struct &gff);
+	Hilight createHilight(const Aurora::GFF3Struct &gff);
+};
+
+} // End of namespace Jade
+
+} // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_JADEWIDGET_H

--- a/src/engines/jade/gui/widgets/label.cpp
+++ b/src/engines/jade/gui/widgets/label.cpp
@@ -1,0 +1,72 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire label widget.
+ */
+
+#include "src/aurora/gff3file.h"
+
+#include "src/graphics/aurora/guiquad.h"
+
+#include "src/engines/jade/gui/widgets/label.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetLabel::WidgetLabel(::Engines::GUI &gui, const Common::UString &tag) :
+		JadeWidget(gui, tag) {
+}
+
+WidgetLabel::~WidgetLabel() {
+}
+
+void WidgetLabel::enableHighlight() {
+	Graphics::Aurora::Highlightable *highlightable = getTextHighlightableComponent();
+	if (highlightable) {
+		highlightable->setHighlightable(true);
+		highlightable->setHighlightDelta(0, 0, 0, .05);
+		highlightable->setHighlightLowerBound(1, 1, 0, .2);
+		highlightable->setHighlightUpperBound(1, 1, 0, 1);
+	}
+}
+
+void WidgetLabel::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+}
+
+void WidgetLabel::enter() {
+	setHighlight(true);
+}
+
+void WidgetLabel::leave() {
+	setHighlight(false);
+}
+
+void WidgetLabel::mouseUp(uint8 UNUSED(state),
+                          float UNUSED(x),
+                          float UNUSED(y)) {
+	setActive(true);
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/label.h
+++ b/src/engines/jade/gui/widgets/label.h
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire label widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_LABEL_H
+#define ENGINES_JADE_GUI_WIDGETS_LABEL_H
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +31,21 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetLabel : public JadeWidget {
+public:
+	WidgetLabel(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetLabel();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void enableHighlight();
+
+	void load(const Aurora::GFF3Struct &gff);
+	void enter();
+	void leave();
+	void mouseUp(uint8 state, float x, float y);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_LABEL_H

--- a/src/engines/jade/gui/widgets/listbox.cpp
+++ b/src/engines/jade/gui/widgets/listbox.cpp
@@ -1,0 +1,314 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Listbox widget for Jade Empire.
+ */
+
+#include "src/common/strutil.h"
+
+#include "src/aurora/gff3file.h"
+
+#include "src/graphics/graphics.h"
+
+#include "src/engines/jade/gui/gui.h"
+
+#include "src/engines/jade/gui/widgets/listbox.h"
+#include "src/engines/jade/gui/widgets/button.h"
+#include "src/engines/jade/gui/widgets/label.h"
+#include "src/engines/jade/gui/widgets/scrollbar.h"
+#include "src/engines/jade/gui/widgets/listitem.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetListBox::WidgetListBox(::Engines::GUI &gui,
+                             const Common::UString &tag)
+		: JadeWidget(gui, tag),
+		  _protoItem(0),
+		  _scrollBar(0),
+		  _padding(0),
+		  _leftScrollBar(false),
+		  _itemSelectionEnabled(false),
+		  _adjustHeight(false),
+		  _selectedIndex(-1),
+		  _startIndex(0),
+		  _numVisibleItems(0),
+		  _hideScrollBar(false) {
+}
+
+WidgetListBox::~WidgetListBox() {
+}
+
+void WidgetListBox::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+
+	if (gff.hasField("PROTOITEM")) {
+		_protoItem = &gff.getStruct("PROTOITEM");
+	}
+
+	if (gff.hasField("LEFTSCROLLBAR")) {
+		_leftScrollBar = gff.getBool("LEFTSCROLLBAR");
+	}
+
+	if (gff.hasField("SCROLLBAR")) {
+		_scrollBar = &gff.getStruct("SCROLLBAR");
+	}
+
+	if (gff.hasField("PADDING")) {
+		_padding = gff.getSint("PADDING");
+
+		if (_gui->getName().stricmp("container") == 0)
+			_padding = 18;
+	}
+}
+
+WidgetScrollbar *WidgetListBox::createScrollBar() {
+	if (!_scrollBar)
+		return 0;
+
+	_scrollBarWidget = new WidgetScrollbar(*_gui, _scrollBar->getString("TAG"));
+	_scrollBarWidget->load(*_scrollBar);
+
+	float x, y, z;
+	getPosition(x, y, z);
+	_scrollBarWidget->setPosition(x, y, z);
+
+	_scrollBarWidget->setSize(_scrollBarWidget->getWidth(), _height);
+	return _scrollBarWidget;
+}
+
+void WidgetListBox::setItemSelectionEnabled(bool value) {
+	_itemSelectionEnabled = value;
+}
+
+void WidgetListBox::setAdjustHeight(bool value) {
+	_adjustHeight = value;
+}
+
+void WidgetListBox::setHideScrollBar(bool value) {
+	_hideScrollBar = value;
+}
+
+const std::vector<JadeWidget *> &WidgetListBox::createItemWidgets(uint count) {
+	if (!_protoItem)
+		throw Common::Exception("ListBox widget has no PROTOITEM");
+
+	const int64 itemHeight = _protoItem->getStruct("EXTENT").getSint("HEIGHT");
+
+	uint widgetCount = count;
+	if ((count == 0) && (itemHeight > 0))
+		widgetCount = getHeight() / itemHeight;
+
+	for (uint i = 0; i < widgetCount; ++i) {
+		Common::UString name = Common::UString::format("%s_ITEM_%u", _tag.c_str(), i);
+		createItem(name);
+	}
+
+	return _itemWidgets;
+}
+
+void WidgetListBox::addItem(const Common::UString &text,
+                            const Common::UString &icon,
+                            int count) {
+	Item item;
+	item.text = text;
+	item.icon = icon;
+	item.count = count;
+	_items.push_back(item);
+}
+
+void WidgetListBox::removeAllItems() {
+	_startIndex = 0;
+	_items.clear();
+}
+
+void WidgetListBox::refreshItemWidgets() {
+	_numVisibleItems = 0;
+	float totalHeight = 0;
+
+	float x, y, z;
+	getPosition(x, y, z);
+	y += getHeight();
+
+	if (_scrollBar && _leftScrollBar)
+		x += _scrollBar->getStruct("BORDER").getSint("DIMENSION") +
+		     _scrollBar->getStruct("EXTENT").getSint("WIDTH");
+
+	GfxMan.lockFrame();
+
+	bool heightExceeded = false;
+
+	for (size_t i = 0; i < _itemWidgets.size(); ++i) {
+		JadeWidget *itemWidget = _itemWidgets[i];
+		bool visible = false;
+
+		if (!heightExceeded) {
+			int itemIndex = _startIndex + i;
+			if (itemIndex < (int)_items.size()) { // have item to display?
+				Item &item = _items[itemIndex];
+				const Common::UString &text = item.text;
+
+				if (_adjustHeight) {
+					float textHeight = itemWidget->getTextHeight(text);
+					if (totalHeight + textHeight > getHeight())
+						heightExceeded = true;
+					else {
+						itemWidget->setSize(itemWidget->getWidth(), textHeight);
+						itemWidget->setPosition(x, y -= textHeight + _padding, z);
+						totalHeight += textHeight;
+					}
+				}
+
+				if (!heightExceeded) {
+					itemWidget->setText(text);
+					itemWidget->setIconTexture(item.icon);
+					itemWidget->setCount(item.count);
+					itemWidget->setHighlight(itemIndex == _selectedIndex);
+					visible = true;
+				}
+			}
+		}
+
+		if (visible) {
+			itemWidget->setInvisible(false);
+			if (isVisible())
+				itemWidget->show();
+			++_numVisibleItems;
+		} else {
+			if (isVisible())
+				itemWidget->hide();
+			itemWidget->setInvisible(true);
+		}
+	}
+
+	if (_hideScrollBar) {
+		if (_numVisibleItems < (int)_items.size()) {
+			_scrollBarWidget->setInvisible(false);
+			if (isVisible())
+				_scrollBarWidget->show();
+		} else {
+			if (isVisible())
+				_scrollBarWidget->hide();
+			_scrollBarWidget->setInvisible(true);
+		}
+	}
+
+	GfxMan.unlockFrame();
+}
+
+JadeWidget *WidgetListBox::createItem(Common::UString name) {
+	if (!_protoItem)
+		throw Common::Exception("ListBox widget has no PROTOITEM");
+
+	JadeWidget *item;
+
+	// Create a new widget.
+	switch (_protoItem->getUint("CONTROLTYPE")) {
+		case 4:
+			item = new WidgetLabel(*_gui, name);
+			break;
+		case 5:
+			item = new WidgetListItem(*_gui, name);
+			break;
+		case 6:
+			item = new WidgetButton(*_gui, name);
+			if (_itemSelectionEnabled)
+				static_cast<WidgetButton *>(item)->setDisableHighlight(true);
+			break;
+		default:
+			throw Common::Exception("TODO: Add other supported widget types to the ListBox");
+	}
+
+	// Load the prototype item.
+	item->load(*_protoItem);
+
+	// Calculate the new position for managing it in a list.
+	float x, y, z;
+	getPosition(x, y, z);
+
+	if (_scrollBar && _leftScrollBar)
+		x += _scrollBar->getStruct("BORDER").getSint("DIMENSION") +
+		     _scrollBar->getStruct("EXTENT").getSint("WIDTH");
+
+	assert(getHeight() > 0);
+
+	y = y - _itemWidgets.size() * (item->getHeight() + _padding) + getHeight() - item->getHeight();
+
+	item->setPosition(x, y, z);
+	_itemWidgets.push_back(item);
+
+	return item;
+}
+
+void WidgetListBox::onClickItemWidget(const Common::UString &tag) {
+	if (!_itemSelectionEnabled)
+		return;
+
+	Common::UString tmp(tag);
+	tmp.replaceAll(_tag + "_ITEM_", "");
+
+	int index = -1;
+	Common::parseString(tmp, index);
+
+	if ((index >= 0) && (_selectedIndex != _startIndex + index)) {
+		_selectedIndex = _startIndex + index;
+		refreshItemWidgets();
+	}
+}
+
+void WidgetListBox::selectNextItem() {
+	if (!_itemSelectionEnabled)
+		return;
+
+	if (_selectedIndex < 0 && !_items.empty()) {
+		_selectedIndex = 0;
+		refreshItemWidgets();
+	} else if (_selectedIndex < (int)_items.size() - 1) {
+		++_selectedIndex;
+		if (_selectedIndex - _startIndex >= _numVisibleItems)
+			_startIndex = _selectedIndex - _numVisibleItems + 1;
+		refreshItemWidgets();
+	}
+}
+
+void WidgetListBox::selectPreviousItem() {
+	if (!_itemSelectionEnabled)
+		return;
+
+	if (_selectedIndex < 0 && !_items.empty()) {
+		_selectedIndex = 0;
+		refreshItemWidgets();
+	} else if (_selectedIndex > 0) {
+		--_selectedIndex;
+		if (_selectedIndex < _startIndex)
+			_startIndex = _selectedIndex;
+		refreshItemWidgets();
+	}
+}
+
+int WidgetListBox::getSelectedIndex() const {
+	return _selectedIndex;
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/listbox.h
+++ b/src/engines/jade/gui/widgets/listbox.h
@@ -1,0 +1,121 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Listbox widget for Jade Empire.
+ */
+
+#ifndef ENGINES_JADE_GUI_WIDGETS_LISTBOX_H
+#define ENGINES_JADE_GUI_WIDGETS_LISTBOX_H
+
+#include "src/engines/jade/gui/widgets/jadewidget.h"
+
+namespace Engines {
+
+namespace Jade {
+
+class WidgetListBox : public JadeWidget {
+public:
+	WidgetListBox(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetListBox();
+
+	void load(const Aurora::GFF3Struct &gff);
+	WidgetScrollbar *createScrollBar();
+
+	/** Toggle item selection mode. When enabled listbox items can be
+	 *  selected by clicking on them. One can also scroll through the
+	 *  list of items (see selectNextItem and selectPreviousItem).
+	 */
+	void setItemSelectionEnabled(bool value);
+
+	/** Toggle height adjustment mode. When enabled item widgets will
+	 *  adjust their height during refresh based on the size of their
+	 *  contents.
+	 */
+	void setAdjustHeight(bool value);
+
+	/** Toggle scroll bar visibility mode. When enabled it will only
+	 *  be displayed when number of underlying items exceeds number
+	 *  of item widgets.
+	 */
+	void setHideScrollBar(bool value);
+
+	// .--- Item widgets management
+
+	/** Create item widgets and return pointers to them.
+	 *
+	 *  @param count Number of widgets to create or 0 to create a
+	 *               maximum number of widgets that could fit into the
+	 *               listbox
+	 */
+	const std::vector<JadeWidget *> &createItemWidgets(uint count = 0);
+
+	JadeWidget *createItem(Common::UString name);
+	void refreshItemWidgets();
+
+	// '---
+
+	// .--- Underlying items management
+
+	void addItem(const Common::UString &text,
+	             const Common::UString &icon = "",
+	             int count = 1);
+
+	void removeAllItems();
+
+	// '---
+
+	// .--- Event handlers
+
+	void onClickItemWidget(const Common::UString &tag);
+	void selectNextItem();
+	void selectPreviousItem();
+
+	// '---
+
+	int getSelectedIndex() const;
+
+private:
+	struct Item {
+		Common::UString text;
+		Common::UString icon;
+		int count;
+	};
+
+	const Aurora::GFF3Struct *_protoItem;
+	const Aurora::GFF3Struct *_scrollBar;
+	std::vector<Item> _items;
+	WidgetScrollbar *_scrollBarWidget;
+	std::vector<JadeWidget *> _itemWidgets;
+	int _padding;
+	bool _leftScrollBar;
+	bool _itemSelectionEnabled;
+	bool _adjustHeight;
+	int _selectedIndex;
+	int _startIndex;
+	int _numVisibleItems;
+	bool _hideScrollBar;
+};
+
+} // End of namespace Jade
+
+} // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_LISTBOX_H

--- a/src/engines/jade/gui/widgets/listitem.cpp
+++ b/src/engines/jade/gui/widgets/listitem.cpp
@@ -1,0 +1,80 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Inventory item widget.
+ */
+
+#include "src/common/strutil.h"
+
+#include "src/graphics/aurora/guiquad.h"
+#include "src/graphics/aurora/textureman.h"
+#include "src/graphics/aurora/fontman.h"
+
+#include "src/engines/jade/gui/widgets/listitem.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetListItem::WidgetListItem(Engines::GUI &gui, const Common::UString &tag)
+		: JadeWidget(gui, tag) {
+}
+
+void WidgetListItem::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+
+	Graphics::Aurora::TextureHandle tex = TextureMan.get("lbl_hex");
+	float frameSize = tex.getTexture().getHeight();
+	_iconFrame.reset(new Graphics::Aurora::GUIQuad(tex, 0.0f, 0.0f, frameSize, frameSize));
+	_iconFrame->setPosition(frameSize / 2.0f, frameSize / 2.0f, -1.0f);
+
+	_icon.reset(new Graphics::Aurora::GUIQuad("", 0.0f, 0.0f, frameSize, frameSize));
+	_icon->setPosition(frameSize / 2.0f, frameSize / 2.0f, -2.0f);
+
+	float r, g, b, a;
+	_text->getColor(r, g, b, a);
+
+	_countText.reset(new Graphics::Aurora::Text(FontMan.get("fnt_d16x16b"),
+	                 "", r, g, b, a,
+	                 Graphics::Aurora::kHAlignRight,
+	                 Graphics::Aurora::kVAlignBottom));
+
+	_countText->setPosition(frameSize / 2.0f - 4.0f, frameSize / 2.0f + 2.0f, -3.0f);
+	_countText->setSize(frameSize, frameSize);
+
+	float x, y, z;
+	_text->getPosition(x, y, z);
+	_text->setPosition(x + frameSize, y, z);
+}
+
+void WidgetListItem::setCount(int count) {
+	if (count > 1) {
+		_iconFrame->setTexture("lbl_hex_4");
+		_countText->setText(Common::composeString(count));
+	} else {
+		_iconFrame->setTexture("lbl_hex");
+		_countText->setText("");
+	}
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/listitem.h
+++ b/src/engines/jade/gui/widgets/listitem.h
@@ -19,10 +19,13 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  Inventory item widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_LISTITEM_H
+#define ENGINES_JADE_GUI_WIDGETS_LISTITEM_H
+
+#include "src/engines/aurora/gui.h"
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +33,15 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
-
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+class WidgetListItem : public JadeWidget {
+public:
+	WidgetListItem(Engines::GUI &gui, const Common::UString &tag);
+	void load(const Aurora::GFF3Struct &gff);
+	void setCount(int count);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_LISTITEM_H

--- a/src/engines/jade/gui/widgets/panel.cpp
+++ b/src/engines/jade/gui/widgets/panel.cpp
@@ -19,24 +19,41 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire panel widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#include "src/aurora/gff3file.h"
 
-#include "src/engines/jade/gui/widgets/jadewidget.h"
+#include "src/graphics/aurora/guiquad.h"
+
+#include "src/engines/jade/gui/widgets/panel.h"
 
 namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
+WidgetPanel::WidgetPanel(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag) {
 }
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
+WidgetPanel::WidgetPanel(::Engines::GUI &gui, const Common::UString &tag,
+                         const Common::UString &texture,
+                         float x, float y, float w, float h) : JadeWidget(gui, tag) {
+
+	_width  = w;
+	_height = h;
+
+	Widget::setPosition(x, y, 0.0f);
+
+	_quad.reset(new Graphics::Aurora::GUIQuad(texture, 0.0f, 0.0f, w, h));
+	_quad->setPosition(x, y, 0.0f);
+}
+
+WidgetPanel::~WidgetPanel() {
+}
+
+void WidgetPanel::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
 }
 
 } // End of namespace Jade

--- a/src/engines/jade/gui/widgets/panel.h
+++ b/src/engines/jade/gui/widgets/panel.h
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire panel widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_PANEL_H
+#define ENGINES_JADE_GUI_WIDGETS_PANEL_H
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +31,18 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetPanel : public JadeWidget {
+public:
+	WidgetPanel(::Engines::GUI &gui, const Common::UString &tag);
+	WidgetPanel(::Engines::GUI &gui, const Common::UString &tag,
+	            const Common::UString &texture, float x, float y, float w, float h);
+	~WidgetPanel();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void load(const Aurora::GFF3Struct &gff);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_PANEL_H

--- a/src/engines/jade/gui/widgets/progressbar.cpp
+++ b/src/engines/jade/gui/widgets/progressbar.cpp
@@ -1,0 +1,136 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire progressbar widget.
+ */
+
+#include "src/common/system.h"
+
+#include "src/aurora/gff3file.h"
+
+#include "src/engines/jade/gui/widgets/progressbar.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetProgressbar::WidgetProgressbar(::Engines::GUI &gui, const Common::UString &tag) :
+		JadeWidget(gui, tag), _maxValue(0), _curValue(0), _horizontal(true) {
+}
+
+WidgetProgressbar::~WidgetProgressbar() {
+}
+
+void WidgetProgressbar::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+
+	_maxValue = gff.getSint("MAXVALUE");
+	_curValue = gff.getSint("CURVALUE");
+	_horizontal = gff.getBool("STARTFROMLEFT", true);
+
+	if (gff.hasField("PROGRESS")) {
+		const Aurora::GFF3Struct &progress = gff.getStruct("PROGRESS");
+		const Common::UString fill = progress.getString("FILL");
+
+		_progress.reset(new Graphics::Aurora::GUIQuad(fill, 0.0f, 0.0f, getWidth(), getHeight()));
+
+		float x, y, z;
+		getPosition(x, y, z);
+		_progress->setPosition(x, y, -FLT_MAX);
+
+		update();
+	}
+}
+
+void WidgetProgressbar::setPosition(float x, float y, float z) {
+	float oX, oY, oZ;
+	getPosition(oX, oY, oZ);
+
+	JadeWidget::setPosition(x, y, z);
+
+	if (_progress) {
+		float pX, pY, pZ;
+		_progress->getPosition(pX, pY, pZ);
+
+		_progress->setPosition(pX - oX + x, pY - oY + y);
+	}
+}
+
+void WidgetProgressbar::show() {
+	if (isInvisible())
+		return;
+
+	JadeWidget::show();
+
+	if (_progress)
+		_progress->show();
+}
+
+void WidgetProgressbar::hide() {
+	if (isInvisible())
+		return;
+
+	JadeWidget::hide();
+
+	if (_progress)
+		_progress->hide();
+}
+
+void WidgetProgressbar::setCurrentValue(int curValue) {
+	_curValue = curValue;
+	update();
+}
+
+void WidgetProgressbar::setMaxValue(int maxValue) {
+	_maxValue = maxValue;
+	update();
+}
+
+int WidgetProgressbar::getCurrentValue() {
+	return _curValue;
+}
+
+int WidgetProgressbar::getMaxValue() {
+	return _maxValue;
+}
+
+void WidgetProgressbar::update() {
+	if (_horizontal) {
+		if ((_maxValue <= 0) || (_curValue >= _maxValue))
+			_progress->setWidth(getWidth());
+		else if (_curValue <= 0)
+			_progress->setWidth(0.0f);
+		else
+			_progress->setWidth(getWidth() * (static_cast<float>(_curValue) / static_cast<float>(_maxValue)));
+
+	} else {
+		if ((_maxValue <= 0) || (_curValue >= _maxValue))
+			_progress->setHeight(getHeight());
+		else if (_curValue <= 0)
+			_progress->setHeight(0.0f);
+		else
+			_progress->setHeight(getHeight() * (static_cast<float>(_curValue) / static_cast<float>(_maxValue)));
+	}
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/progressbar.h
+++ b/src/engines/jade/gui/widgets/progressbar.h
@@ -19,10 +19,13 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire progressbar widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_PROGRESSBAR_H
+#define ENGINES_JADE_GUI_WIDGETS_PROGRESSBAR_H
+
+#include "src/graphics/aurora/guiquad.h"
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +33,41 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetProgressbar : public JadeWidget {
+public:
+	WidgetProgressbar(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetProgressbar();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void show();
+	void hide();
+
+	void load(const Aurora::GFF3Struct &gff);
+
+	void setPosition(float x, float y, float z);
+
+	/** Set the current progress bar value */
+	void setCurrentValue(int curValue);
+	/** Set the max progress bar value */
+	void setMaxValue(int maxValue);
+
+	/** Get the current progress bar value */
+	int getCurrentValue();
+	/** Get the max progress bar value */
+	int getMaxValue();
+
+private:
+	void update();
+
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _progress;
+
+	int _maxValue;
+	int _curValue;
+
+	bool _horizontal;
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_PROGRESSBAR_H

--- a/src/engines/jade/gui/widgets/protoitem.cpp
+++ b/src/engines/jade/gui/widgets/protoitem.cpp
@@ -19,24 +19,26 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire protoitem widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#include "src/common/system.h"
 
-#include "src/engines/jade/gui/widgets/jadewidget.h"
+#include "src/engines/jade/gui/widgets/protoitem.h"
 
 namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
+WidgetProtoItem::WidgetProtoItem(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag) {
 }
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
+WidgetProtoItem::~WidgetProtoItem() {
+}
+
+void WidgetProtoItem::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
 }
 
 } // End of namespace Jade

--- a/src/engines/jade/gui/widgets/protoitem.h
+++ b/src/engines/jade/gui/widgets/protoitem.h
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire protoitem widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_PROTOITEM_H
+#define ENGINES_JADE_GUI_WIDGETS_PROTOITEM_H
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +31,16 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetProtoItem : public JadeWidget {
+public:
+	WidgetProtoItem(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetProtoItem();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void load(const Aurora::GFF3Struct &gff);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_PROTOITEM_H

--- a/src/engines/jade/gui/widgets/rules.mk
+++ b/src/engines/jade/gui/widgets/rules.mk
@@ -1,0 +1,48 @@
+# xoreos - A reimplementation of BioWare's Aurora engine
+#
+# xoreos is the legal property of its developers, whose names
+# can be found in the AUTHORS file distributed with this source
+# distribution.
+#
+# xoreos is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# xoreos is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+
+# GUI widgets in Jade Empire.
+
+src_engines_jade_libjade_la_SOURCES += \
+    src/engines/jade/gui/widgets/button.h \
+    src/engines/jade/gui/widgets/checkbox.h \
+    src/engines/jade/gui/widgets/jadewidget.h \
+    src/engines/jade/gui/widgets/label.h \
+    src/engines/jade/gui/widgets/listbox.h \
+    src/engines/jade/gui/widgets/panel.h \
+    src/engines/jade/gui/widgets/progressbar.h \
+    src/engines/jade/gui/widgets/protoitem.h \
+    src/engines/jade/gui/widgets/scrollbar.h \
+    src/engines/jade/gui/widgets/slider.h \
+    src/engines/jade/gui/widgets/listitem.h \
+    $(EMPTY)
+
+src_engines_jade_libjade_la_SOURCES += \
+    src/engines/jade/gui/widgets/button.cpp \
+    src/engines/jade/gui/widgets/checkbox.cpp \
+    src/engines/jade/gui/widgets/jadewidget.cpp \
+    src/engines/jade/gui/widgets/label.cpp \
+    src/engines/jade/gui/widgets/listbox.cpp \
+    src/engines/jade/gui/widgets/panel.cpp \
+    src/engines/jade/gui/widgets/progressbar.cpp \
+    src/engines/jade/gui/widgets/protoitem.cpp \
+    src/engines/jade/gui/widgets/scrollbar.cpp \
+    src/engines/jade/gui/widgets/slider.cpp \
+    src/engines/jade/gui/widgets/listitem.cpp \
+    $(EMPTY)

--- a/src/engines/jade/gui/widgets/scrollbar.cpp
+++ b/src/engines/jade/gui/widgets/scrollbar.cpp
@@ -1,0 +1,86 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  A Jade Empire scrollbar widget.
+ */
+
+#include "src/common/system.h"
+
+#include "src/graphics/aurora/guiquad.h"
+
+#include "src/engines/jade/gui/widgets/scrollbar.h"
+
+namespace Engines {
+
+namespace Jade {
+
+WidgetScrollbar::WidgetScrollbar(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag) {
+}
+
+WidgetScrollbar::~WidgetScrollbar() {
+}
+
+void WidgetScrollbar::load(const Aurora::GFF3Struct &gff) {
+	JadeWidget::load(gff);
+}
+
+void WidgetScrollbar::setPosition(float x, float y, float z) {
+	float oX, oY, oZ;
+	getPosition(oX, oY, oZ);
+
+	Widget::setPosition(x, y, z);
+	getPosition(x, y, z);
+
+	if (_quad) {
+		float qX, qY, qZ;
+		_quad->getPosition(qX, qY, qZ);
+		_quad->setPosition(qX - oX + x, qY - oY + y, qZ - oZ + z);
+	}
+
+	if (_border) {
+		float bX, bY, bZ;
+		_border->getPosition(bX, bY, bZ);
+		_border->setPosition(bX - oX + x, bY - oY + y, bZ - oZ + z);
+	}
+
+	if (_upArrow) {
+		float aX, aY, aZ;
+		_upArrow->getPosition(aX, aY, aZ);
+		_upArrow->setPosition(aX - oX + x, aY - oY + y, aZ - oZ + z);
+	}
+
+	if (_downArrow) {
+		float aX, aY, aZ;
+		_downArrow->getPosition(aX, aY, aZ);
+		_downArrow->setPosition(aX - oX + x, aY - oY + y, aZ - oZ + z);
+	}
+
+	if (_thumb) {
+		float tX, tY, tZ;
+		_thumb->getPosition(tX, tY, tZ);
+		_thumb->setPosition(tX - oX + x, tY - oY + y, tZ - oZ + z);
+	}
+}
+
+} // End of namespace Jade
+
+} // End of namespace Engines

--- a/src/engines/jade/gui/widgets/scrollbar.h
+++ b/src/engines/jade/gui/widgets/scrollbar.h
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire scrollbar widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_SCROLLBAR_H
+#define ENGINES_JADE_GUI_WIDGETS_SCROLLBAR_H
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +31,17 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetScrollbar : public JadeWidget {
+public:
+	WidgetScrollbar(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetScrollbar();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void load(const Aurora::GFF3Struct &gff);
+	void setPosition(float x, float y, float z);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_SCROLLBAR_H

--- a/src/engines/jade/gui/widgets/slider.cpp
+++ b/src/engines/jade/gui/widgets/slider.cpp
@@ -19,24 +19,26 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire slider widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#include "src/common/system.h"
 
-#include "src/engines/jade/gui/widgets/jadewidget.h"
+#include "src/engines/jade/gui/widgets/slider.h"
 
 namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
+WidgetSlider::WidgetSlider(::Engines::GUI &gui, const Common::UString &tag) :
+	JadeWidget(gui, tag) {
 }
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
+WidgetSlider::~WidgetSlider() {
+}
+
+void WidgetSlider::load(const Aurora::GFF3Struct &gff) {
+  JadeWidget::load(gff);
 }
 
 } // End of namespace Jade

--- a/src/engines/jade/gui/widgets/slider.h
+++ b/src/engines/jade/gui/widgets/slider.h
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The Jade Empire game info options menu.
+ *  A Jade Empire slider widget.
  */
 
-#include "src/engines/jade/gui/options/feed.h"
+#ifndef ENGINES_JADE_GUI_WIDGETS_SLIDER_H
+#define ENGINES_JADE_GUI_WIDGETS_SLIDER_H
 
 #include "src/engines/jade/gui/widgets/jadewidget.h"
 
@@ -30,15 +31,16 @@ namespace Engines {
 
 namespace Jade {
 
-GameInfoOptionsMenu::GameInfoOptionsMenu(Console *console) : GUI(console) {
-	load("opt_feed");
-}
+class WidgetSlider : public JadeWidget {
+public:
+	WidgetSlider(::Engines::GUI &gui, const Common::UString &tag);
+	~WidgetSlider();
 
-void GameInfoOptionsMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "ButtonCancel")
-		_returnCode = kReturnCodeAbort;
-}
+	void load(const Aurora::GFF3Struct &gff);
+};
 
 } // End of namespace Jade
 
 } // End of namespace Engines
+
+#endif // ENGINES_JADE_GUI_WIDGETS_SLIDER_H


### PR DESCRIPTION
Make Jade Empire use a copy of KotOR GUI, effectively removing the dependency on KotOR engine. This is the first step of the GUI system update I have in mind.