### PR TITLE
KOTOR: Add getPCSpeaker nwscript function

### DIFF
--- a/src/engines/kotor/script/function_tables.h
+++ b/src/engines/kotor/script/function_tables.h
@@ -356,7 +356,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{ 235, "GetIsEnemy"                          , 0                                                },
 	{ 236, "GetIsFriend"                         , 0                                                },
 	{ 237, "GetIsNeutral"                        , 0                                                },
-	{ 238, "GetPCSpeaker"                        , 0                                                },
+	{ 238, "GetPCSpeaker"                        , &Functions::getPCSpeaker                         },
 	{ 239, "GetStringByStrRef"                   , &Functions::getStringByStrRef                    },
 	{ 240, "ActionSpeakStringByStrRef"           , 0                                                },
 	{ 241, "DestroyObject"                       , 0                                                },

--- a/src/engines/kotor/script/functions.h
+++ b/src/engines/kotor/script/functions.h
@@ -169,6 +169,8 @@ private:
 	void getFirstPC(Aurora::NWScript::FunctionContext &ctx);
 	void getNextPC(Aurora::NWScript::FunctionContext &ctx);
 
+	void getPCSpeaker(Aurora::NWScript::FunctionContext &ctx);
+
 	void setGlobalFadeOut(Aurora::NWScript::FunctionContext &ctx);
 	void setGlobalFadeIn(Aurora::NWScript::FunctionContext &ctx);
 

--- a/src/engines/kotor/script/functions_module.cpp
+++ b/src/engines/kotor/script/functions_module.cpp
@@ -48,6 +48,10 @@ void Functions::getNextPC(Aurora::NWScript::FunctionContext &ctx) {
 	ctx.getReturn() = (Aurora::NWScript::Object *) 0;
 }
 
+void Functions::getPCSpeaker(Aurora::NWScript::FunctionContext &ctx) {
+	ctx.getReturn() = (Aurora::NWScript::Object *) _game->getModule().getPC();
+}
+
 void Functions::setGlobalFadeOut(Aurora::NWScript::FunctionContext &ctx) {
 	float wait = ctx.getParams()[0].getFloat();
 	float run = ctx.getParams()[1].getFloat();


### PR DESCRIPTION
This pr adds the getPCSpeaker nwscript function, which should enable trasks class specific lines in the first dialog.