### PR TITLE
ACTIONSCRIPT: Fix string checks in actionGetURL

### DIFF
--- a/src/aurora/actionscript/asbuffer.cpp
+++ b/src/aurora/actionscript/asbuffer.cpp
@@ -509,11 +509,11 @@ void ASBuffer::actionExtends() {
 
 void ASBuffer::actionGetURL(AVM &avm) {
 	const Variable url = _stack.top();
-	if (url.isString())
+	if (!url.isString())
 		throw Common::Exception("actionGetURL: url is not a string");
 	_stack.pop();
 	const Variable target = _stack.top();
-	if (target.isString())
+	if (!target.isString())
 		throw Common::Exception("actionGetURL: target is not a string");
 	_stack.pop();
 


### PR DESCRIPTION
This PR fixes a bug in the actionGetURL opccode of actionscript. Thanks to @darkstar for pointing me to this.