### PR TITLE
COMMON: Writing multiple bytes at once

### DIFF
--- a/src/common/writestream.h
+++ b/src/common/writestream.h
@@ -131,6 +131,19 @@ public:
 			throw Exception(kWriteError);
 	}
 
+	/** Write n bytes of value to the stream. */
+	void writeBytes(byte value, size_t n) {
+		for (size_t i = 0; i < n; ++i) {
+			if (write(&value, 1) != 1)
+				throw Exception(kWriteError);
+		}
+	}
+
+	/** Write n zeros to the stream. */
+	FORCEINLINE void writeZeros(size_t n) {
+		writeBytes(0, n);
+	}
+
 	FORCEINLINE void writeSint16LE(int16 value) {
 		writeUint16LE((uint16)value);
 	}

--- a/tests/common/memwritestream.cpp
+++ b/tests/common/memwritestream.cpp
@@ -311,6 +311,21 @@ GTEST_TEST(MemoryWriteStream, writeString) {
 	EXPECT_EQ(data[5], 'r');
 }
 
+GTEST_TEST(MemoryWriteStream, writeBytes) {
+	byte data[6] = { 0 };
+	Common::MemoryWriteStream stream(data);
+
+	stream.writeBytes(1, 3);
+	stream.writeBytes(2, 3);
+
+	EXPECT_EQ(data[0], 1);
+	EXPECT_EQ(data[1], 1);
+	EXPECT_EQ(data[2], 1);
+	EXPECT_EQ(data[3], 2);
+	EXPECT_EQ(data[4], 2);
+	EXPECT_EQ(data[5], 2);
+}
+
 GTEST_TEST(MemoryWriteStreamDynamic, write) {
 	static const byte data[8] = { 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF };
 


### PR DESCRIPTION
An idea, ihad while writing #302, was to have more the possibility to write a sequence of same bytes to the stream. This is for example useful for the ERFWriter, which has a 116 byte zeros section.