### PR TITLE
KOTOR: Fix transparent borders in minimaps

### DIFF
--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -224,6 +224,7 @@ void HUD::setMinimap(const Common::UString &map, int northAxis,
 
 	_minimap.reset(new Minimap(map, northAxis, mapPt1X, mapPt1Y, mapPt2X, mapPt2Y, worldPt1X, worldPt1Y, worldPt2X, worldPt2Y));
 	mapView->setSubScene(_minimap.get());
+	_minimap->setClearEnabled(true);
 
 	GfxMan.unlockFrame();
 }


### PR DESCRIPTION
This PR should fix the transparent areas on the minimap