### PR TITLE
KOTOR: Character Switching

### DIFF
--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -400,6 +400,19 @@ void HUD::initWidget(Engines::Widget &widget) {
 }
 
 void HUD::callbackActive(Widget &widget) {
+	if (widget.getTag() == "LBL_CHAR1") {
+		_module->switchPlayerCharacter(0);
+		return;
+	}
+	if (widget.getTag() == "LBL_CHAR2") {
+		_module->switchPlayerCharacter(2);
+		return;
+	}
+	if (widget.getTag() == "LBL_CHAR3") {
+		_module->switchPlayerCharacter(1);
+		return;
+	}
+
 	_menu.showMenu(widget.getTag());
 	sub(_menu);
 }

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -125,6 +125,8 @@ public:
 	void addToParty(Creature *creature);
 	/** Check if the specified creature is a party member. */
 	bool isObjectPartyMember(Creature *creature);
+	/** Switch the player character. */
+	void switchPlayerCharacter(int npc);
 	/** Show the party selection GUI. */
 	void showPartySelectionGUI(const Common::UString &exitScript, int forceNPC1 = -1, int forceNPC2 = -1);
 	/** Add available party member by template. */


### PR DESCRIPTION
This PR enables switching between characters. After Trask joined the party, you should be able to switch to him by clicking on his portrait.