### PR TITLE
KOTOR: Fix the loading screen in the saveload menu

### DIFF
--- a/src/engines/kotor/gui/saveload.cpp
+++ b/src/engines/kotor/gui/saveload.cpp
@@ -165,6 +165,7 @@ void SaveLoadMenu::addSavedGameItems(WidgetListBox *listBox) {
 
 void SaveLoadMenu::tryLoadGame(const Common::UString &dir) {
 	try {
+		hide();
 		Common::ScopedPtr<SavedGame> save(SavedGame::load(dir, true));
 		_module->loadSavedGame(save.get());
 		GfxMan.lockFrame();


### PR DESCRIPTION
I experienced a bug in the loading menu, where the where the loading screen overlapped with the load menu. This should fix this.