### PR TITLE
KOTOR: Fixes and preparation for character switching

### DIFF
--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -49,6 +49,20 @@ namespace Engines {
 
 namespace KotOR {
 
+Creature::Creature(const Common::UString &resRef)
+		: Object(kObjectTypeCreature),
+		  _walkRate(0.0f),
+		  _runRate(0.0f) {
+
+	init();
+
+	Common::ScopedPtr<Aurora::GFF3File> utc(loadOptionalGFF3(resRef, Aurora::kFileTypeUTC));
+	if (!utc)
+		throw Common::Exception("Creature \"%s\" has no blueprint", resRef.c_str());
+
+	load(utc->getTopLevel());
+}
+
 Creature::Creature(const Aurora::GFF3Struct &creature)
 		: Object(kObjectTypeCreature),
 		  _walkRate(0.0f),

--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -281,8 +281,12 @@ void Creature::loadPortrait(const Aurora::GFF3Struct &gff) {
 		const Aurora::TwoDAFile &twoda = TwoDAReg.get2DA("portraits");
 
 		Common::UString portrait = twoda.getRow(portraitID).getString("BaseResRef");
-		if (!portrait.empty())
-			_portrait = "po_" + portrait;
+		if (!portrait.empty()) {
+			if (portrait.beginsWith("po_"))
+				_portrait = portrait;
+			else
+				_portrait = "po_" + portrait;
+		}
 	}
 
 	_portrait = gff.getString("Portrait", _portrait);

--- a/src/engines/kotor/creature.h
+++ b/src/engines/kotor/creature.h
@@ -51,6 +51,8 @@ public:
 	Creature();
 	/** Load from a creature instance. */
 	Creature(const Aurora::GFF3Struct &creature);
+	/** Load from a creature template. */
+	Creature(const Common::UString &resRef);
 	~Creature();
 
 	/** Create a fake player character creature for testing purposes. */

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -286,11 +286,11 @@ void HUD::setPartyLeader(Creature *creature) {
 }
 
 void HUD::setPartyMember1(Creature *creature) {
-	setPortrait(2, creature != 0, creature ? creature->getPortrait() : "");
+	setPortrait(3, creature != 0, creature ? creature->getPortrait() : "");
 }
 
 void HUD::setPartyMember2(Creature *creature) {
-	setPortrait(3, creature != 0, creature ? creature->getPortrait() : "");
+	setPortrait(2, creature != 0, creature ? creature->getPortrait() : "");
 }
 
 void HUD::update(int width, int height) {

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -785,6 +785,10 @@ void Module::addAvailablePartyMember(int slot, const Common::UString &templ) {
 	_availableParty.insert(std::pair<int, Common::UString>(slot, templ));
 }
 
+bool Module::isAvailableCreature(int slot) {
+	return _availableParty.find(slot) != _availableParty.end();
+}
+
 void Module::setReturnStrref(uint32 id) {
 	_ingame->setReturnStrref(id);
 }

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -127,6 +127,8 @@ public:
 	void showPartySelectionGUI(const Common::UString &exitScript, int forceNPC1 = -1, int forceNPC2 = -1);
 	/** Add available party member by template. */
 	void addAvailablePartyMember(int slot, const Common::UString &templ);
+	/** Check if there is a party member available for this id. */
+	bool isAvailableCreature(int slot);
 	// '---
 
 	// .--- Gui management

--- a/src/engines/kotor/script/function_tables.h
+++ b/src/engines/kotor/script/function_tables.h
@@ -814,7 +814,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{ 693, "SetGlobalLocation"                   , 0                                                },
 	{ 694, "AddAvailableNPCByObject"             , 0                                                },
 	{ 695, "RemoveAvailableNPC"                  , 0                                                },
-	{ 696, "IsAvailableCreature"                 , 0                                                },
+	{ 696, "IsAvailableCreature"                 , &Functions::isAvailableCreature                  },
 	{ 697, "AddAvailableNPCByTemplate"           , &Functions::addAvailableNPCByTemplate            },
 	{ 698, "SpawnAvailableNPC"                   , 0                                                },
 	{ 699, "IsNPCPartyMember"                    , 0                                                },

--- a/src/engines/kotor/script/functions.h
+++ b/src/engines/kotor/script/functions.h
@@ -266,6 +266,7 @@ private:
 	// .--- Party, functions_party.cpp
 	void isObjectPartyMember(Aurora::NWScript::FunctionContext &ctx);
 	void showPartySelectionGUI(Aurora::NWScript::FunctionContext &ctx);
+	void isAvailableCreature(Aurora::NWScript::FunctionContext &ctx);
 	void addAvailableNPCByTemplate(Aurora::NWScript::FunctionContext &ctx);
 	// '---
 

--- a/src/engines/kotor/script/functions_party.cpp
+++ b/src/engines/kotor/script/functions_party.cpp
@@ -58,6 +58,12 @@ void Functions::showPartySelectionGUI(Aurora::NWScript::FunctionContext &ctx) {
 	_game->getModule().showPartySelectionGUI(exitScript, forceNPC1, forceNPC2);
 }
 
+void Functions::isAvailableCreature(Aurora::NWScript::FunctionContext &ctx) {
+	int slot = ctx.getParams()[0].getInt();
+
+	ctx.getReturn() = _game->getModule().isAvailableCreature(slot);
+}
+
 void Functions::addAvailableNPCByTemplate(Aurora::NWScript::FunctionContext &ctx) {
 	const int slot = ctx.getParams()[0].getInt();
 	const Common::UString &templ = ctx.getParams()[1].getString();


### PR DESCRIPTION
This PR fixes and prepares some things to enable the creation of and switching between party members, especially intended for the first dialog when you need to switch to trask to actually open the door.