### PR TITLE
AURORA: Fix return value of Array::getMember

### DIFF
--- a/src/aurora/actionscript/array.cpp
+++ b/src/aurora/actionscript/array.cpp
@@ -72,7 +72,7 @@ Variable Array::getMember(const Variable &id) {
 	}
 
 	if (id.isString() && id.asString() == "length")
-		return _values.size();
+		return Variable((unsigned long)_values.size());
 
 	return Object::getMember(id);
 }


### PR DESCRIPTION
This fixes compilation error on VS 2017