### PR TITLE
KOTOR: Make the party member symbols immediately appear and disappear

### DIFF
--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -280,6 +280,16 @@ void HUD::setPortrait(uint8 n, bool visible, const Common::UString &portrait) {
 	WidgetProgressbar *vitals = getProgressbar(Common::UString("PB_VIT") + Common::composeString(n));
 	if (vitals)
 		vitals->setInvisible(!visible);
+
+	if (visible) {
+		labelBack->show();
+		labelChar->show();
+		vitals->show();
+	} else {
+		labelBack->hide();
+		labelChar->hide();
+		vitals->hide();
+	}
 }
 
 void HUD::setPartyLeader(Creature *creature) {


### PR DESCRIPTION
If adding a new character portrait to the hud, it won't appear unless the hud is hidden and shown again. This PR shows or hides the specific elemts immediately