### PR TITLE
KOTOR: Add DestroyObject nwscript method

### DIFF
--- a/src/engines/kotor/script/function_tables.h
+++ b/src/engines/kotor/script/function_tables.h
@@ -359,7 +359,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{ 238, "GetPCSpeaker"                        , 0                                                },
 	{ 239, "GetStringByStrRef"                   , &Functions::getStringByStrRef                    },
 	{ 240, "ActionSpeakStringByStrRef"           , 0                                                },
-	{ 241, "DestroyObject"                       , 0                                                },
+	{ 241, "DestroyObject"                       , &Functions::destroyObject                        },
 	{ 242, "GetModule"                           , &Functions::getModule                            },
 	{ 243, "CreateObject"                        , 0                                                },
 	{ 244, "EventSpellCastAt"                    , 0                                                },

--- a/src/engines/kotor/script/functions.h
+++ b/src/engines/kotor/script/functions.h
@@ -176,6 +176,8 @@ private:
 	// '---
 
 	// .--- General object functions, functions_object.cpp
+	void destroyObject(Aurora::NWScript::FunctionContext &ctx);
+
 	void getClickingObject(Aurora::NWScript::FunctionContext &ctx);
 	void getEnteringObject(Aurora::NWScript::FunctionContext &ctx);
 	void getExitingObject (Aurora::NWScript::FunctionContext &ctx);

--- a/src/engines/kotor/script/functions_object.cpp
+++ b/src/engines/kotor/script/functions_object.cpp
@@ -43,6 +43,22 @@ namespace Engines {
 
 namespace KotOR {
 
+void Functions::destroyObject(Aurora::NWScript::FunctionContext &ctx) {
+	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
+	//float delay = ctx.getParams()[1].getFloat();
+	//bool noFade = ctx.getParams()[2].getInt() != 0;
+	//float delayUntilFade = ctx.getParams()[3].getFloat();
+
+	// TODO: Implement fading out objects.
+
+	Object *kotorObject = ObjectContainer::toObject(object);
+	if (!kotorObject)
+		throw Common::Exception("Functions::destroyObject(): invalid object");
+
+	kotorObject->hide();
+	_game->getModule().removeObject(*kotorObject);
+}
+
 void Functions::getClickingObject(Aurora::NWScript::FunctionContext &ctx) {
 	ctx.getReturn() = ctx.getTriggerer();
 }


### PR DESCRIPTION
This nwscript method should let trask disappear after you equipped and talked to him to later replace him by a version of him placed as your companion.