### PR TITLE
KOTOR: Fix the wrong function in setGlobalBoolean

### DIFF
--- a/src/engines/kotor/script/functions_global.cpp
+++ b/src/engines/kotor/script/functions_global.cpp
@@ -45,7 +45,7 @@ void Functions::setGlobalBoolean(Aurora::NWScript::FunctionContext &ctx) {
 	Common::UString id = ctx.getParams()[0].getString();
 	bool value = ctx.getParams()[1].getInt() != 0;
 
-	_game->getModule().setGlobalNumber(id, value);
+	_game->getModule().setGlobalBoolean(id, value);
 }
 
 void Functions::getGlobalNumber(Aurora::NWScript::FunctionContext &ctx) {


### PR DESCRIPTION
I recognized a small bug in the setGlobalBoolean nwscript function.