### PR TITLE
DRAGONAGE2: Add xbox360 probe

### DIFF
--- a/src/engines/dragonage2/probes.cpp
+++ b/src/engines/dragonage2/probes.cpp
@@ -88,12 +88,32 @@ public:
 	}
 };
 
+class EngineProbeXbox360 : public EngineProbe {
+public:
+	Aurora::Platform getPlatform() const {
+		return Aurora::kPlatformXbox360;
+	}
+
+	bool probe(const Common::UString &directory, const Common::FileList &rootFiles) const {
+		/*
+		 * If we find the xbox executable and a dragonage2 specific path (./modules/campaign_base),
+		 * this should be a valid path.
+		 */
+		if (rootFiles.contains("default.xex", true) &&
+		    Common::FileList(directory + "/modules/campaign_base").contains("campaign_base.cif", true))
+			return true;
+
+		return false;
+	}
+};
+
 const Common::UString EngineProbe::kGameName = "Dragon Age II";
 
 
 void createEngineProbes(std::list<const ::Engines::EngineProbe *> &probes) {
 	probes.push_back(new EngineProbeWindowsRetail);
 	probes.push_back(new EngineProbeWindowsOrigin);
+	probes.push_back(new EngineProbeXbox360);
 }
 
 } // End of namespace DragonAge2


### PR DESCRIPTION
As the name suggests, this PR adds a probe for the xbox360 version of dragonage2.
In the long term it might be worth looking into some of the archive formats utilized by the xbox360, namely the pirs format (mostly used for content acquired from the xbox store), the con format (for dvd content installed to the hard drive) and xbox dvd images.
This will not work, since the xbox image is in some ways different from the pc image but at least it will now recognize the xbox version correctly.