### PR TITLE
KotOR equipment screen update

### DIFF
--- a/src/engines/aurora/kotorjadegui/kotorinventoryitem.cpp
+++ b/src/engines/aurora/kotorjadegui/kotorinventoryitem.cpp
@@ -75,10 +75,24 @@ void KotORInventoryItem::load(const Aurora::GFF3Struct &gff) {
 	_icon.reset(new Graphics::Aurora::GUIQuad("", 0.0f, 0.0f, frameSize, frameSize));
 	_icon->setPosition(x, y + (_height - frameSize) / 2.0f, 0.0f);
 
+	if (_border) {
+		float bX, bY, bZ;
+		_border->getPosition(bX, bY, bZ);
+		_border->setPosition(bX + frameSize, bY, bZ);
+
+		float width, height;
+		_border->getSize(width, height);
+		_border->setSize(width - frameSize, height);
+	}
+
 	if (_text) {
 		float tX, tY, tZ;
 		_text->getPosition(tX, tY, tZ);
 		_text->setPosition(tX + frameSize, tY, tZ);
+		
+		float width = _text->getWidth();
+		float height = _text->getHeight();
+		_text->setSize(width - frameSize, height);
 
 		_text->setVerticalAlign(Graphics::Aurora::kVAlignMiddle);
 

--- a/src/engines/aurora/kotorjadegui/kotorinventoryitem.cpp
+++ b/src/engines/aurora/kotorjadegui/kotorinventoryitem.cpp
@@ -89,7 +89,7 @@ void KotORInventoryItem::load(const Aurora::GFF3Struct &gff) {
 		float tX, tY, tZ;
 		_text->getPosition(tX, tY, tZ);
 		_text->setPosition(tX + frameSize, tY, tZ);
-		
+
 		float width = _text->getWidth();
 		float height = _text->getHeight();
 		_text->setSize(width - frameSize, height);

--- a/src/engines/aurora/kotorjadegui/kotorjadewidget.cpp
+++ b/src/engines/aurora/kotorjadegui/kotorjadewidget.cpp
@@ -373,7 +373,7 @@ void KotORJadeWidget::show() {
 }
 
 void KotORJadeWidget::hide() {
-	if (isInvisible())
+	if (!isVisible())
 		return;
 
 	if (_subScene)

--- a/src/engines/aurora/kotorjadegui/label.cpp
+++ b/src/engines/aurora/kotorjadegui/label.cpp
@@ -31,7 +31,8 @@
 namespace Engines {
 
 WidgetLabel::WidgetLabel(GUI &gui, const Common::UString &tag)
-		: KotORJadeWidget(gui, tag) {
+		: KotORJadeWidget(gui, tag),
+		  _hovered(false) {
 }
 
 WidgetLabel::~WidgetLabel() {
@@ -39,6 +40,22 @@ WidgetLabel::~WidgetLabel() {
 
 void WidgetLabel::load(const Aurora::GFF3Struct &gff) {
 	KotORJadeWidget::load(gff);
+}
+
+bool WidgetLabel::isHovered() const {
+	return _hovered;
+}
+
+void WidgetLabel::enter() {
+	_hovered = true;
+}
+
+void WidgetLabel::leave() {
+	_hovered = false;
+}
+
+void WidgetLabel::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)) {
+	setActive(true);
 }
 
 } // End of namespace Engines

--- a/src/engines/aurora/kotorjadegui/label.h
+++ b/src/engines/aurora/kotorjadegui/label.h
@@ -35,6 +35,15 @@ public:
 	~WidgetLabel();
 
 	void load(const Aurora::GFF3Struct &gff);
+
+	bool isHovered() const;
+
+	void enter();
+	void leave();
+	
+	void mouseUp(uint8 state, float x, float y);
+private:
+	bool _hovered;
 };
 
 } // End of namespace Engines

--- a/src/engines/aurora/kotorjadegui/label.h
+++ b/src/engines/aurora/kotorjadegui/label.h
@@ -40,7 +40,7 @@ public:
 
 	void enter();
 	void leave();
-	
+
 	void mouseUp(uint8 state, float x, float y);
 private:
 	bool _hovered;

--- a/src/engines/aurora/kotorjadegui/listbox.cpp
+++ b/src/engines/aurora/kotorjadegui/listbox.cpp
@@ -81,6 +81,8 @@ void WidgetListBox::setItemType(ListBoxItemType itemType) {
 
 void WidgetListBox::setItemSelectionEnabled(bool itemSelectionEnabled) {
 	_itemSelectionEnabled = itemSelectionEnabled;
+	if (!_itemSelectionEnabled)
+		_selectedIndex = -1;
 }
 
 void WidgetListBox::setAdjustHeight(bool adjustHeight) {
@@ -140,13 +142,6 @@ void WidgetListBox::createItemWidgets(uint32 count) {
 
 		item->load(*_protoItem);
 
-		if (_itemSelectionEnabled)
-			item->setDisableHighlight(true);
-		if (_textColorChanged)
-			item->setTextColor(_textR, _textG, _textB, _textA);
-		if (_borderColorChanged)
-			item->setBorderColor(_borderR, _borderG, _borderB, _borderA);
-
 		addChild(*item);
 		addSub(*item);
 
@@ -203,6 +198,14 @@ void WidgetListBox::refreshItemWidgets() {
 
 		if (visible) {
 			itemWidget->setInvisible(false);
+
+			if (_itemSelectionEnabled)
+				itemWidget->setDisableHighlight(true);
+			if (_textColorChanged)
+				itemWidget->setTextColor(_textR, _textG, _textB, _textA);
+			if (_borderColorChanged)
+				itemWidget->setBorderColor(_borderR, _borderG, _borderB, _borderA);
+
 			if (isVisible())
 				itemWidget->show();
 			++_numVisibleItems;
@@ -341,10 +344,11 @@ void WidgetListBox::positionItemWidgets() {
 		x += _scrollbar->getWidth() + _scrollbar->getBorderDimension();
 
 	y += _height;
+	z -= 1.0f;
 
 	size_t count = _itemWidgets.size();
 	for (size_t i = 0; i < count; ++i) {
-		_itemWidgets[i]->setPosition(x, y -= _itemWidgets[i]->getHeight() + _padding, -1.0f);
+		_itemWidgets[i]->setPosition(x, y -= _itemWidgets[i]->getHeight() + _padding, z);
 	}
 }
 

--- a/src/engines/kotor/console.cpp
+++ b/src/engines/kotor/console.cpp
@@ -31,6 +31,7 @@
 #include "src/common/filepath.h"
 #include "src/common/filelist.h"
 #include "src/common/configman.h"
+#include "src/common/strutil.h"
 
 #include "src/aurora/resman.h"
 
@@ -76,6 +77,8 @@ Console::Console(KotOREngine &engine) :
 			"Usage: listroomsvisiblefrom <room>\nList rooms that are visible from the specified room");
 	registerCommand("playanim"            , boost::bind(&Console::cmdPlayAnim            , this, _1),
 			"Usage: playanim <base> [<head>]\nPlay the specified animations on the active object");
+	registerCommand("additem"             , boost::bind(&Console::cmdAddItem             , this, _1),
+			"Usage: additem <item> [<count>]\nAdd the specified item to the active object");
 
 }
 
@@ -196,6 +199,21 @@ void Console::cmdPlayAnim(const CommandLine &cl) {
 	size_t animCount = anims.size();
 	_engine->getGame().getModule().playAnimationOnActiveObject(anims[0],
 			animCount >= 2 ? anims[1] : "");
+}
+
+void Console::cmdAddItem(const CommandLine &cl) {
+	if (cl.args.empty()) {
+		printCommandHelp(cl.cmd);
+		return;
+	}
+
+	std::vector<Common::UString> args;
+	Common::UString::split(cl.args, ' ', args);
+	int count = 1;
+	if (args.size() >= 2)
+		Common::parseString(args[1], count);
+
+	_engine->getGame().getModule().addItemToActiveObject(args[0], count);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/console.h
+++ b/src/engines/kotor/console.h
@@ -69,6 +69,7 @@ private:
 	void cmdGetPCRoom           (const CommandLine &cl);
 	void cmdListRoomsVisibleFrom(const CommandLine &cl);
 	void cmdPlayAnim            (const CommandLine &cl);
+	void cmdAddItem             (const CommandLine &cl);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -97,6 +97,13 @@ public:
 
 	float getCameraHeight() const;
 
+	// Inventory and equipment
+
+	void equipItem(Common::UString tag, EquipmentSlot slot);
+
+	Inventory &getInventory();
+	const Common::UString getEquipedItem(EquipmentSlot slot) const;
+
 	// Animation
 
 	void playDefaultAnimation();
@@ -121,6 +128,7 @@ private:
 		Common::UString head;
 
 		Common::UString bodyTexture;
+		Common::UString portrait;
 	};
 
 	/** A class level. */
@@ -138,12 +146,18 @@ private:
 
 	Gender _gender;
 	std::vector<ClassLevel> _levels; ///< The levels of the creature.
+	Skin _skin; ///< The skin type of the creature.
+	uint8 _face; ///< The face of the creature.
 
-	Common::ScopedPtr<Graphics::Aurora::Model> _model; ///< The creature's model.
-	Common::UString _conversation;
 	Common::UString _modelType;
+	Common::ScopedPtr<Graphics::Aurora::Model> _model; ///< The creature's model.
+	Graphics::Aurora::Model *_headModel; ///< The creature's head model.
+	bool _visible;
+
+	Common::UString _conversation;
 
 	Inventory _inventory;
+	std::map<EquipmentSlot, Common::UString> _equipment;
 
 
 	void init();
@@ -156,8 +170,11 @@ private:
 	void loadAppearance();
 
 	void getPartModels(PartModels &parts, uint32 state = 'a');
+	void getPartModelsPC(PartModels &parts, uint32 state, uint8 textureVariation);
 	void loadBody(PartModels &parts);
 	void loadHead(PartModels &parts);
+	void changeBody();
+	void changeWeapon(EquipmentSlot slot);
 
 	void setDefaultAnimations();
 };

--- a/src/engines/kotor/gui/ingame/container.cpp
+++ b/src/engines/kotor/gui/ingame/container.cpp
@@ -53,18 +53,30 @@ void ContainerMenu::fillFromInventory(const Inventory &inv) {
 	const std::map<Common::UString, InventoryItem> &invItems = inv.getItems();
 	for (std::map<Common::UString, InventoryItem>::const_iterator i = invItems.begin();
 			i != invItems.end(); ++i) {
-		Item item(i->second.tag);
-		lbItems->addItem(Common::UString::format("%s|%s|%u",
-		                                         item.getName().c_str(),
-		                                         item.getIcon().c_str(),
-		                                         i->second.count));
+		try {
+			Item item(i->second.tag);
+			lbItems->addItem(Common::UString::format("%s|%s|%u",
+			                                         item.getName().c_str(),
+			                                         item.getIcon().c_str(),
+			                                         i->second.count));
+		} catch (Common::Exception &e) {
+			e.add("Failed to load item %s", i->second.tag.c_str());
+			Common::printException(e, "WARNING: ");
+		}
 	}
 
 	lbItems->refreshItemWidgets();
 }
 
 void ContainerMenu::callbackActive(Widget &widget) {
-	if (widget.getTag() == "BTN_CANCEL") {
+	const Common::UString &tag = widget.getTag();
+
+	if (tag == "BTN_OK") {
+		_returnCode = 1;
+		return;
+	}
+
+	if (tag == "BTN_CANCEL") {
 		_returnCode = kReturnCodeAbort;
 		return;
 	}

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -36,7 +36,9 @@ namespace Engines {
 namespace KotOR {
 
 HUD::HUD(Module &module, Engines::Console *console)
-		: GUI(console), _menu(module, console) {
+		: GUI(console),
+		  _module(&module),
+		  _menu(module, console) {
 	unsigned int wWidth = WindowMan.getWindowWidth();
 	unsigned int wHeight = WindowMan.getWindowHeight();
 
@@ -152,7 +154,18 @@ void HUD::setPosition(float x, float y) {
 void HUD::showContainer(Inventory &inv) {
 	_container.reset(new ContainerMenu());
 	_container->fillFromInventory(inv);
-	sub(*_container, kStartCodeNone, true, false);
+
+	if (sub(*_container, kStartCodeNone, true, false) == 1) {
+		Inventory &partyInventory = _module->getPC()->getInventory();
+
+		const std::map<Common::UString, InventoryItem> &items = inv.getItems();
+		for (std::map<Common::UString, InventoryItem>::const_iterator i = items.begin();
+				i != items.end(); ++i) {
+			partyInventory.addItem(i->first, i->second.count);
+		}
+
+		inv.removeAllItems();
+	}
 }
 
 void HUD::setPortrait(uint8 n, bool visible, const Common::UString &portrait) {

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -63,6 +63,7 @@ public:
 	void setPartyMember2(Creature *creature);
 
 private:
+	Module *_module;
 	Menu _menu;
 	Common::ScopedPtr<ContainerMenu> _container;
 

--- a/src/engines/kotor/gui/ingame/menu.cpp
+++ b/src/engines/kotor/gui/ingame/menu.cpp
@@ -144,6 +144,8 @@ void Menu::showEquipment() {
 		_protoEqu->setHighlight(true);
 		_lastProto = _protoEqu;
 	}
+
+	_menuEqu->setPC(_module.getPC());
 }
 
 void Menu::showInventory() {

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -22,7 +22,16 @@
  *  The ingame equipment menu.
  */
 
-#include "src/engines/aurora/widget.h"
+#include "src/aurora/talkman.h"
+
+#include "src/graphics/graphics.h"
+
+#include "src/engines/aurora/kotorjadegui/button.h"
+#include "src/engines/aurora/kotorjadegui/label.h"
+#include "src/engines/aurora/kotorjadegui/listbox.h"
+
+#include "src/engines/kotor/item.h"
+#include "src/engines/kotor/creature.h"
 
 #include "src/engines/kotor/gui/ingame/menu_equ.h"
 
@@ -30,15 +39,404 @@ namespace Engines {
 
 namespace KotOR {
 
-MenuEquipment::MenuEquipment(Console *console) : GUI(console) {
+MenuEquipment::MenuEquipment(Console *console)
+		: GUI(console),
+		  _pc(0),
+		  _selectedSlot(kEquipmentSlotBody),
+		  _slotFixated(false) {
 	load("equip");
+
+	getListBox("LB_DESC")->setInvisible(true);
+	getLabel("LBL_CANTEQUIP")->setInvisible(true);
+	getLabel("LBL_SLOTNAME")->setText(getSlotName(kEquipmentSlotBody));
+
+	WidgetListBox *lbItems = getListBox("LB_ITEMS");
+	lbItems->setItemType(kLBItemTypeKotORInventory);
+	lbItems->setHideScrollbar(false);
+	lbItems->setPadding(6);
+	lbItems->setItemBorderColor(0.0f, 0.0f, 0.0f, 0.0f);
+	lbItems->createItemWidgets(5);
+}
+
+void MenuEquipment::setPC(Creature *pc) {
+	_pc = pc;
+
+	fillEquipedItems();
+	fillEquipableItemsList();
+}
+
+void MenuEquipment::show() {
+	GUI::show();
+
+	if (_selectedSlot != kEquipmentSlotNone)
+		getSlotButton(_selectedSlot)->setHighlight(true);
+}
+
+void MenuEquipment::hide() {
+	if (_selectedSlot != kEquipmentSlotNone)
+		getSlotButton(_selectedSlot)->setHighlight(false);
+
+	GUI::hide();
+}
+
+void MenuEquipment::callbackRun() {
+	EquipmentSlot newSlot;
+
+	if (getLabel("LBL_INV_IMPLANT")->isHovered())
+		newSlot = kEquipmentSlotImplant;
+	else if (getLabel("LBL_INV_HEAD")->isHovered())
+		newSlot = kEquipmentSlotHead;
+	else if (getLabel("LBL_INV_HANDS")->isHovered())
+		newSlot = kEquipmentSlotHands;
+	else if (getLabel("LBL_INV_ARM_L")->isHovered())
+		newSlot = kEquipmentSlotArmL;
+	else if (getLabel("LBL_INV_BODY")->isHovered())
+		newSlot = kEquipmentSlotBody;
+	else if (getLabel("LBL_INV_ARM_R")->isHovered())
+		newSlot = kEquipmentSlotArmR;
+	else if (getLabel("LBL_INV_WEAP_L")->isHovered())
+		newSlot = kEquipmentSlotWeaponL;
+	else if (getLabel("LBL_INV_BELT")->isHovered())
+		newSlot = kEquipmentSlotBelt;
+	else if (getLabel("LBL_INV_WEAP_R")->isHovered())
+		newSlot = kEquipmentSlotWeaponR;
+	else
+		return;
+
+	if (newSlot != _selectedSlot) {
+		if (_selectedSlot != kEquipmentSlotNone)
+			getSlotButton(_selectedSlot)->setHighlight(false);
+
+		_selectedSlot = newSlot;
+		getSlotButton(_selectedSlot)->setHighlight(true);
+		getLabel("LBL_SLOTNAME")->setText(getSlotName(_selectedSlot));
+		fillEquipableItemsList();
+	}
 }
 
 void MenuEquipment::callbackActive(Widget &widget) {
-	if (widget.getTag() == "BTN_BACK") {
-		_returnCode = 1;
-		return;
+	const Common::UString &tag = widget.getTag();
+	if (_slotFixated) {
+		if (tag == "BTN_EQUIP") {
+			int selectedIndex = getListBox("LB_ITEMS")->getSelectedIndex();
+			Common::UString itemTag = selectedIndex > 0 ? _visibleItems[selectedIndex - 1] : "";
+			_pc->equipItem(itemTag, _selectedSlot);
+
+			fillEquipedItems();
+			fillEquipableItemsList();
+
+			fixateOnSlot(false);
+			return;
+		}
+		if (tag == "BTN_BACK") {
+			fixateOnSlot(false);
+			return;
+		}
+	} else {
+		if (tag == "BTN_BACK") {
+			_returnCode = 1;
+			return;
+		}
+		if (tag.beginsWith("LBL_INV_")) {
+			fixateOnSlot(true);
+			return;
+		}
 	}
+}
+
+void MenuEquipment::callbackKeyInput(const Events::Key &key, const Events::EventType &type) {
+	if (type == Events::kEventKeyDown) {
+		switch (key) {
+			case Events::kKeyUp:
+				getListBox("LB_ITEMS")->selectPreviousItem();
+				break;
+			case Events::kKeyDown:
+				getListBox("LB_ITEMS")->selectNextItem();
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+void MenuEquipment::fillEquipedItems() {
+	Common::UString implant = getItemIcon(_pc->getEquipedItem(kEquipmentSlotImplant));
+	Common::UString head = getItemIcon(_pc->getEquipedItem(kEquipmentSlotHead));
+	Common::UString hands = getItemIcon(_pc->getEquipedItem(kEquipmentSlotHands));
+	Common::UString armL = getItemIcon(_pc->getEquipedItem(kEquipmentSlotArmL));
+	Common::UString body = getItemIcon(_pc->getEquipedItem(kEquipmentSlotBody));
+	Common::UString armR = getItemIcon(_pc->getEquipedItem(kEquipmentSlotArmR));
+	Common::UString weapL = getItemIcon(_pc->getEquipedItem(kEquipmentSlotWeaponL));
+	Common::UString belt = getItemIcon(_pc->getEquipedItem(kEquipmentSlotBelt));
+	Common::UString weapR = getItemIcon(_pc->getEquipedItem(kEquipmentSlotWeaponR));
+
+	getLabel("LBL_INV_IMPLANT")->setFill(implant.empty() ? "iimplant" : implant);
+	getLabel("LBL_INV_HEAD")->setFill(head.empty() ? "ihead" : head);
+	getLabel("LBL_INV_HANDS")->setFill(hands.empty() ? "ihands" : hands);
+	getLabel("LBL_INV_ARM_L")->setFill(armL.empty() ? "iforearm_l" : armL);
+	getLabel("LBL_INV_BODY")->setFill(body.empty() ? "iarmor" : body);
+	getLabel("LBL_INV_ARM_R")->setFill(armR.empty() ? "iforearm_r" : armR);
+	getLabel("LBL_INV_WEAP_L")->setFill(weapL.empty() ? "iweap_l" : weapL);
+	getLabel("LBL_INV_BELT")->setFill(belt.empty() ? "ibelt" : belt);
+	getLabel("LBL_INV_WEAP_R")->setFill(weapR.empty() ? "iweap_r" : weapR);
+}
+
+Common::UString MenuEquipment::getItemIcon(const Common::UString &tag) const {
+	if (tag.empty())
+		return "";
+
+	Common::UString icon;
+
+	try {
+		Item item(tag);
+		icon = item.getIcon();
+	} catch (Common::Exception &e) {
+		e.add("Failed to load item %s", tag.c_str());
+		Common::printException(e, "WARNING: ");
+	}
+
+	return icon;
+}
+
+void MenuEquipment::fillEquipableItemsList() {
+	Inventory &inv = _pc->getInventory();
+
+	WidgetListBox *lbItems = getListBox("LB_ITEMS");
+	lbItems->removeAllItems();
+	lbItems->addItem("None|inone|1");
+
+	_visibleItems.clear();
+
+	const std::map<Common::UString, InventoryItem> &invItems = inv.getItems();
+	for (std::map<Common::UString, InventoryItem>::const_iterator i = invItems.begin();
+			i != invItems.end(); ++i) {
+		try {
+			Item item(i->second.tag);
+			if ((item.getEquipableSlots() & _selectedSlot) == 0)
+				continue;
+
+			lbItems->addItem(Common::UString::format("%s|%s|%u",
+			                                         item.getName().c_str(),
+			                                         item.getIcon().c_str(),
+			                                         i->second.count));
+
+			_visibleItems.push_back(i->second.tag);
+		} catch (Common::Exception &e) {
+			e.add("Failed to load item %s", i->second.tag.c_str());
+			Common::printException(e, "WARNING: ");
+		}
+	}
+
+	GfxMan.lockFrame();
+	lbItems->refreshItemWidgets();
+	GfxMan.unlockFrame();
+}
+
+EquipmentSlot MenuEquipment::getSlotByWidgetTag(const Common::UString &tag) const {
+	if (tag == "LBL_INV_IMPLANT")
+		return kEquipmentSlotImplant;
+	if (tag == "LBL_INV_BODY")
+		return kEquipmentSlotBody;
+	if (tag == "LBL_INV_HANDS")
+		return kEquipmentSlotHands;
+	if (tag == "LBL_INV_ARM_R")
+		return kEquipmentSlotArmR;
+	if (tag == "LBL_INV_BODY")
+		return kEquipmentSlotBody;
+	if (tag == "LBL_INV_ARM_L")
+		return kEquipmentSlotArmL;
+	if (tag == "LBL_INV_WEAP_R")
+		return kEquipmentSlotWeaponR;
+	if (tag == "LBL_INV_BELT")
+		return kEquipmentSlotBelt;
+	if (tag == "LBL_INV_WEAP_L")
+		return kEquipmentSlotWeaponL;
+
+	return kEquipmentSlotNone;
+}
+
+WidgetButton *MenuEquipment::getSlotButton(EquipmentSlot slot) {
+	switch (slot) {
+		case kEquipmentSlotImplant:
+			return getButton("BTN_INV_IMPLANT");
+		case kEquipmentSlotHead:
+			return getButton("BTN_INV_HEAD");
+		case kEquipmentSlotHands:
+			return getButton("BTN_INV_HANDS");
+		case kEquipmentSlotArmR:
+			return getButton("BTN_INV_ARM_R");
+		case kEquipmentSlotBody:
+			return getButton("BTN_INV_BODY");
+		case kEquipmentSlotArmL:
+			return getButton("BTN_INV_ARM_L");
+		case kEquipmentSlotWeaponR:
+			return getButton("BTN_INV_WEAP_R");
+		case kEquipmentSlotBelt:
+			return getButton("BTN_INV_BELT");
+		case kEquipmentSlotWeaponL:
+			return getButton("BTN_INV_WEAP_L");
+		default:
+			return 0;
+	}
+}
+
+Common::UString MenuEquipment::getSlotName(EquipmentSlot slot) const {
+	switch (slot) {
+		case kEquipmentSlotImplant:
+			return TalkMan.getString(31388); // Implant
+		case kEquipmentSlotHead:
+			return TalkMan.getString(31375); // Head
+		case kEquipmentSlotHands:
+			return TalkMan.getString(31383); // Hands
+		case kEquipmentSlotArmR:
+			return TalkMan.getString(31377); // Right Arm
+		case kEquipmentSlotBody:
+			return TalkMan.getString(31380); // Body
+		case kEquipmentSlotArmL:
+			return TalkMan.getString(31376); // Left Arm
+		case kEquipmentSlotWeaponR:
+			return TalkMan.getString(31379); // Right Weapon
+		case kEquipmentSlotBelt:
+			return TalkMan.getString(31382); // Belt
+		case kEquipmentSlotWeaponL:
+			return TalkMan.getString(31378); // Left Weapon
+		default:
+			return "";
+	}
+}
+
+void MenuEquipment::fixateOnSlot(bool fixate) {
+	_slotFixated = fixate;
+
+	WidgetListBox *lbDesc = getListBox("LB_DESC");
+
+	WidgetButton *btnInvImplant = getButton("BTN_INV_IMPLANT");
+	WidgetButton *btnInvHead = getButton("BTN_INV_HEAD");
+	WidgetButton *btnInvHands = getButton("BTN_INV_HANDS");
+	WidgetButton *btnInvArmL = getButton("BTN_INV_ARM_L");
+	WidgetButton *btnInvBody = getButton("BTN_INV_BODY");
+	WidgetButton *btnInvArmR = getButton("BTN_INV_ARM_R");
+	WidgetButton *btnInvWeapL = getButton("BTN_INV_WEAP_L");
+	WidgetButton *btnInvBelt = getButton("BTN_INV_BELT");
+	WidgetButton *btnInvWeapR = getButton("BTN_INV_WEAP_R");
+
+	WidgetLabel *lblInvImplant = getLabel("LBL_INV_IMPLANT");
+	WidgetLabel *lblInvHead = getLabel("LBL_INV_HEAD");
+	WidgetLabel *lblInvHands = getLabel("LBL_INV_HANDS");
+	WidgetLabel *lblInvArmL = getLabel("LBL_INV_ARM_L");
+	WidgetLabel *lblInvBody = getLabel("LBL_INV_BODY");
+	WidgetLabel *lblInvArmR = getLabel("LBL_INV_ARM_R");
+	WidgetLabel *lblInvWeapL = getLabel("LBL_INV_WEAP_L");
+	WidgetLabel *lblInvBelt = getLabel("LBL_INV_BELT");
+	WidgetLabel *lblInvWeapR = getLabel("LBL_INV_WEAP_R");
+
+	WidgetLabel *lblTxtBar = getLabel("LBL_TXTBAR");
+	WidgetLabel *lblSlotName = getLabel("LBL_SLOTNAME");
+	WidgetLabel *lblPortBord = getLabel("LBL_PORT_BORD");
+	WidgetLabel *lblPortrait = getLabel("LBL_PORTRAIT");
+
+	WidgetListBox *lbItems = getListBox("LB_ITEMS");
+	WidgetButton *btnBack = getButton("BTN_BACK");
+
+	lbDesc->setInvisible(!_slotFixated);
+
+	btnInvImplant->setInvisible(_slotFixated);
+	btnInvHead->setInvisible(_slotFixated);
+	btnInvHands->setInvisible(_slotFixated);
+	btnInvArmL->setInvisible(_slotFixated);
+	btnInvBody->setInvisible(_slotFixated);
+	btnInvArmR->setInvisible(_slotFixated);
+	btnInvWeapL->setInvisible(_slotFixated);
+	btnInvBelt->setInvisible(_slotFixated);
+	btnInvWeapR->setInvisible(_slotFixated);
+
+	lblInvImplant->setInvisible(_slotFixated);
+	lblInvHead->setInvisible(_slotFixated);
+	lblInvHands->setInvisible(_slotFixated);
+	lblInvArmL->setInvisible(_slotFixated);
+	lblInvBody->setInvisible(_slotFixated);
+	lblInvArmR->setInvisible(_slotFixated);
+	lblInvWeapL->setInvisible(_slotFixated);
+	lblInvBelt->setInvisible(_slotFixated);
+	lblInvWeapR->setInvisible(_slotFixated);
+
+	lblTxtBar->setInvisible(_slotFixated);
+	lblSlotName->setInvisible(_slotFixated);
+	lblPortBord->setInvisible(_slotFixated);
+	lblPortrait->setInvisible(_slotFixated);
+
+	if (_slotFixated) {
+		lbDesc->show();
+
+		getSlotButton(_selectedSlot)->setHighlight(false);
+
+		btnInvImplant->hide();
+		btnInvHead->hide();
+		btnInvHands->hide();
+		btnInvArmL->hide();
+		btnInvBody->hide();
+		btnInvArmR->hide();
+		btnInvWeapL->hide();
+		btnInvBelt->hide();
+		btnInvWeapR->hide();
+
+		lblInvImplant->hide();
+		lblInvHead->hide();
+		lblInvHands->hide();
+		lblInvArmL->hide();
+		lblInvBody->hide();
+		lblInvArmR->hide();
+		lblInvWeapL->hide();
+		lblInvBelt->hide();
+		lblInvWeapR->hide();
+
+		lblTxtBar->hide();
+		lblSlotName->hide();
+		lblPortBord->hide();
+		lblPortrait->hide();
+
+		lbItems->setItemSelectionEnabled(true);
+		lbItems->setItemBorderColor(0.0f, 0.648438f, 0.968750f, 1.0f);
+		lbItems->selectItemByWidgetTag("LB_ITEMS_ITEM_0");
+
+		btnBack->setText(TalkMan.getString(1581));
+	} else {
+		lbDesc->hide();
+
+		btnInvImplant->show();
+		btnInvHead->show();
+		btnInvHands->show();
+		btnInvArmL->show();
+		btnInvBody->show();
+		btnInvArmR->show();
+		btnInvWeapL->show();
+		btnInvBelt->show();
+		btnInvWeapR->show();
+
+		getSlotButton(_selectedSlot)->setHighlight(true);
+
+		lblInvImplant->show();
+		lblInvHead->show();
+		lblInvHands->show();
+		lblInvArmL->show();
+		lblInvBody->show();
+		lblInvArmR->show();
+		lblInvWeapL->show();
+		lblInvBelt->show();
+		lblInvWeapR->show();
+
+		lblTxtBar->show();
+		lblSlotName->show();
+		lblPortBord->show();
+		lblPortrait->show();
+
+		lbItems->setItemSelectionEnabled(false);
+		lbItems->setItemBorderColor(0.0f, 0.0f, 0.0f, 0.0f);
+
+		btnBack->setText(TalkMan.getString(1582));
+	}
+
+	lbItems->refreshItemWidgets();
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/menu_equ.h
+++ b/src/engines/kotor/gui/ingame/menu_equ.h
@@ -29,14 +29,40 @@
 
 namespace Engines {
 
+class WidgetButton;
+class WidgetLabel;
+
 namespace KotOR {
+
+class Creature;
 
 class MenuEquipment : public GUI {
 public:
 	MenuEquipment(::Engines::Console *console = 0);
 
+	void setPC(Creature *pc);
+
+	void show();
+	void hide();
+
 protected:
+	void callbackRun();
 	void callbackActive(Widget &widget);
+	void callbackKeyInput(const Events::Key &key, const Events::EventType &type);
+
+private:
+	Creature *_pc;
+	EquipmentSlot _selectedSlot;
+	bool _slotFixated;
+	std::vector<Common::UString> _visibleItems;
+
+	void fillEquipedItems();
+	Common::UString getItemIcon(const Common::UString &tag) const;
+	void fillEquipableItemsList();
+	EquipmentSlot getSlotByWidgetTag(const Common::UString &tag) const;
+	WidgetButton *getSlotButton(EquipmentSlot slot);
+	Common::UString getSlotName(EquipmentSlot slot) const;
+	void fixateOnSlot(bool fixate);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/inventory.cpp
+++ b/src/engines/kotor/inventory.cpp
@@ -54,6 +54,10 @@ void Inventory::removeItem(const Common::UString &tag, int count) {
 		_items.erase(i);
 }
 
+void Inventory::removeAllItems() {
+	_items.clear();
+}
+
 const std::map<Common::UString, InventoryItem> &Inventory::getItems() const {
 	return _items;
 }

--- a/src/engines/kotor/inventory.h
+++ b/src/engines/kotor/inventory.h
@@ -42,6 +42,7 @@ class Inventory {
 public:
 	void addItem(const Common::UString &tag, int count = 1);
 	void removeItem(const Common::UString &tag, int count = 1);
+	void removeAllItems();
 
 	const std::map<Common::UString, InventoryItem> &getItems() const;
 	bool hasItem(const Common::UString &tag) const;

--- a/src/engines/kotor/item.cpp
+++ b/src/engines/kotor/item.cpp
@@ -49,15 +49,30 @@ void Item::load(const Aurora::GFF3Struct &gff) {
 
 	// Base item
 	_baseItem = gff.getSint("BaseItem");
-	_itemClass = TwoDAReg.get2DA("baseitems").getRow(_baseItem).getString("itemclass");
+	const Aurora::TwoDARow &twoDA = TwoDAReg.get2DA("baseitems").getRow(_baseItem);
+	_equipableSlots = static_cast<EquipmentSlot>(twoDA.getInt("equipableslots"));
+	_itemClass = twoDA.getString("itemclass");
 
-	// Model and texture variation
+	// Model, body and texture variations
 	_modelVariation = gff.getSint("ModelVariation");
-	_textureVariation = gff.getSint("TextureVariation");
+	_bodyVariation = gff.getSint("BodyVariation");
+	_textureVariation = gff.getSint("TextureVar");
 }
 
 const Common::UString &Item::getName() const {
 	return _name;
+}
+
+EquipmentSlot Item::getEquipableSlots() const {
+	return _equipableSlots;
+}
+
+int Item::getBodyVariation() const {
+	return _bodyVariation;
+}
+
+int Item::getTextureVariation() const {
+	return _textureVariation;
 }
 
 const Common::UString Item::getIcon() const {
@@ -65,6 +80,10 @@ const Common::UString Item::getIcon() const {
 	if (variation == 0)
 		variation = 1;
 	return Common::UString::format("i%s_%03d", _itemClass.c_str(), variation);
+}
+
+const Common::UString Item::getModelName() const {
+	return Common::UString::format("%s_%03d", _itemClass.c_str(), _modelVariation);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/item.h
+++ b/src/engines/kotor/item.h
@@ -36,13 +36,20 @@ public:
 	Item(const Common::UString &item);
 
 	const Common::UString &getName() const;
+	EquipmentSlot getEquipableSlots() const;
+
+	int getBodyVariation() const;
+	int getTextureVariation() const;
 	const Common::UString getIcon() const;
+	const Common::UString getModelName() const;
 
 private:
 	int _baseItem;
 	Common::UString _itemClass;
+	EquipmentSlot _equipableSlots;
 
 	int _modelVariation;
+	int _bodyVariation;
 	int _textureVariation;
 
 	void load(const Aurora::GFF3Struct &gff);

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -887,6 +887,34 @@ void Module::playAnimationOnActiveObject(const Common::UString &baseAnim,
 	}
 }
 
+void Module::addItemToActiveObject(const Common::UString &item, int count) {
+	Inventory *inv = 0;
+
+	KotOR::Object *o = _area->getActiveObject();
+	if (!o) {
+		if (_pc)
+			inv = &_pc->getInventory();
+	} else {
+		Placeable *placeable = ObjectContainer::toPlaceable(o);
+		if (placeable && placeable->hasInventory())
+			inv = &placeable->getInventory();
+
+		if (!inv) {
+			Creature *creature = ObjectContainer::toCreature(o);
+			if (creature)
+				inv = &creature->getInventory();
+		}
+	}
+
+	if (!inv)
+		return;
+
+	if (count > 0)
+		inv->addItem(item, count);
+	else if (count < 0)
+		inv->removeItem(item, -count);
+}
+
 void Module::stopCameraMovement() {
 	SatelliteCam.clearInput();
 }

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -172,6 +172,8 @@ public:
 	void playAnimationOnActiveObject(const Common::UString &baseAnim,
 	                                 const Common::UString &headAnim);
 
+	void addItemToActiveObject(const Common::UString &item, int count);
+
 private:
 	enum ActionType {
 		kActionNone   = 0,

--- a/src/engines/kotor/types.h
+++ b/src/engines/kotor/types.h
@@ -152,6 +152,19 @@ enum SubRace {
 	kSubRaceWookie
 };
 
+enum EquipmentSlot {
+	kEquipmentSlotNone    = 0,
+	kEquipmentSlotHead    = 1U << 0,
+	kEquipmentSlotBody    = 1U << 1,
+	kEquipmentSlotHands   = 1U << 3,
+	kEquipmentSlotWeaponR = 1U << 4,
+	kEquipmentSlotWeaponL = 1U << 5,
+	kEquipmentSlotArmR    = 1U << 7,
+	kEquipmentSlotArmL    = 1U << 8,
+	kEquipmentSlotImplant = 1U << 9,
+	kEquipmentSlotBelt    = 1U << 10
+};
+
 } // End of namespace KotOR
 
 } // End of namespace Engines

--- a/src/graphics/aurora/model.cpp
+++ b/src/graphics/aurora/model.cpp
@@ -480,13 +480,17 @@ const std::list<ModelNode *> &Model::getNodes() {
 void Model::attachModel(const Common::UString &nodeName, Model *model) {
 	ModelNode *node = getNode(nodeName);
 	if (node) {
-		node->_attachedModel = model;
-		createBound();
-
 		std::map<Common::UString, Model *>::iterator m = _attachedModels.find(nodeName);
-		if (m != _attachedModels.end())
+		if (m != _attachedModels.end()) {
 			_attachedModels.erase(m);
-		_attachedModels.insert(std::pair<Common::UString, Model *>(nodeName, model));
+		}
+
+		node->_attachedModel = model;
+
+		if (model)
+			_attachedModels.insert(std::pair<Common::UString, Model *>(nodeName, model));
+
+		createBound();
 	}
 }
 


### PR DESCRIPTION
This PR:
1. Adds console command to modify inventory of creatures and placeables.
2. Partly implements equipment screen functionality: equipment slot selection, party inventory display, fixation on equipment slot.
