### PR TITLE
AURORA: GFF3Writer

### DIFF
--- a/src/aurora/gff3writer.cpp
+++ b/src/aurora/gff3writer.cpp
@@ -1,0 +1,466 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Writer for writing version 3.x of biowares GFF (general file format).
+ */
+
+#include <algorithm>
+
+#include <boost/make_shared.hpp>
+
+#include "src/common/writestream.h"
+#include "src/common/memreadstream.h"
+
+#include "src/aurora/gff3writer.h"
+
+namespace Aurora {
+
+GFF3Writer::GFF3Writer(uint32 id, uint32 version) : _id(id), _version(version) {
+	_structs.push_back(boost::make_shared<GFF3WriterStruct>(this));
+}
+
+GFF3WriterStructPtr GFF3Writer::getTopLevelStruct() {
+	return _structs[0];
+}
+
+void GFF3Writer::write(Common::WriteStream &stream) {
+	stream.writeUint32BE(_id);
+	stream.writeUint32BE(_version);
+
+	uint32 structOffset = 56; // id + version + header.
+	uint32 structCount = static_cast<uint32>(_structs.size());
+
+	uint32 fieldOffset = structOffset + structCount * 12;
+	uint32 fieldCount = static_cast<uint32>(_fields.size());
+
+	uint32 labelOffset = fieldOffset + fieldCount * 12;
+	uint32 labelCount = static_cast<uint32>(_labels.size());
+
+	uint32 fieldDataOffset = labelOffset + labelCount * 16;
+	uint32 fieldDataCount = 0;
+
+	// Count the total size of field data.
+	for (size_t i = 0; i < _fields.size(); ++i)
+		fieldDataCount += getFieldDataSize(_fields[i]);
+
+	uint32 fieldIndicesOffset = fieldDataOffset + fieldDataCount;
+	uint32 fieldIndicesCount = 0;
+
+	// Count all fields of structs with more than one field.
+	for (size_t i = 0; i < _structs.size(); ++i) {
+		const GFF3WriterStructPtr strct = _structs[i];
+		if (strct->getFieldCount() <= 1)
+			continue;
+
+		fieldIndicesCount += strct->getFieldCount() * 4;
+	}
+
+	uint32 listIndicesOffset = fieldIndicesOffset + fieldIndicesCount;
+	uint32 listIndicesCount = 0;
+
+	// Count all lists elements plus their size as int.
+	for (size_t i = 0; i < _lists.size(); ++i) {
+		listIndicesCount += (_lists[i]->getSize() + 1) * 4;
+	}
+
+	// Write the header.
+	stream.writeUint32LE(structOffset);
+	stream.writeUint32LE(structCount);
+	stream.writeUint32LE(fieldOffset);
+	stream.writeUint32LE(fieldCount);
+	stream.writeUint32LE(labelOffset);
+	stream.writeUint32LE(labelCount);
+	stream.writeUint32LE(fieldDataOffset);
+	stream.writeUint32LE(fieldDataCount);
+	stream.writeUint32LE(fieldIndicesOffset);
+	stream.writeUint32LE(fieldIndicesCount);
+	stream.writeUint32LE(listIndicesOffset);
+	stream.writeUint32LE(listIndicesCount);
+
+	// Write structs data.
+	size_t structFieldIndicesIndex = 0;
+	for (size_t i = 0; i < _structs.size(); ++i) {
+		GFF3WriterStructPtr strct = _structs[i];
+
+		// Struct Id.
+		stream.writeUint32LE(strct->getId());
+
+		// Field Index.
+		if (strct->getFieldCount() > 1) {
+			stream.writeUint32LE(structFieldIndicesIndex * 4);
+			structFieldIndicesIndex += strct->getFieldCount();
+		} else {
+			if (strct->getFieldCount() != 0)
+				stream.writeUint32LE(strct->_fieldIndices[0]);
+			else
+				stream.writeUint32LE(0);
+		}
+
+		// Field Count.
+		stream.writeUint32LE(strct->getFieldCount());
+	}
+
+	// Write fields.
+	size_t fieldDataIndex = 0;
+	size_t listDataIndex = 0;
+	for (size_t i = 0; i < _fields.size(); ++i) {
+		FieldPtr field = _fields[i];
+		stream.writeUint32LE(field->type);
+		stream.writeUint32LE(field->labelIndex);
+
+		/*
+		 * Determine if this field has simple values (less equal 32 bit) which are written in the field
+		 * or complex values, bigger than 32bit like strings written in the field data section.
+		 */
+		const bool simple =
+			field->type == GFF3Struct::kFieldTypeByte ||
+			field->type == GFF3Struct::kFieldTypeChar ||
+			field->type == GFF3Struct::kFieldTypeUint16 ||
+			field->type == GFF3Struct::kFieldTypeUint32 ||
+			field->type == GFF3Struct::kFieldTypeStruct ||
+			field->type == GFF3Struct::kFieldTypeSint16 ||
+			field->type == GFF3Struct::kFieldTypeSint32 ||
+			field->type == GFF3Struct::kFieldTypeFloat ||
+			field->type == GFF3Struct::kFieldTypeList;
+
+		if (simple) {
+			// If the values are simple (less equal 4 bytes) write them to the field.
+			switch (field->type) {
+				case GFF3Struct::kFieldTypeByte:
+				case GFF3Struct::kFieldTypeUint16:
+				case GFF3Struct::kFieldTypeUint32:
+				case GFF3Struct::kFieldTypeStruct:
+					stream.writeUint32LE(field->uint32Value);
+					break;
+				case GFF3Struct::kFieldTypeList:
+					stream.writeUint32LE(listDataIndex * 4);
+					listDataIndex += 1 + _lists[field->uint32Value]->getSize();
+					break;
+				case GFF3Struct::kFieldTypeChar:
+				case GFF3Struct::kFieldTypeSint16:
+				case GFF3Struct::kFieldTypeSint32:
+					stream.writeSint32LE(field->int32Value);
+					break;
+				case GFF3Struct::kFieldTypeFloat:
+					stream.writeIEEEFloatLE(field->floatValue);
+					break;
+				default:
+					throw Common::Exception("Invalid Field type");
+			}
+		} else {
+			// If the values are complex (greater then 4 bytes) write the index to the field data.
+			stream.writeUint32LE(fieldDataIndex);
+			fieldDataIndex += getFieldDataSize(field);
+		}
+	}
+
+	// Write labels.
+	for (size_t i = 0; i < _labels.size(); ++i) {
+		const Common::UString &label = _labels[i];
+		stream.write(label.c_str(), MIN<size_t>(label.size(), 16));
+		stream.writeZeros(16 - MIN<size_t>(label.size(), 16));
+	}
+
+	// Write field data.
+	for (size_t i = 0; i < _fields.size(); ++i) {
+		FieldPtr field = _fields[i];
+		switch (field->type) {
+			case GFF3Struct::kFieldTypeUint64:
+				stream.writeUint64LE(field->uint64Value);
+				break;
+			case GFF3Struct::kFieldTypeSint64:
+				stream.writeSint64LE(field->int64Value);
+				break;
+			case GFF3Struct::kFieldTypeDouble:
+				stream.writeIEEEDoubleLE(field->doubleValue);
+				break;
+			case GFF3Struct::kFieldTypeStrRef:
+				stream.writeUint32LE(4);
+				stream.writeUint32LE(field->uint32Value);
+				break;
+			case GFF3Struct::kFieldTypeResRef:
+				stream.writeByte(MIN(static_cast<byte>(16), static_cast<byte>(field->stringValue.size())));
+				stream.write(field->stringValue.c_str(), MIN<size_t>(field->stringValue.size(), 16));
+				break;
+			case GFF3Struct::kFieldTypeExoString:
+				stream.writeUint32LE(static_cast<uint32>(field->stringValue.size()));
+				stream.writeString(field->stringValue);
+				break;
+			case GFF3Struct::kFieldTypeLocString:
+				stream.writeUint32LE(field->locStringValue.getWrittenSize() + 8);
+				stream.writeUint32LE(field->locStringValue.getID());
+				stream.writeUint32LE(field->locStringValue.getNumStrings());
+				field->locStringValue.writeLocString(stream);
+				break;
+			case GFF3Struct::kFieldTypeVoid:
+				stream.writeUint32LE(static_cast<uint32>(field->voidSize));
+				stream.write(field->voidData.get(), field->voidSize);
+				break;
+			case GFF3Struct::kFieldTypeVector:
+				stream.writeIEEEFloatLE(field->vectorValue.x);
+				stream.writeIEEEFloatLE(field->vectorValue.y);
+				stream.writeIEEEFloatLE(field->vectorValue.z);
+				break;
+			case GFF3Struct::kFieldTypeOrientation:
+				stream.writeIEEEFloatLE(field->vectorValue.x);
+				stream.writeIEEEFloatLE(field->vectorValue.y);
+				stream.writeIEEEFloatLE(field->vectorValue.z);
+				stream.writeIEEEFloatLE(field->vectorValue.w);
+				break;
+			default:
+				break;
+		}
+	}
+
+	// Write field indices of every struct with more than one field.
+	for (size_t i = 0; i < _structs.size(); ++i) {
+		GFF3WriterStructPtr strct = _structs[i];
+		if (strct->getFieldCount() <= 1)
+			continue;
+
+		for (size_t j = 0; j < strct->getFieldCount(); ++j) {
+			stream.writeUint32LE(strct->_fieldIndices[j]);
+		}
+	}
+
+	// Write list indices.
+	for (size_t i = 0; i < _lists.size(); ++i) {
+		GFF3WriterListPtr list = _lists[i];
+		stream.writeUint32LE(list->getSize());
+		for (size_t j = 0; j < list->_strcts.size(); ++j) {
+			stream.writeUint32LE(list->_strcts[j]);
+		}
+	}
+}
+
+uint32 GFF3Writer::addLabel(const Common::UString &label) {
+	std::vector<Common::UString>::iterator iter = std::find(_labels.begin(), _labels.end(), label);
+	if (iter != _labels.end()) {
+		return static_cast<uint32>(std::distance(_labels.begin(), iter));
+	} else {
+		_labels.push_back(label);
+		return static_cast<uint32>(_labels.size() - 1);
+	}
+}
+
+uint32 GFF3Writer::getFieldDataSize(FieldPtr field) {
+	switch (field->type) {
+		case GFF3Struct::kFieldTypeUint64:
+		case GFF3Struct::kFieldTypeSint64:
+		case GFF3Struct::kFieldTypeStrRef:
+		case GFF3Struct::kFieldTypeDouble:
+			return 8;
+		case GFF3Struct::kFieldTypeExoString:
+			return 4 + field->stringValue.size();
+		case GFF3Struct::kFieldTypeLocString:
+			return 12 + field->locStringValue.getWrittenSize();
+		case GFF3Struct::kFieldTypeResRef:
+			return 1 + field->stringValue.size();
+		case GFF3Struct::kFieldTypeVector:
+			return 12;
+		case GFF3Struct::kFieldTypeOrientation:
+			return 16;
+		case GFF3Struct::kFieldTypeVoid:
+			return 4 + field->voidSize;
+		default:
+			return 0;
+	}
+}
+
+size_t GFF3Writer::createField(GFF3Struct::FieldType type, const Common::UString &label) {
+	// Create a field index.
+	size_t index = _fields.size();
+
+	// Create field.
+	GFF3Writer::FieldPtr field = boost::make_shared<Field>();
+	field->type = type;
+	field->labelIndex = addLabel(label);
+	_fields.push_back(field);
+
+	return index;
+}
+
+GFF3WriterStructPtr GFF3WriterList::addStruct(const Common::UString &label) {
+	// Create the structure pointer.
+	GFF3WriterStructPtr strct(
+			boost::make_shared<GFF3WriterStruct>(_parent, static_cast<uint32>(_parent->_structs.size()) - 1));
+
+	// Create a field index.
+	_strcts.push_back(_parent->_structs.size());
+	GFF3Writer::FieldPtr field = boost::make_shared<GFF3Writer::Field>();
+	field->type = GFF3Struct::kFieldTypeStruct;
+	field->uint32Value = static_cast<uint32>(_parent->_structs.size());
+
+	// Add the label.
+	field->labelIndex = _parent->addLabel(label);
+
+	// Insert the newly created struct into the struct vector.
+	_parent->_structs.push_back(strct);
+
+	// Insert the struct to the field vector.
+	_parent->_fields.push_back(field);
+
+	return strct;
+}
+
+size_t GFF3WriterList::getSize() const {
+	return _strcts.size();
+}
+
+GFF3WriterList::GFF3WriterList(GFF3Writer *parent) : _parent(parent) {
+}
+
+uint32 GFF3WriterStruct::getId() const {
+	return _id;
+}
+
+size_t GFF3WriterStruct::getFieldCount() const {
+	return _fieldIndices.size();
+}
+
+GFF3WriterStructPtr GFF3WriterStruct::addStruct(const Common::UString &label) {
+	// Create the structure pointer.
+	GFF3WriterStructPtr strct(
+			boost::make_shared<GFF3WriterStruct>(_parent, static_cast<uint32>(_parent->_structs.size()) - 1));
+
+	// Create a field index.
+	_fieldIndices.push_back(_parent->_fields.size());
+	GFF3Writer::FieldPtr field = boost::make_shared<GFF3Writer::Field>();
+	field->type = GFF3Struct::kFieldTypeStruct;
+	field->uint32Value = static_cast<uint32>(_parent->_structs.size());
+
+	// Add the label.
+	field->labelIndex = _parent->addLabel(label);
+
+	// Insert the newly created struct into the struct vector.
+	_parent->_structs.push_back(strct);
+
+	// Insert the struct to the field vector.
+	_parent->_fields.push_back(field);
+
+	return strct;
+}
+
+GFF3WriterListPtr GFF3WriterStruct::addList(const Common::UString &label) {
+	// Create the list pointer.
+	GFF3WriterListPtr strct(boost::make_shared<GFF3WriterList>(_parent));
+
+	// Create a field index.
+	_fieldIndices.push_back(_parent->_fields.size());
+	GFF3Writer::FieldPtr field = boost::make_shared<GFF3Writer::Field>();
+	field->type = GFF3Struct::kFieldTypeList;
+	field->uint32Value = static_cast<uint32>(_parent->_lists.size());
+
+	// Add the label.
+	field->labelIndex = _parent->addLabel(label);
+
+	// Insert the newly created list into the lists vector.
+	_parent->_lists.push_back(strct);
+
+	// Insert the list to the field vector.
+	_parent->_fields.push_back(field);
+
+	return strct;
+}
+
+void GFF3WriterStruct::addByte(const Common::UString &label, byte value) {
+	createField(GFF3Struct::kFieldTypeByte, label)->uint32Value = value;
+}
+
+void GFF3WriterStruct::addChar(const Common::UString &label, char value) {
+	createField(GFF3Struct::kFieldTypeChar, label)->int32Value = value;
+}
+
+void GFF3WriterStruct::addFloat(const Common::UString &label, float value) {
+	createField(GFF3Struct::kFieldTypeFloat, label)->floatValue = value;
+}
+
+void GFF3WriterStruct::addDouble(const Common::UString &label, double value) {
+	createField(GFF3Struct::kFieldTypeDouble, label)->doubleValue = value;
+}
+
+void GFF3WriterStruct::addUint16(const Common::UString &label, uint16 value) {
+	createField(GFF3Struct::kFieldTypeUint16, label)->uint32Value = value;
+}
+
+void GFF3WriterStruct::addUint32(const Common::UString &label, uint32 value) {
+	createField(GFF3Struct::kFieldTypeUint32, label)->uint32Value = value;
+}
+
+void GFF3WriterStruct::addUint64(const Common::UString &label, uint64 value) {
+	createField(GFF3Struct::kFieldTypeUint64, label)->uint64Value = value;
+}
+
+void GFF3WriterStruct::addSint16(const Common::UString &label, int16 value) {
+	createField(GFF3Struct::kFieldTypeSint16, label)->int32Value = value;
+}
+
+void GFF3WriterStruct::addSint32(const Common::UString &label, int32 value) {
+	createField(GFF3Struct::kFieldTypeSint32, label)->int32Value = value;
+}
+
+void GFF3WriterStruct::addSint64(const Common::UString &label, int64 value) {
+	createField(GFF3Struct::kFieldTypeSint64, label)->int64Value = value;
+}
+
+void GFF3WriterStruct::addExoString(const Common::UString &label, const Common::UString &value) {
+	createField(GFF3Struct::kFieldTypeExoString, label)->stringValue = value;
+}
+
+void GFF3WriterStruct::addStrRef(const Common::UString &label, uint32 value) {
+	createField(GFF3Struct::kFieldTypeStrRef, label)->uint32Value = value;
+
+}
+
+void GFF3WriterStruct::addResRef(const Common::UString &label, const Common::UString &value) {
+	createField(GFF3Struct::kFieldTypeResRef, label)->stringValue = value;
+
+}
+
+void GFF3WriterStruct::addVoid(const Common::UString &label, const byte *data, uint32 size) {
+	GFF3Writer::FieldPtr field = createField(GFF3Struct::kFieldTypeVoid, label);
+	field->voidData.reset(new byte[size]);
+	field->voidSize = size;
+	memcpy(field->voidData.get(), data, size);
+}
+
+void GFF3WriterStruct::addVector(const Common::UString &label, glm::vec3 value) {
+	createField(GFF3Struct::kFieldTypeVector, label)->vectorValue = glm::vec4(value, 0.0f);
+}
+
+void GFF3WriterStruct::addOrientation(const Common::UString &label, glm::vec4 value) {
+	createField(GFF3Struct::kFieldTypeOrientation, label)->vectorValue = value;
+}
+
+void GFF3WriterStruct::addLocString(const Common::UString &label, const LocString &value) {
+	createField(GFF3Struct::kFieldTypeLocString, label)->locStringValue = value;
+}
+
+GFF3Writer::FieldPtr GFF3WriterStruct::createField(GFF3Struct::FieldType type, const Common::UString &label) {
+	size_t index = _parent->createField(type, label);
+	_fieldIndices.push_back(index);
+	return _parent->_fields.back();
+}
+
+GFF3WriterStruct::GFF3WriterStruct(GFF3Writer *parent, uint32 id) : _id(id), _parent(parent) {
+}
+
+} // End of namespace Aurora

--- a/src/aurora/gff3writer.h
+++ b/src/aurora/gff3writer.h
@@ -1,0 +1,184 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Writer for writing version 3.x of biowares gff (general file format).
+ */
+
+#ifndef AURORA_GFF3WRITER_H
+#define AURORA_GFF3WRITER_H
+
+#include <list>
+
+#include <glm/glm.hpp>
+
+#include <boost/shared_ptr.hpp>
+
+#include "src/aurora/gff3file.h"
+#include "src/aurora/locstring.h"
+
+namespace Aurora {
+
+class GFF3WriterStruct;
+class GFF3WriterList;
+
+typedef boost::shared_ptr<GFF3WriterStruct> GFF3WriterStructPtr;
+typedef boost::shared_ptr<GFF3WriterList> GFF3WriterListPtr;
+
+class GFF3Writer {
+public:
+	// TODO: Add a constructor consuming a GFF3File object.
+	GFF3Writer(uint32 id, uint32 version = MKTAG('V', '3', '.', '2'));
+
+	/** Get the toplevel struct. */
+	GFF3WriterStructPtr getTopLevelStruct();
+
+	/** Write the GFF3 to stream. */
+	void write(Common::WriteStream &stream);
+
+private:
+	/** An implementation for a field. */
+	struct Field : boost::noncopyable {
+		GFF3Struct::FieldType type;
+		uint32 labelIndex;
+
+		uint32 uint32Value;
+		uint64 uint64Value;
+		int32 int32Value;
+		int64 int64Value;
+		float floatValue;
+		double doubleValue;
+		glm::vec4 vectorValue;
+		Common::UString stringValue;
+		LocString locStringValue;
+		Common::ScopedArray<byte> voidData;
+		uint32 voidSize;
+
+		Field() {
+		}
+	};
+
+	typedef boost::shared_ptr<Field> FieldPtr;
+
+	uint32 _id, _version;
+
+	std::vector<GFF3WriterStructPtr> _structs;
+	std::vector<GFF3WriterListPtr> _lists;
+
+	std::vector<Common::UString> _labels;
+	std::vector<FieldPtr> _fields;
+
+	friend class GFF3WriterList;
+	friend class GFF3WriterStruct;
+
+	/** Adds a label to the writer and returns the corresponding index. */
+	uint32 addLabel(const Common::UString &label);
+	/** Get the actual size of the field. */
+	static uint32 getFieldDataSize(FieldPtr field);
+
+	size_t createField(GFF3Struct::FieldType type, const Common::UString &label);
+};
+
+/**
+ * Every GFF3 list can contain structs.
+ */
+class GFF3WriterList : boost::noncopyable {
+public:
+	GFF3WriterList(GFF3Writer *parent);
+
+	/** Add a new struct to the list. */
+	GFF3WriterStructPtr addStruct(const Common::UString &label);
+
+	size_t getSize() const;
+
+private:
+	friend class GFF3Writer;
+	friend class GFF3WriterStruct;
+
+	GFF3Writer *_parent;
+	std::vector<size_t> _strcts;
+};
+
+/**
+ * A GFF3 struct can contain every other value including other structs.
+ */
+class GFF3WriterStruct : boost::noncopyable {
+public:
+	GFF3WriterStruct(GFF3Writer *parent, uint32 id = 0xFFFFFFFF);
+
+	/** Get Id of the struct. */
+	uint32 getId() const;
+	/** Get the count of fields. */
+	size_t getFieldCount() const;
+
+	/** Create a new struct. */
+	GFF3WriterStructPtr addStruct(const Common::UString &label);
+	/** Create a new list. */
+	GFF3WriterListPtr addList(const Common::UString &label);
+
+	/** Add a new byte. */
+	void addByte(const Common::UString &label, byte value);
+	/** Add a new char. */
+	void addChar(const Common::UString &label, char value);
+	/** Add a new float. */
+	void addFloat(const Common::UString &label, float value);
+	/** Add a new double. */
+	void addDouble(const Common::UString &label, double value);
+	/** Add a new uint16. */
+	void addUint16(const Common::UString &label, uint16 value);
+	/** Add a new uint32. */
+	void addUint32(const Common::UString &label, uint32 value);
+	/** Add a new uint64. */
+	void addUint64(const Common::UString &label, uint64 value);
+	/** Add a new sint16. */
+	void addSint16(const Common::UString &label, int16 value);
+	/** Add a new sint32. */
+	void addSint32(const Common::UString &label, int32 value);
+	/** Add a new sint64. */
+	void addSint64(const Common::UString &label, int64 value);
+	/** Add a new ExoString. */
+	void addExoString(const Common::UString &label, const Common::UString &value);
+	/** Add a new String reference. */
+	void addStrRef(const Common::UString &label, uint32 value);
+	/** Add a new Resource reference. */
+	void addResRef(const Common::UString &label, const Common::UString &value);
+	/** Add new void data. Data will be copied. */
+	void addVoid(const Common::UString &label, const byte *data, uint32 size);
+	/** Add a new Vector. */
+	void addVector(const Common::UString &label, glm::vec3 value);
+	/** Add a new Orientation. */
+	void addOrientation(const Common::UString &label, glm::vec4 value);
+	/** Add a new LocString. */
+	void addLocString(const Common::UString &label, const LocString &value);
+
+private:
+	GFF3Writer::FieldPtr createField(GFF3Struct::FieldType type, const Common::UString &label);
+
+	uint32 _id;
+	GFF3Writer *_parent;
+	std::vector<size_t> _fieldIndices;
+
+	friend class GFF3Writer;
+	friend class GFF3WriterList;
+};
+
+} // End of namespace Aurora
+
+#endif // AURORA_GFF3WRITER_H

--- a/src/aurora/locstring.cpp
+++ b/src/aurora/locstring.cpp
@@ -176,9 +176,9 @@ void LocString::readLocString(Common::SeekableReadStream &stream) {
 	readLocString(stream, id, count);
 }
 
-uint32 LocString::getWrittenSize(bool withNullTerminate) {
+uint32 LocString::getWrittenSize(bool withNullTerminate) const {
 	uint32 size = 0;
-	for (StringMap::iterator iter = _strings.begin(); iter != _strings.end() ; iter++) {
+	for (StringMap::const_iterator iter = _strings.begin(); iter != _strings.end() ; iter++) {
 		size += (*iter).second.size();
 
 		if (withNullTerminate)
@@ -190,8 +190,8 @@ uint32 LocString::getWrittenSize(bool withNullTerminate) {
 	return size;
 }
 
-void LocString::writeLocString(Common::WriteStream &stream, bool withNullTerminate) {
-	for (StringMap::iterator iter = _strings.begin(); iter != _strings.end() ; iter++) {
+void LocString::writeLocString(Common::WriteStream &stream, bool withNullTerminate) const {
+	for (StringMap::const_iterator iter = _strings.begin(); iter != _strings.end() ; iter++) {
 		stream.writeUint32LE((*iter).first);
 		stream.writeUint32LE((*iter).second.size());
 		stream.write((*iter).second.c_str(), (*iter).second.size());

--- a/src/aurora/locstring.h
+++ b/src/aurora/locstring.h
@@ -91,9 +91,9 @@ public:
 	void readLocString(Common::SeekableReadStream &stream);
 
 	/** Get the size, the string table will consume after being written. */
-	uint32 getWrittenSize(bool withNullTerminate = false);
+	uint32 getWrittenSize(bool withNullTerminate = false) const;
 	/** Write the LocString to a write stream. */
-	void writeLocString(Common::WriteStream &stream, bool withNullTerminate = false);
+	void writeLocString(Common::WriteStream &stream, bool withNullTerminate = false) const;
 
 private:
 	typedef std::map<uint32, Common::UString> StringMap;

--- a/src/aurora/rules.mk
+++ b/src/aurora/rules.mk
@@ -49,6 +49,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/2dareg.h \
     src/aurora/locstring.h \
     src/aurora/gff3file.h \
+    src/aurora/gff3writer.h \
     src/aurora/gff4file.h \
     src/aurora/gff4fields.h \
     src/aurora/dlgfile.h \
@@ -91,6 +92,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/2dareg.cpp \
     src/aurora/locstring.cpp \
     src/aurora/gff3file.cpp \
+    src/aurora/gff3writer.cpp \
     src/aurora/gff4file.cpp \
     src/aurora/dlgfile.cpp \
     src/aurora/lytfile.cpp \

--- a/tests/aurora/gff3writer.cpp
+++ b/tests/aurora/gff3writer.cpp
@@ -1,0 +1,234 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Unit tests for our GFF3 file writer class.
+ */
+
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "src/common/util.h"
+#include "src/common/error.h"
+#include "src/common/memreadstream.h"
+#include "src/common/memwritestream.h"
+#include "src/common/writefile.h"
+
+#include "src/aurora/gff3writer.h"
+#include "src/aurora/gff3file.h"
+#include "src/aurora/locstring.h"
+
+GTEST_TEST(GFF3Writer, WriteEmptyStruct) {
+	Aurora::GFF3Writer writer(MKTAG('G', 'F', 'F', ' '), MKTAG('V', '3', '.', '2'));
+	writer.getTopLevelStruct()->addStruct("EmptyStruct");
+
+	Common::MemoryWriteStreamDynamic *writeStream = new Common::MemoryWriteStreamDynamic(true);
+	writer.write(*writeStream);
+
+	Aurora::GFF3File gff(new Common::MemoryReadStream(writeStream->getData(), writeStream->size()));
+
+	EXPECT_TRUE(gff.getTopLevel().hasField("EmptyStruct"));
+	EXPECT_EQ(gff.getID(), MKTAG('G', 'F', 'F', ' '));
+
+	delete writeStream;
+}
+
+GTEST_TEST(GFF3Writer, WriteMultipleEmptyStructs) {
+	Aurora::GFF3Writer writer(MKTAG('G', 'F', 'F', ' '));
+	writer.getTopLevelStruct()->addStruct("EmptyStruct1");
+	writer.getTopLevelStruct()->addStruct("EmptyStruct2");
+	Aurora::GFF3WriterStructPtr strct = writer.getTopLevelStruct()->addStruct("EmptyStruct3");
+	strct->addStruct("EmptyStruct3_1");
+
+	Common::MemoryWriteStreamDynamic *writeStream = new Common::MemoryWriteStreamDynamic(true);
+	writer.write(*writeStream);
+
+	Aurora::GFF3File gff(new Common::MemoryReadStream(writeStream->getData(), writeStream->size()));
+
+	EXPECT_EQ(gff.getID(), MKTAG('G', 'F', 'F', ' '));
+
+	EXPECT_TRUE(gff.getTopLevel().hasField("EmptyStruct1"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("EmptyStruct2"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("EmptyStruct3"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("EmptyStruct3").hasField("EmptyStruct3_1"));
+
+	delete writeStream;
+}
+
+GTEST_TEST(GFF3Writer, WriteSingleStruct) {
+	LangMan.addLanguage(Aurora::kLanguageEnglish, 0, Common::kEncodingASCII);
+	LangMan.addLanguage(Aurora::kLanguageGerman, 1, Common::kEncodingASCII);
+
+	Aurora::GFF3Writer writer(MKTAG('G', 'F', 'F', ' '));
+	writer.getTopLevelStruct()->addByte("FieldByte", 8);
+	writer.getTopLevelStruct()->addChar("FieldChar", 'C');
+	writer.getTopLevelStruct()->addUint16("FieldUint16", 16);
+	writer.getTopLevelStruct()->addUint32("FieldUint32", 33);
+	writer.getTopLevelStruct()->addUint64("FieldUint64", 5000000000);
+	writer.getTopLevelStruct()->addSint16("FieldSint16", -16);
+	writer.getTopLevelStruct()->addSint32("FieldSint32", 34);
+	writer.getTopLevelStruct()->addSint64("FieldSint64", -5000000000);
+	writer.getTopLevelStruct()->addFloat("FieldFloat", 34.5f);
+	writer.getTopLevelStruct()->addDouble("FieldDouble", 34.55);
+	writer.getTopLevelStruct()->addExoString("FieldExoString", "NiceString");
+	writer.getTopLevelStruct()->addStrRef("FieldStrRef", 20);
+	writer.getTopLevelStruct()->addResRef("FieldResRef", "file.txt");
+	writer.getTopLevelStruct()->addVoid("FieldVoid", reinterpret_cast<const byte *>("![DATA]!"), 8);
+	writer.getTopLevelStruct()->addVector("FieldVector", glm::vec3(1.0f, 2.0f, 2.5f));
+	writer.getTopLevelStruct()->addOrientation("FieldOrientation", glm::vec4(1.0f, 4.0f, 2.5f, 1.5f));
+
+	Aurora::LocString locString;
+	locString.setString(Aurora::kLanguageEnglish, Aurora::kLanguageGenderMale, "Localized Test String");
+	locString.setString(Aurora::kLanguageGerman, Aurora::kLanguageGenderMale, "Lokalisierter Test String");
+	writer.getTopLevelStruct()->addLocString("FieldLocString", locString);
+
+	Common::MemoryWriteStreamDynamic *writeStream = new Common::MemoryWriteStreamDynamic(true);
+	writer.write(*writeStream);
+
+	Aurora::GFF3File gff(new Common::MemoryReadStream(writeStream->getData(), writeStream->size()));
+
+	EXPECT_EQ(gff.getID(), MKTAG('G', 'F', 'F', ' '));
+	EXPECT_EQ(gff.getVersion(), MKTAG('V', '3', '.', '2'));
+
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldByte"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldChar"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldUint16"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldUint32"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldUint64"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldSint16"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldSint32"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldSint64"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldFloat"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldDouble"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldExoString"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldStrRef"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldResRef"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldVoid"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldVector"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldOrientation"));
+
+	EXPECT_EQ(gff.getTopLevel().getUint("FieldByte"), 8);
+	EXPECT_EQ(gff.getTopLevel().getChar("FieldChar"), 'C');
+	EXPECT_EQ(gff.getTopLevel().getUint("FieldUint16"), 16);
+	EXPECT_EQ(gff.getTopLevel().getUint("FieldUint32"), 33);
+	EXPECT_EQ(gff.getTopLevel().getUint("FieldUint64"), 5000000000);
+	EXPECT_EQ(gff.getTopLevel().getSint("FieldSint16"), -16);
+	EXPECT_EQ(gff.getTopLevel().getSint("FieldSint32"), 34);
+	EXPECT_EQ(gff.getTopLevel().getSint("FieldSint64"), -5000000000);
+	EXPECT_EQ(gff.getTopLevel().getDouble("FieldFloat"), 34.5f);
+	EXPECT_EQ(gff.getTopLevel().getDouble("FieldDouble"), 34.55);
+	EXPECT_EQ(gff.getTopLevel().getUint("FieldStrRef"), 20);
+	EXPECT_EQ(gff.getTopLevel().getString("FieldResRef"), "file.txt");
+	EXPECT_STREQ(gff.getTopLevel().getString("FieldExoString").c_str(), "NiceString");
+
+	Common::SeekableReadStream *data = gff.getTopLevel().getData("FieldVoid");
+	char voidData[8];
+	data->read(voidData, 8);
+	EXPECT_STREQ(Common::UString(voidData, 8).c_str(), "![DATA]!");
+	delete data;
+
+	float x, y, z, w;
+	gff.getTopLevel().getVector("FieldVector", x, y, z);
+	EXPECT_EQ(x, 1.0f);
+	EXPECT_EQ(y, 2.0f);
+	EXPECT_EQ(z, 2.5f);
+
+	gff.getTopLevel().getOrientation("FieldOrientation", x, y, z, w);
+	EXPECT_EQ(x, 1.0f);
+	EXPECT_EQ(y, 4.0f);
+	EXPECT_EQ(z, 2.5f);
+	EXPECT_EQ(w, 1.5f);
+
+	Aurora::LocString locString2;
+	gff.getTopLevel().getLocString("FieldLocString", locString2);
+	EXPECT_STREQ(locString2.getString(Aurora::kLanguageEnglish).c_str(), "Localized Test String");
+	EXPECT_STREQ(locString2.getString(Aurora::kLanguageGerman).c_str(), "Lokalisierter Test String");
+
+	delete writeStream;
+}
+
+GTEST_TEST(GFF3Writer, WriteList) {
+	Aurora::GFF3Writer writer(MKTAG('G', 'F', 'F', ' '));
+	Aurora::GFF3WriterListPtr list1 = writer.getTopLevelStruct()->addList("FieldList1");
+	list1->addStruct("EmptyStruct1");
+	list1->addStruct("EmptyStruct2");
+	Aurora::GFF3WriterStructPtr empty3 = list1->addStruct("EmptyStruct3");
+	Aurora::GFF3WriterListPtr list2 = empty3->addList("FieldList2");
+	list2->addStruct("EmptyStruct4");
+
+	Common::MemoryWriteStreamDynamic *writeStream = new Common::MemoryWriteStreamDynamic(true);
+	writer.write(*writeStream);
+
+	Aurora::GFF3File gff(new Common::MemoryReadStream(writeStream->getData(), writeStream->size()));
+
+	EXPECT_EQ(gff.getID(), MKTAG('G', 'F', 'F', ' '));
+	EXPECT_EQ(gff.getVersion(), MKTAG('V', '3', '.', '2'));
+
+	EXPECT_TRUE(gff.getTopLevel().hasField("FieldList1"));
+	EXPECT_EQ(gff.getTopLevel().getList("FieldList1").size(), 3);
+	EXPECT_TRUE(gff.getTopLevel().getList("FieldList1")[2]->hasField("FieldList2"));
+	EXPECT_EQ(gff.getTopLevel().getList("FieldList1")[2]->getList("FieldList2").size(), 1);
+
+	delete writeStream;
+}
+
+GTEST_TEST(GFF3Writer, WriteNestedStructs) {
+	Aurora::GFF3Writer writer(MKTAG('G', 'F', 'F', ' '));
+	Aurora::GFF3WriterStructPtr struct1 = writer.getTopLevelStruct()->addStruct("Struct1");
+	Aurora::GFF3WriterStructPtr struct2 = writer.getTopLevelStruct()->addStruct("Struct2");
+	Aurora::GFF3WriterStructPtr struct3 = struct2->addStruct("Struct3");
+
+	struct3->addUint64("FieldUint64_1", 214453251);
+	struct3->addUint64("FieldUint64_2", 343251);
+
+	struct1->addSint16("FieldSint16", 1);
+	struct1->addSint32("FieldSint32", 32);
+
+	struct2->addSint16("FieldSint16_1", 3);
+	struct2->addSint16("FieldSint16_2", -3);
+
+	Common::MemoryWriteStreamDynamic *writeStream = new Common::MemoryWriteStreamDynamic(true);
+	writer.write(*writeStream);
+
+	Aurora::GFF3File gff(new Common::MemoryReadStream(writeStream->getData(), writeStream->size()));
+
+	EXPECT_EQ(gff.getID(), MKTAG('G', 'F', 'F', ' '));
+	EXPECT_EQ(gff.getVersion(), MKTAG('V', '3', '.', '2'));
+
+	EXPECT_TRUE(gff.getTopLevel().hasField("Struct1"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct1").hasField("FieldSint16"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct1").hasField("FieldSint32"));
+	EXPECT_TRUE(gff.getTopLevel().hasField("Struct2"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct2").hasField("FieldSint16_1"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct2").hasField("FieldSint16_2"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct2").hasField("Struct3"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct2").getStruct("Struct3").hasField("FieldUint64_1"));
+	EXPECT_TRUE(gff.getTopLevel().getStruct("Struct2").getStruct("Struct3").hasField("FieldUint64_2"));
+
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct1").getSint("FieldSint16"), 1);
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct1").getSint("FieldSint32"), 32);
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct2").getSint("FieldSint16_1"), 3);
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct2").getSint("FieldSint16_2"), -3);
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct2").getStruct("Struct3").getUint("FieldUint64_1"), 214453251);
+	EXPECT_EQ(gff.getTopLevel().getStruct("Struct2").getStruct("Struct3").getUint("FieldUint64_2"), 343251);
+
+	delete writeStream;
+}

--- a/tests/aurora/rules.mk
+++ b/tests/aurora/rules.mk
@@ -165,3 +165,8 @@ check_PROGRAMS                      += tests/aurora/test_erfwriter
 tests_aurora_test_erfwriter_SOURCES  = tests/aurora/erfwriter.cpp
 tests_aurora_test_erfwriter_LDADD    = $(aurora_LIBS)
 tests_aurora_test_erfwriter_CXXFLAGS = $(test_CXXFLAGS)
+
+check_PROGRAMS                       += tests/aurora/test_gff3writer
+tests_aurora_test_gff3writer_SOURCES  = tests/aurora/gff3writer.cpp
+tests_aurora_test_gff3writer_LDADD    = $(aurora_LIBS)
+tests_aurora_test_gff3writer_CXXFLAGS = $(test_CXXFLAGS)


### PR DESCRIPTION
I thought long about my first attempt on a gff3 writer, but ultimately decided that it would be better to write an external class for exporting gff3, since the internal structure of the GFF3File class makes it very difficult to modify values. Also it is difficult to get the necessary information for exporting in an easy way. This class is only for generating a gff3 tree and export it. I have made many unit tests and also tested it against the original kotor executable by replacing a simple file by one created by the writer, and it behaved as i expected.