### PR TITLE
AURORA: SACFile

### DIFF
--- a/src/aurora/rules.mk
+++ b/src/aurora/rules.mk
@@ -64,6 +64,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nfofile.h \
     src/aurora/ltrfile.h \
     src/aurora/textureatlasfile.h \
+    src/aurora/sacfile.h \
     $(EMPTY)
 
 src_aurora_libaurora_la_SOURCES += \
@@ -105,6 +106,7 @@ src_aurora_libaurora_la_SOURCES += \
     src/aurora/nfofile.cpp \
     src/aurora/ltrfile.cpp \
     src/aurora/textureatlasfile.cpp \
+    src/aurora/sacfile.cpp \
     $(EMPTY)
 
 src_aurora_libaurora_la_LIBADD = \

--- a/src/aurora/sacfile.cpp
+++ b/src/aurora/sacfile.cpp
@@ -1,0 +1,52 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Handling GFF3 files with SAC header.
+ */
+
+#include "src/common/encoding.h"
+#include "src/common/memreadstream.h"
+
+#include "sacfile.h"
+
+namespace Aurora {
+
+SACFile::SACFile(Common::SeekableReadStream *stream) : GFF3File(load(stream)), _stream(stream) {
+	if (getType() != MKTAG('S', 'A', 'V', ' '))
+		throw Common::Exception("Invalid GFF ID");
+}
+
+Common::UString SACFile::getLevelFile() const {
+	return _levelFile;
+}
+
+Common::SeekableReadStream *SACFile::load(Common::SeekableReadStream *stream) {
+	stream->skip(4); // Unknown value, probably a version header?
+	const uint32 nameLength = stream->readUint32LE(); // Length of the level identifier.
+
+	_levelFile = Common::readStringFixed(*stream, Common::kEncodingASCII, nameLength); // The Level identifier string.
+
+	stream->skip(4); // Unknown value, probably a checksum?
+
+	return new Common::SeekableSubReadStream(stream, stream->pos(), stream->size());
+}
+
+} // End of namespace Aurora

--- a/src/aurora/sacfile.h
+++ b/src/aurora/sacfile.h
@@ -1,0 +1,54 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Handling GFF3 files with SAC header.
+ */
+
+#ifndef AURORA_SACFILE_H
+#define AURORA_SACFILE_H
+
+#include "src/common/readstream.h"
+
+#include "src/aurora/gff3file.h"
+
+namespace Aurora {
+
+/**
+ * A SAC file is basically a GFF3 file with some bytes extra header. This
+ * class inherits from the GFF3File class to offer all GFF access methods
+ * while providing also information about the SAC header.
+ */
+class SACFile : public GFF3File {
+public:
+	SACFile(Common::SeekableReadStream *stream);
+
+	Common::UString getLevelFile() const;
+
+private:
+	Common::UString _levelFile;
+	Common::ScopedPtr<Common::SeekableReadStream> _stream;
+
+	Common::SeekableReadStream *load(Common::SeekableReadStream *stream);
+};
+
+} // End of namespace Aurora
+
+#endif // AURORA_SACFILE_H


### PR DESCRIPTION
This PR adds support for sac files. These are essentially gff3 files with an extra header, used in Jade Empire as save files.