### PR TITLE
COMMON: Fix bug write completely in written data in WriteFile

### DIFF
--- a/src/common/writefile.cpp
+++ b/src/common/writefile.cpp
@@ -96,7 +96,7 @@ size_t WriteFile::write(const void *dataPtr, size_t dataSize) {
 
 	const size_t oldPos = pos();
 	const size_t written = std::fwrite(dataPtr, 1, dataSize, _handle);
-	_size += MAX<size_t>(0, -size() + oldPos + written);
+	_size += MAX<int>(0, -static_cast<int>(size()) + static_cast<int>(oldPos) + static_cast<int>(written));
 
 	return written;
 }

--- a/tests/common/memwritestream.cpp
+++ b/tests/common/memwritestream.cpp
@@ -393,6 +393,25 @@ GTEST_TEST(MemoryWriteStream, size) {
 	EXPECT_EQ(data[11], 0xAB);
 	EXPECT_EQ(data[12], 0x01);
 	EXPECT_EQ(data[13], 0x02);
+
+	stream.seek(0);
+	stream.writeByte(0xFF);
+	EXPECT_EQ(stream.size(), 14);
+
+	EXPECT_EQ(data[0], 0xFF);
+	EXPECT_EQ(data[1], 0x23);
+	EXPECT_EQ(data[2], 0x45);
+	EXPECT_EQ(data[3], 0x67);
+	EXPECT_EQ(data[4], 0x89);
+	EXPECT_EQ(data[5], 0xAB);
+	EXPECT_EQ(data[6], 0x01);
+	EXPECT_EQ(data[7], 0x23);
+	EXPECT_EQ(data[8], 0x45);
+	EXPECT_EQ(data[9], 0x67);
+	EXPECT_EQ(data[10], 0x89);
+	EXPECT_EQ(data[11], 0xAB);
+	EXPECT_EQ(data[12], 0x01);
+	EXPECT_EQ(data[13], 0x02);
 }
 
 GTEST_TEST(MemoryWriteStream, writeBytes) {
@@ -470,7 +489,11 @@ GTEST_TEST(MemoryWriteStreamDynamic, size) {
 	stream.writeUint64BE(0x0123456789ABCDEF);
 	EXPECT_EQ(stream.size(), 14);
 
-	EXPECT_EQ(stream.getData()[0], 0x01);
+	stream.seek(0);
+	stream.writeByte(0xFF);
+	EXPECT_EQ(stream.size(), 14);
+
+	EXPECT_EQ(stream.getData()[0], 0xFF);
 	EXPECT_EQ(stream.getData()[1], 0x23);
 	EXPECT_EQ(stream.getData()[2], 0x45);
 	EXPECT_EQ(stream.getData()[3], 0x67);

--- a/tests/common/writefile.cpp
+++ b/tests/common/writefile.cpp
@@ -140,6 +140,10 @@ GTEST_TEST_F(WriteFile, size) {
 	file.writeUint64BE(0x0123456789ABCDEF);
 	EXPECT_EQ(file.size(), 14);
 
+	file.seek(0);
+	file.writeByte(0xFF);
+	EXPECT_EQ(file.size(), 14);
+
 	file.flush();
 	file.close();
 
@@ -150,7 +154,7 @@ GTEST_TEST_F(WriteFile, size) {
 	testFile.read(reinterpret_cast<char *>(data), 14);
 	ASSERT_FALSE(testFile.fail());
 
-	EXPECT_EQ(data[0], 0x01);
+	EXPECT_EQ(data[0], 0xFF);
 	EXPECT_EQ(data[1], 0x23);
 	EXPECT_EQ(data[2], 0x45);
 	EXPECT_EQ(data[3], 0x67);


### PR DESCRIPTION
I recognized a bug in the WriteFile class, where the size was calculated wrong, when writing completely in already written data. This PR fixes this problem and extends the unit tests to check for this corner case.