### PR TITLE
KOTOR: Enable dialogs for situated objects

### DIFF
--- a/src/engines/kotor/gui/dialog.cpp
+++ b/src/engines/kotor/gui/dialog.cpp
@@ -296,7 +296,11 @@ void DialogGUI::makeLookAtPC(const Common::UString &tag) {
 	if (!o)
 		return;
 
-	o->makeLookAt(pc);
+	// Only creatures should orient themselves to the pc.
+	Creature *creature = ObjectContainer::toCreature(o);
+	if (creature)
+		creature->makeLookAt(pc);
+
 	pc->makeLookAt(o);
 
 	float x, y, z, a;

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -500,6 +500,12 @@ void Module::clickObject(Object *object) {
 		return;
 	}
 
+	Situated *situated = ObjectContainer::toSituated(object);
+	if (situated && !situated->getConversation().empty()) {
+		startConversation(situated->getConversation(), situated);
+		return;
+	}
+
 	Placeable *placeable = ObjectContainer::toPlaceable(object);
 	if (placeable) {
 		if (placeable->hasInventory()) {

--- a/src/engines/kotor/situated.cpp
+++ b/src/engines/kotor/situated.cpp
@@ -114,6 +114,10 @@ Object *Situated::getLastUsedBy() const {
 	return _lastUsedBy;
 }
 
+const Common::UString &Situated::getConversation() const {
+	return _conversation;
+}
+
 void Situated::load(const Aurora::GFF3Struct &instance, const Aurora::GFF3Struct *blueprint) {
 	// General properties
 
@@ -194,6 +198,9 @@ void Situated::loadProperties(const Aurora::GFF3Struct &gff) {
 
 	// Locked
 	_locked = gff.getBool("Locked", _locked);
+
+	// Conversation
+	_conversation = gff.getString("Conversation", _conversation);
 
 	// Scripts
 	readScripts(gff);

--- a/src/engines/kotor/situated.h
+++ b/src/engines/kotor/situated.h
@@ -65,6 +65,9 @@ public:
 	/** Return the object that last used this situated object. */
 	Object *getLastUsedBy  () const;
 
+	/** Get the conversation for this object. */
+	const Common::UString &getConversation() const;
+
 	// Positioning
 
 	/** Set the situated object's position. */
@@ -95,6 +98,8 @@ protected:
 	Common::UString _soundDestroyed; ///< The sound the object makes when destroyed.
 	Common::UString _soundUsed;      ///< The sound the object makes when used.
 	Common::UString _soundLocked;    ///< The sound the object makes when locked.
+
+	Common::UString _conversation; ///< The optional conversation with this situated object.
 
 	Object *_lastOpenedBy; ///< The object that last opened this situated object.
 	Object *_lastClosedBy; ///< The object that last closed this situated object.


### PR DESCRIPTION
Situated objects like doors, can have dialogs too. This PR should enable them.