### PR TITLE
JADE: Fix a language encoding problem

### DIFF
--- a/src/engines/jade/jade.cpp
+++ b/src/engines/jade/jade.cpp
@@ -171,16 +171,15 @@ void JadeEngine::init() {
 
 void JadeEngine::declareLanguages() {
 	static const Aurora::LanguageManager::Declaration kLanguageDeclarations[] = {
-		{ Aurora::kLanguageEnglish           ,   0, Common::kEncodingCP1252, Common::kEncodingCP1252 },
-		{ Aurora::kLanguageFrench            ,   1, Common::kEncodingCP1252, Common::kEncodingCP1252 },
-		{ Aurora::kLanguageGerman            ,   2, Common::kEncodingCP1252, Common::kEncodingCP1252 },
-		{ Aurora::kLanguageItalian           ,   3, Common::kEncodingCP1252, Common::kEncodingCP1252 },
-		{ Aurora::kLanguageSpanish           ,   4, Common::kEncodingCP1252, Common::kEncodingCP1252 },
-		{ Aurora::kLanguagePolish            ,   5, Common::kEncodingCP1250, Common::kEncodingCP1250 },
-		{ Aurora::kLanguageKorean            , 128, Common::kEncodingCP949 , Common::kEncodingCP949  },
-		{ Aurora::kLanguageChineseTraditional, 129, Common::kEncodingCP950 , Common::kEncodingCP950  },
-		{ Aurora::kLanguageChineseSimplified , 130, Common::kEncodingCP936 , Common::kEncodingCP936  },
-		{ Aurora::kLanguageJapanese          , 131, Common::kEncodingCP932 , Common::kEncodingCP932  }
+		{ Aurora::kLanguageEnglish  ,   0, Common::kEncodingUTF8, Common::kEncodingCP1252 },
+		{ Aurora::kLanguageFrench   ,   1, Common::kEncodingUTF8, Common::kEncodingCP1252 },
+		{ Aurora::kLanguageGerman   ,   2, Common::kEncodingUTF8, Common::kEncodingCP1252 },
+		{ Aurora::kLanguageItalian  ,   3, Common::kEncodingUTF8, Common::kEncodingCP1252 },
+		{ Aurora::kLanguageSpanish  ,   4, Common::kEncodingUTF8, Common::kEncodingCP1252 },
+		{ Aurora::kLanguagePolish   ,   5, Common::kEncodingUTF8, Common::kEncodingCP1250 },
+		{ Aurora::kLanguageCzech    ,   6, Common::kEncodingUTF8, Common::kEncodingCP1250 },
+		{ Aurora::kLanguageHungarian,   7, Common::kEncodingUTF8, Common::kEncodingCP1250 },
+		{ Aurora::kLanguageRussian  , 132, Common::kEncodingUTF8, Common::kEncodingCP1251 }
 	};
 
 	LangMan.addLanguages(kLanguageDeclarations, ARRAYSIZE(kLanguageDeclarations));


### PR DESCRIPTION
This PR should fix the encoding of jade to utf8. Since it was configured with the wrong encodings.