### PR TITLE
KOTOR: Character generation model change

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -356,27 +356,21 @@ void Creature::getPartModels(PartModels &parts, uint32 state) {
 }
 
 void Creature::getPartModelsPC(PartModels &parts, uint32 state, uint8 textureVariation) {
-	parts.body = "p";
-	parts.head = "p";
+	parts.body = getBodyMeshString(_gender, getClassByPosition(0), state);
+	parts.head = getHeadMeshString(_gender, _skin, _face);
 	parts.bodyTexture = "p";
 
 	switch (_gender) {
 		case kGenderMale:
-			parts.body += "m";
-			parts.head += "m";
 			parts.bodyTexture += "m";
 			break;
 		case kGenderFemale:
-			parts.body += "f";
-			parts.head += "f";
 			parts.bodyTexture += "f";
 			break;
 		default:
 			throw Common::Exception("Unknown gender");
 	}
 
-	parts.body += Common::UString("b") + state;
-	parts.head += "h";
 	parts.bodyTexture  += Common::UString("b") + state;
 
 	switch (state) {
@@ -384,16 +378,13 @@ void Creature::getPartModelsPC(PartModels &parts, uint32 state, uint8 textureVar
 		case 'b':
 			switch (_levels.back().characterClass) {
 				case kClassSoldier:
-					parts.body += "l";
 					parts.bodyTexture += "l";
 					break;
 				case kClassScout:
-					parts.body += "m";
 					parts.bodyTexture += "m";
 					break;
 				default:
 				case kClassScoundrel:
-					parts.body += "s";
 					parts.bodyTexture += "s";
 					break;
 			}
@@ -424,25 +415,8 @@ void Creature::getPartModelsPC(PartModels &parts, uint32 state, uint8 textureVar
 			break;
 	}
 
-	switch (_skin) {
-		case kSkinA:
-			parts.head += "a";
-			break;
-		case kSkinB:
-			parts.head += "b";
-			break;
-		default:
-		case kSkinC:
-			parts.head += "c";
-			break;
-	}
-
 	parts.portrait = "po_" + parts.head;
-	parts.portrait += Common::composeString(_face + 1);
-
-	parts.head += "0";
-	parts.head += Common::composeString(_face + 1);
-
+	parts.portrait.replaceAll("0", "");
 	parts.bodyTexture += Common::UString::format("%02u", textureVariation);
 
 	loadMovementRate("PLAYER");
@@ -717,6 +691,78 @@ void Creature::playHeadAnimation(const Common::UString &anim, bool restart, floa
 
 	if (headChannel)
 		headChannel->playAnimation(anim, restart, length, speed);
+}
+
+Common::UString Creature::getBodyMeshString(Gender gender, Class charClass, char state) {
+	Common::UString body, head;
+
+	body = "p";
+
+	switch (gender) {
+		case kGenderMale:
+			body += "m";
+			break;
+		case kGenderFemale:
+			body += "f";
+			break;
+		default:
+			throw Common::Exception("Unknown gender");
+	}
+
+	body += "b";
+	body += state;
+
+	switch (charClass) {
+		case kClassSoldier:
+			body += "l";
+			break;
+		case kClassScout:
+			body += "m";
+			break;
+		default:
+		case kClassScoundrel:
+			body += "s";
+			break;
+	}
+
+	return body;
+}
+
+Common::UString Creature::getHeadMeshString(Gender gender, Skin skin, uint32 faceId) {
+	Common::UString head;
+
+	head = "p";
+
+	switch (gender) {
+		case kGenderMale:
+			head += "m";
+			break;
+		case kGenderFemale:
+			head += "f";
+			break;
+		default:
+			throw Common::Exception("Unknown gender");
+	}
+
+	head += "h";
+
+	switch (skin) {
+		case kSkinA:
+			head += "a";
+			break;
+		case kSkinB:
+			head += "b";
+			break;
+		default:
+		case kSkinC:
+			head += "c";
+			break;
+	}
+
+	head += "0";
+	head += Common::composeString(faceId + 1);
+
+	return head;
 }
 
 void Creature::clearActionQueue() {

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -127,6 +127,13 @@ public:
 	                       float length = 0.0f,
 	                       float speed = 1.0f);
 
+	// PC Mesh string generation
+
+	/** Generate a string for the body mesh. */
+	static Common::UString getBodyMeshString(Gender gender, Class charClass, char state = 'b');
+	/** Generate a string for the head mesh. */
+	static Common::UString getHeadMeshString(Gender gender, Skin skin, uint32 faceId);
+
 	// Action queue
 
 	void clearActionQueue();

--- a/src/engines/kotor/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor/gui/chargen/charactergeneration.cpp
@@ -182,6 +182,8 @@ void CharacterGenerationMenu::showPortrait() {
 		if (lblPortrait)
 			lblPortrait->setFill(_pc->getPortrait());
 
+		_pc->recreateHead();
+
 		_step += 1;
 	}
 }

--- a/src/engines/kotor/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor/gui/chargen/chargeninfo.cpp
@@ -197,68 +197,27 @@ Creature *CharacterGenerationInfo::getCharacter() const {
 	return creature.release();
 }
 
-Graphics::Aurora::Model *CharacterGenerationInfo::getModel() {
-	// TODO: This duplicates code in Creature::createPC()
+void CharacterGenerationInfo::recreateHead() {
+	Graphics::Aurora::Model *head = _head;
+	_head = loadModelObject(Creature::getHeadMeshString(getGender(), getSkin(), getFace()), "");
+	_body->attachModel("headhook", _head);
+	delete head;
 
+	// Restart animation to apply it to the new head.
+	// TODO: Possibly there is another way of doing this, without restarting the animation?
+	_body->playAnimation("pause1", true, -1);
+}
+
+Graphics::Aurora::Model *CharacterGenerationInfo::getModel() {
 	if (_body)
 		return _body.get();
 
-	Common::UString body, head;
-
-	body = "p";
-	head = "p";
-
-	switch (getGender()) {
-		case kGenderMale:
-			body += "m";
-			head += "m";
-			break;
-		case kGenderFemale:
-			body += "f";
-			head += "f";
-			break;
-		default:
-			throw Common::Exception("Unknown gender");
-	}
-
-	body += "bb";
-	head += "h";
-
-	switch (getClass()) {
-		case kClassSoldier:
-			body += "l";
-			break;
-		case kClassScout:
-			body += "m";
-			break;
-		default:
-		case kClassScoundrel:
-			body += "s";
-			break;
-	}
-
-	_body.reset(loadModelObject(body, ""));
+	_body.reset(loadModelObject(Creature::getBodyMeshString(getGender(), getClass()), ""));
 	if (!_body)
 		return 0;
 
-	switch (getSkin()) {
-		case kSkinA:
-			head += "a";
-			break;
-		case kSkinB:
-			head += "b";
-			break;
-		default:
-		case kSkinC:
-			head += "c";
-			break;
-	}
-
-	head += "0";
-	head += Common::composeString(getFace() + 1);
-
-	Graphics::Aurora::Model *headModel = loadModelObject(head, "");
-	_body->attachModel("headhook", headModel);
+	_head = loadModelObject(Creature::getHeadMeshString(getGender(), getSkin(), getFace()), "");
+	_body->attachModel("headhook", _head);
 
 	return _body.get();
 }

--- a/src/engines/kotor/gui/chargen/chargeninfo.h
+++ b/src/engines/kotor/gui/chargen/chargeninfo.h
@@ -73,6 +73,8 @@ public:
 	void setFace(uint8 face);
 
 	Creature *getCharacter() const;
+
+	void recreateHead();
 	Graphics::Aurora::Model *getModel();
 
 private:
@@ -85,6 +87,7 @@ private:
 
 	Common::UString _name;
 
+	Graphics::Aurora::Model *_head;
 	Common::ScopedPtr<Graphics::Aurora::Model> _body;
 };
 


### PR DESCRIPTION
This PR recreates the heads of the models if thei portraits are changed in the character generation.