### PR TITLE
TESTS: Add unit test for Engines::Trigger class

### DIFF
--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -34,7 +34,7 @@ namespace Engines {
 
 Trigger::Trigger()
 		: Renderable(Graphics::kRenderableTypeObject),
-		  _visible(false) {
+		  _visible(false), _prepared(false) {
 
 }
 
@@ -42,11 +42,19 @@ void Trigger::setVisible(bool visible) {
 	_visible = visible;
 }
 
+/*
+ * Return true if the (x, y) coordinates are located within
+ * the horizontal projection of this closed polygon.
+ */
 bool Trigger::contains(float x, float y) const {
+	// Must have a surface defined
 	size_t vertexCount = _geometry.size();
 	if (vertexCount < 3)
 		return false;
 
+	// Check the container data
+	assert(_prepared);
+	
 	glm::vec3 orig(x, y, 1000);
 	glm::vec3 intersection;
 
@@ -76,6 +84,7 @@ void Trigger::render(Graphics::RenderPass pass) {
 	if (vertexCount < 3)
 		return;
 
+	// Semi-transparent blue hue
 	glColor4f(0.0f, 0.0f, 1.0f, 0.5f);
 	glBegin(GL_TRIANGLES);
 
@@ -87,6 +96,15 @@ void Trigger::render(Graphics::RenderPass pass) {
 
 	glEnd();
 	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+}
+
+/*
+ * Prepare internal data for the contains(x, y) call.
+ * Run this after the trigger geometry data is loaded.
+ */
+void Trigger::prepare() {
+	// Flag as processed
+	_prepared = true;
 }
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -128,6 +128,20 @@ void Trigger::prepare() {
 bool Trigger::isRayIntersect(float  x, float  y,
                              float x1, float y1,
 			     float x2, float y2) const {
+	// Check if y is below max of y1 and y2
+	if ((y > y1) && (y > y2))
+		return false;
+
+	// Check if x is between x1 and x2
+	if (x < x1 ) {
+		if (x < x2)
+			return false;
+	} else {
+		if (x > x2)
+			return false;
+	}
+
+
 	return true; // TODO
 }
 

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -35,7 +35,6 @@ namespace Engines {
 Trigger::Trigger()
 		: Renderable(Graphics::kRenderableTypeObject),
 		  _visible(false), _prepared(false) {
-
 }
 
 void Trigger::setVisible(bool visible) {
@@ -54,6 +53,10 @@ bool Trigger::contains(float x, float y) const {
 
 	// Check the container data
 	assert(_prepared);
+
+	// Check if point is in bounding box
+	if (!_boundingbox.isIn(x, y))
+		return false;
 	
 	glm::vec3 orig(x, y, 1000);
 	glm::vec3 intersection;
@@ -100,9 +103,15 @@ void Trigger::render(Graphics::RenderPass pass) {
 
 /*
  * Prepare internal data for the contains(x, y) call.
- * Run this after the trigger geometry data is loaded.
+ * Run this after the _geometry data is loaded.
  */
 void Trigger::prepare() {
+	std::vector<glm::vec3>::iterator it;
+
+	// Add vertices to the bounding box
+	for (it = _geometry.begin(); it != _geometry.end(); ++it)
+		_boundingbox.add(it->x, it->y, it->z);
+
 	// Flag as processed
 	_prepared = true;
 }

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -30,6 +30,8 @@
 
 #include "src/engines/aurora/trigger.h"
 
+const float kEpsilon = 1.0e-5; // Negligible distance in game space
+
 namespace Engines {
 
 Trigger::Trigger()
@@ -60,6 +62,7 @@ bool Trigger::contains(float x, float y) {
 	
 	// Initialization
 	std::vector<glm::vec3>::iterator it1, it2;
+	std::vector<SlopeData>::iterator it3;
 	int count = 0;
 
 	// Set first iterator to the last vertex
@@ -67,9 +70,9 @@ bool Trigger::contains(float x, float y) {
 	it1--;
 
 	// Cycle through the vertices, counting the number of ray intersections
-	for (it2 = _geometry.begin(); it2 != _geometry.end(); ++it2) {
+	for (it2 = _geometry.begin(), it3 = _sides.begin(); it2 != _geometry.end(); ++it2, ++it3) {
 		// Check for a ray intersection
-		if (isRayIntersect(x, y, it1->x, it1->y, it2->x, it2->y))
+		if (isRayIntersect(x, y, it1->x, it1->y, it2->x, it2->y, it3->m, it3->isVert))
 			count++;
 
 		// Store for the next loop
@@ -116,6 +119,36 @@ void Trigger::prepare() {
 	// Add vertices to the bounding box
 	for (it = _geometry.begin(); it != _geometry.end(); ++it)
 		_boundingbox.add(it->x, it->y, it->z);
+	//
+	// Initialization
+	std::vector<glm::vec3>::iterator it1, it2;
+	_sides.clear();
+
+	// Set first iterator to the last vertex
+	it1 = _geometry.end();
+	it1--;
+
+	// Precompute the slopes of the sides
+	for (it2 = _geometry.begin(); it2 != _geometry.end(); ++it2) {
+		float dx = it2->x - it1->x;
+		float dy = it2->y - it1->y;
+		SlopeData data;
+
+		// Check if this is a (near) vertical side
+		if ((dx > kEpsilon) || (dx < -kEpsilon)) {
+			data.m = dy / dx;
+			data.isVert = false;
+		} else {
+			data.m = 0.0f;
+			data.isVert = true;
+		}
+
+		// Add the data to the vector
+		_sides.push_back(data);
+
+		// Store for the next loop
+		it1 = it2;
+	}
 
 	// Flag as processed
 	_prepared = true;
@@ -127,7 +160,8 @@ void Trigger::prepare() {
  */
 bool Trigger::isRayIntersect(float  x, float  y,
                              float x1, float y1,
-			     float x2, float y2) const {
+                             float x2, float y2,
+                             float  m, bool isVert) const {
 
 	// Check if y is below max of y1 and y2
 	if ((y > y1) && (y > y2))
@@ -136,7 +170,7 @@ bool Trigger::isRayIntersect(float  x, float  y,
 	// On a vertex alignment, add an offset
 	float x0 = x;
 	if ((x0 == x1) || (x0 == x2)) {
-		x0 = x0 + epsilon;
+		x0 = x0 + kEpsilon;
 	}
 
 	// Check if x0 is in [x1, x2]
@@ -148,21 +182,15 @@ bool Trigger::isRayIntersect(float  x, float  y,
 			return false;
 	}
 
-	float dx = x2 - x1;
-	float dy = y2 - y1;
-
 	// Check if line segment is vertical
-	if ((dx > epsilon) || (dx < -epsilon)) {
-		// Get the y intersection coordinate
-		float m = dy / dx;
+	if (isVert) {
+		return true;
+	} else {
 		float yint = m * (x0 - x1) + y1;
 
 		// Is the point above the line?
 		if (!(y > yint))
 			return true;
-	} else {
-		// Aligned with vertical line segment
-		return true;
 	}
 
 	return false;

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -128,18 +128,23 @@ void Trigger::prepare() {
 bool Trigger::isRayIntersect(float  x, float  y,
                              float x1, float y1,
 			     float x2, float y2) const {
-	const float epsilon = 0.00000001;
 
 	// Check if y is below max of y1 and y2
 	if ((y > y1) && (y > y2))
 		return false;
 
-	// Check if x is in (x1, x2)
+	// On a vertex alignment, add an offset
+	float x0 = x;
+	if ((x0 == x1) || (x0 == x2)) {
+		x0 = x0 + epsilon;
+	}
+
+	// Check if x0 is in [x1, x2]
 	if (x1 < x2) {
-		if ((x < x1) || (x > x2))
+		if ((x0 < x1) || (x0 > x2))
 			return false;
 	} else {
-		if ((x < x2) || (x > x1))
+		if ((x0 < x2) || (x0 > x1))
 			return false;
 	}
 
@@ -150,10 +155,10 @@ bool Trigger::isRayIntersect(float  x, float  y,
 	if ((dx > epsilon) || (dx < -epsilon)) {
 		// Get the y intersection coordinate
 		float m = dy / dx;
-		float yint = m * (x - x1) + y1;
+		float yint = m * (x0 - x1) + y1;
 
-		// Is the point below the line?
-		if (y < yint)
+		// Is the point above the line?
+		if (!(y > yint))
 			return true;
 	} else {
 		// Aligned with vertical line segment

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -45,7 +45,7 @@ void Trigger::setVisible(bool visible) {
  * Return true if the (x, y) coordinates are located within
  * the horizontal projection of this closed polygon.
  */
-bool Trigger::contains(float x, float y) const {
+bool Trigger::contains(float x, float y) {
 	// Must have a surface defined
 	size_t vertexCount = _geometry.size();
 	if (vertexCount < 3)
@@ -58,21 +58,26 @@ bool Trigger::contains(float x, float y) const {
 	if (!_boundingbox.isIn(x, y))
 		return false;
 	
-	glm::vec3 orig(x, y, 1000);
-	glm::vec3 intersection;
+	// Initialization
+	std::vector<glm::vec3>::iterator it1, it2;
+	int count = 0;
 
-	for (size_t i = 2; i < vertexCount; ++i) {
-		if (glm::intersectRayTriangle(orig,
-					glm::vec3(0, 0, -1),
-					_geometry[0],
-					_geometry[i - 1],
-					_geometry[i],
-					intersection) == 1) {
-			return true;
-		}
+	// Set first iterator to the last vertex
+	it1 = _geometry.end();
+	it1--;
+
+	// Cycle through the vertices, counting the number of ray intersections
+	for (it2 = _geometry.begin(); it2 != _geometry.end(); ++it2) {
+		// Check for a ray intersection
+		if (isRayIntersect(x, y, it1->x, it1->y, it2->x, it2->y))
+			count++;
+
+		// Store for the next loop
+		it1 = it2;
 	}
 
-	return false;
+	// Ray-casting algorithm
+	return (count % 2) ? true : false;
 }
 
 void Trigger::calculateDistance() {
@@ -114,6 +119,16 @@ void Trigger::prepare() {
 
 	// Flag as processed
 	_prepared = true;
+}
+
+/*
+ * Return true if a ray extending from (x, y) to (x, infinity)
+ * intersects the line segment from (x1, y1) to (x2, y2).
+ */
+bool Trigger::isRayIntersect(float  x, float  y,
+                             float x1, float y1,
+			     float x2, float y2) const {
+	return true; // TODO
 }
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.cpp
+++ b/src/engines/aurora/trigger.cpp
@@ -128,21 +128,39 @@ void Trigger::prepare() {
 bool Trigger::isRayIntersect(float  x, float  y,
                              float x1, float y1,
 			     float x2, float y2) const {
+	const float epsilon = 0.00000001;
+
 	// Check if y is below max of y1 and y2
 	if ((y > y1) && (y > y2))
 		return false;
 
-	// Check if x is between x1 and x2
-	if (x < x1 ) {
-		if (x < x2)
+	// Check if x is in (x1, x2)
+	if (x1 < x2) {
+		if ((x < x1) || (x > x2))
 			return false;
 	} else {
-		if (x > x2)
+		if ((x < x2) || (x > x1))
 			return false;
 	}
 
+	float dx = x2 - x1;
+	float dy = y2 - y1;
 
-	return true; // TODO
+	// Check if line segment is vertical
+	if ((dx > epsilon) || (dx < -epsilon)) {
+		// Get the y intersection coordinate
+		float m = dy / dx;
+		float yint = m * (x - x1) + y1;
+
+		// Is the point below the line?
+		if (y < yint)
+			return true;
+	} else {
+		// Aligned with vertical line segment
+		return true;
+	}
+
+	return false;
 }
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.h
+++ b/src/engines/aurora/trigger.h
@@ -39,7 +39,7 @@ public:
 	Trigger();
 
 	void setVisible(bool visible);
-	bool contains(float x, float y) const;
+	bool contains(float x, float y);
 
 	// .--- Renderable
 	void calculateDistance();
@@ -53,6 +53,10 @@ protected:
 private:
 	bool _prepared;
 	Common::BoundingBox _boundingbox;
+
+	bool isRayIntersect(float  x, float  y,
+	                    float x1, float y1,
+			    float x2, float y2) const;
 };
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.h
+++ b/src/engines/aurora/trigger.h
@@ -51,13 +51,19 @@ protected:
 
 	void prepare();
 private:
-	const float epsilon = 1.0e-5;
+	typedef struct {
+		float m;
+		bool isVert;
+	} SlopeData;
+
 	bool _prepared;
 	Common::BoundingBox _boundingbox;
+	std::vector<SlopeData> _sides;
 
 	bool isRayIntersect(float  x, float  y,
 	                    float x1, float y1,
-			    float x2, float y2) const;
+			    float x2, float y2,
+			    float  m, bool isVert) const;
 };
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.h
+++ b/src/engines/aurora/trigger.h
@@ -51,6 +51,7 @@ protected:
 
 	void prepare();
 private:
+	const float epsilon = 1.0e-5;
 	bool _prepared;
 	Common::BoundingBox _boundingbox;
 

--- a/src/engines/aurora/trigger.h
+++ b/src/engines/aurora/trigger.h
@@ -47,6 +47,10 @@ public:
 protected:
 	std::vector<glm::vec3> _geometry;
 	bool _visible;
+
+	void prepare();
+private:
+	bool _prepared;
 };
 
 } // End of namespace Engines

--- a/src/engines/aurora/trigger.h
+++ b/src/engines/aurora/trigger.h
@@ -30,6 +30,7 @@
 #include "glm/vec3.hpp"
 
 #include "src/graphics/renderable.h"
+#include "src/common/boundingbox.h"
 
 namespace Engines {
 
@@ -51,6 +52,7 @@ protected:
 	void prepare();
 private:
 	bool _prepared;
+	Common::BoundingBox _boundingbox;
 };
 
 } // End of namespace Engines

--- a/src/engines/kotor/trigger.cpp
+++ b/src/engines/kotor/trigger.cpp
@@ -37,6 +37,7 @@ Trigger::Trigger(const Aurora::GFF3Struct &gff)
 		: ::Engines::Trigger(),
 		  Object(kObjectTypeTrigger) {
 	load(gff);
+	prepare();
 }
 
 void Trigger::show() {

--- a/src/engines/kotor2/trigger.cpp
+++ b/src/engines/kotor2/trigger.cpp
@@ -38,6 +38,7 @@ Trigger::Trigger(const Aurora::GFF3Struct &gff)
 		: ::Engines::Trigger(),
 		  Object(kObjectTypeTrigger) {
 	load(gff);
+	prepare();
 }
 
 void Trigger::show() {

--- a/tests/engines/rules.mk
+++ b/tests/engines/rules.mk
@@ -17,28 +17,19 @@
 # You should have received a copy of the GNU General Public License
 # along with xoreos. If not, see <http://www.gnu.org/licenses/>.
 
-# Unit tests.
+# Unit tests for the Engines namespace.
 
-# Our Unit test framework, Google Test
+engines_LIBS = \
+    $(test_LIBS) \
+    src/engines/libengines.la \
+    src/graphics/libgraphics.la \
+    src/aurora/libaurora.la \
+    src/common/libcommon.la \
+    src/events/libevents.la \
+    tests/version/libversion.la \
+    $(LDADD)
 
-include tests/googletest/rules.mk
-
-test_LIBS  = \
-    tests/googletest/libgtest.la \
-    tests/googletest/libgtest_main.la \
-    $(GTEST_LIBS)
-    $(EMPTY)
-
-test_CXXFLAGS = $(GTEST_FLAGS) $(AM_CXXFLAGS)
-
-noinst_HEADERS += \
-    tests/skip.h \
-    $(EMPTY)
-
-include tests/engines/rules.mk
-include tests/version/rules.mk
-include tests/common/rules.mk
-include tests/aurora/rules.mk
-include tests/images/rules.mk
-
-TESTS += $(check_PROGRAMS)
+check_PROGRAMS                     += tests/engines/test_trigger
+tests_engines_test_trigger_SOURCES  = tests/engines/trigger.cpp
+tests_engines_test_trigger_LDADD    = $(engines_LIBS)
+tests_engines_test_trigger_CXXFLAGS = $(test_CXXFLAGS)

--- a/tests/engines/trigger.cpp
+++ b/tests/engines/trigger.cpp
@@ -1,0 +1,342 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/** @file
+  *  Unit tests for the Engines::Trigger class.
+  */
+
+#include "gtest/gtest.h"
+
+#include "src/common/util.h"
+
+#include "src/engines/aurora/util.h"
+#include "src/engines/aurora/trigger.h"
+
+
+namespace Engines {
+
+// Utility class for testing Engines::Trigger
+class UtilTrigger : public Trigger {
+public:
+	UtilTrigger(const float verts[], const size_t size);
+
+protected:
+	void load(const float verts[], const size_t size);
+};
+
+UtilTrigger::UtilTrigger(const float verts[], const size_t size)
+	: Trigger() {
+	load(verts, size);
+	prepare();
+}
+
+void UtilTrigger::load(const float verts[], const size_t size) {
+	float x, y, z;
+	size_t i = 0;
+
+	assert((size % 3) == 0);
+
+	while (i < size) {
+		x = verts[i++];
+		y = verts[i++];
+		z = verts[i++];
+		_geometry.push_back(glm::vec3(x, y, z));
+	}
+}
+
+
+/*
+ * Test Region 1:
+ *
+ *   5 -              -           H
+ *     |              :          / \ 5 
+ *   4 -              -         /   \
+ *     |              :        /     \
+ *   3 -      B-------C       /       G 
+ *     |     /        :\     /       /
+ *   2 -    / 2       - \ 3 /       /
+ *     |   /          :  \ /       /
+ *   1 -  A           -   /       F 6 
+ *     |   \          :  / \       \
+ *   0 -..:.\.:...:...*./.:.\.:...:.\.:...:
+ *     |     \        :/     \       \
+ *  -1 -      \   1   /   7   \       E 
+ *     |       \     /:        \     /
+ *  -2 -      0 \   / -         \ 4 /
+ *     |         \ /  :          \ /
+ *  -3 -          I   -           D 
+ *     |                                  
+ *     +--|---|---|---|---|---|---|---|---|-
+ *       -3  -2  -1   0   1   2   3   4   5
+ */
+static const float kTestClassPos1[16] = {
+    -2.0, -2.0, // 0 -- Outside
+    -1.0, -1.0, // 1 -- Inside
+    -2.0,  2.0, // 2 -- Inside
+     1.0,  2.0, // 3 -- Outside
+     3.0, -2.0, // 4 -- Inside
+     3.9,  4.9, // 5 -- Outside
+     3.5,  1.0, // 6 -- Outside
+     1.0, -1.0, // 7 -- Outside
+};
+
+static const float kTestClass1[27] = {
+    -3.0,  1.0,  0.0, // A
+    -2.0,  3.0,  0.5, // B
+     0.0,  3.0,  1.5, // C
+     3.0, -3.0,  2.0, // D
+     4.0, -1.0,  0.5, // E
+     3.0,  1.0,  0.0, // F
+     4.0,  3.0, -1.0, // G
+     3.0,  5.0, -2.0, // H
+    -1.0, -3.0, -0.5  // I
+};
+
+GTEST_TEST(TestTrigger, contains_part_1) {
+	size_t size = ARRAYSIZE(kTestClass1);
+	UtilTrigger trigger(kTestClass1, size);
+	const size_t num = 8;
+	bool result[num] = {
+		false, true, true, false,
+		true, false, false, false };
+	int i = 0;
+
+	for (size_t n = 0; n < num; n++) {
+		float x = kTestClassPos1[i++];
+		float y = kTestClassPos1[i++];
+		EXPECT_EQ(trigger.contains(x, y), result[n]) << "At index " << n;
+	}
+}
+
+/*
+ * Test Region 2:
+ *
+ *   5 -        C---------------------D
+ *     |       /      :                \
+ *   4 -    0 /       H-----------G   6 \
+ *     |     /       /:       5   |      \
+ *   3 -    /       / -           F-------E
+ *     |   /       /  :            7 
+ *   2 -  B       J   -   P-----------Q
+ *     |  |       |   :   | 4         |
+ *   1 -  |   1   |   -   N---M       |
+ *     |  |       |   :       /       |
+ *   0 -..:...:...:...*...:../:...:...:...:
+ *     |  |       |   :     /         |
+ *  -1 -  A       | 2 -    / 3        R 
+ *     |   \      K---:---L          /
+ *  -2 -    \         -             /
+ *     |     \        :            /
+ *  -3 -      T-------------------S
+ *     |                                  
+ *     +--|---|---|---|---|---|---|---|---|-
+ *       -3  -2  -1   0   1   2   3   4   5
+ */
+static const float kTestClassPos2[16] = {
+    -2.5,  4.0, // 0 -- Outside
+    -2.0,  1.0, // 1 -- Inside
+    -0.5, -1.0, // 2 -- Outside
+     1.7, -1.0, // 3 -- Inside
+     1.5,  1.5, // 4 -- Inside
+     2.0,  3.5, // 5 -- Outside
+     4.0,  4.0, // 6 -- Inside
+     3.0,  2.5, // 7 -- Outside
+};
+
+static const float kTestClass2[54] = {
+    -3.0, -1.0,  1.0, // A
+    -3.0,  2.0,  1.0, // B
+    -1.5,  5.0,  1.0, // C
+     4.0,  5.0, -1.0, // D
+     5.0,  3.0, -1.0, // E
+     3.0,  3.0, -1.0, // F
+     3.0,  4.0, -1.0, // G
+     0.0,  4.0, -1.0, // H
+    -1.0,  2.0,  1.0, // J
+    -1.0, -1.5,  1.0, // K
+     1.0, -1.5, -1.0, // L
+     2.0,  1.0, -1.0, // M
+     1.0,  1.0, -1.0, // N
+     1.0,  2.0, -1.0, // P
+     4.0,  2.0, -1.0, // Q
+     4.0, -1.0, -1.0, // R
+     3.0, -3.0, -1.0, // S
+    -2.0, -3.0,  1.0, // T
+};
+
+GTEST_TEST(TestTrigger, contains_part_2) {
+	size_t size = ARRAYSIZE(kTestClass2);
+	UtilTrigger trigger(kTestClass2, size);
+	const size_t num = 8;
+	bool result[num] = {
+		false, true, false, true,
+		true, false, true, false };
+	int i = 0;
+
+	for (size_t n = 0; n < num; n++) {
+		float x = kTestClassPos2[i++];
+		float y = kTestClassPos2[i++];
+		EXPECT_EQ(trigger.contains(x, y), result[n]) << "At index " << n;
+	}
+}
+
+/*
+ * Test Region 3:
+ *
+ *   5 -              -               J---K
+ *     |              :               |   |
+ *   4 -      A---B   -               |   |
+ *     |      |   |   :               | 7 |
+ *   3 -      | 1 |   -   E---F       |   |
+ *     |      |   |   :   |   |     6 |   |   8
+ *   2 -      |   |   -   |   G-------H   |
+ *     |      |   |   :   |       5       |
+ *   1 -  0   |   |   -   |   P-------N   |
+ *     |      |   | 2 :   |   | 4     |   |
+ *   0 -..:...:...:...*...:...:...:...:...:
+ *     |      |   |   :   |   |       |   |
+ *  -1 -      |   C-------D   |       M---L
+ *     |      |       :     3 |
+ *  -2 -      R---------------Q
+ *     |              :
+ *  -3 -              -   9 
+ *     |                                  
+ *     +--|---|---|---|---|---|---|---|---|-
+ *       -3  -2  -1   0   1   2   3   4   5
+ */
+static const float kTestClassPos3[20] = {
+    -3.0,  1.0, // 0 -- Outside
+    -1.5,  3.0, // 1 -- Inside
+    -0.5,  0.5, // 2 -- Outside
+     1.5, -1.5, // 3 -- Inside
+     2.5,  0.5, // 4 -- Outside
+     3.0,  1.5, // 5 -- Inside
+     3.5,  2.5, // 6 -- Outside
+     4.5,  3.5, // 7 -- Inside
+     6.0,  2.5, // 8 -- Outside
+     1.0, -3.0, // 9 -- Outside
+};
+
+static const float kTestClass3[48] = {
+    -2.0,  4.0, -1.0, // A
+    -1.0,  4.0, -1.0, // B
+    -1.0, -1.0, -1.0, // C
+     1.0,  1.0,  0.0, // D
+     1.0,  3.0,  0.0, // E
+     2.0,  3.0,  0.0, // F
+     2.0,  2.0,  0.0, // G
+     4.0,  2.0,  0.0, // H
+     4.0,  5.0,  0.0, // J
+     5.0,  5.0,  0.0, // K
+     5.0, -1.0,  0.0, // L
+     4.0, -1.0,  0.0, // M
+     4.0,  1.0,  0.0, // N
+     2.0,  1.0,  0.0, // P
+     2.0, -2.0,  0.0, // Q
+    -2.0, -2.0, -1.0, // R
+};
+
+GTEST_TEST(TestTrigger, contains_part_3) {
+	size_t size = ARRAYSIZE(kTestClass3);
+	UtilTrigger trigger(kTestClass3, size);
+	const size_t num = 10;
+	bool result[num] = {
+		false, true, false, true, false,
+		true, false, true, false, false };
+	int i = 0;
+
+	for (size_t n = 0; n < num; n++) {
+		float x = kTestClassPos3[i++];
+		float y = kTestClassPos3[i++];
+		EXPECT_EQ(trigger.contains(x, y), result[n]) << "At index " << n;
+	}
+}
+
+/*
+ * Test Region 4:
+ *
+ *   5 -  0           -
+ *     |              :           
+ *   4 -      C-----------------------D
+ *     |     /        :   3          /
+ *   3 -    /       Q-----------P   /
+ *     |   /       /  :        /   /
+ *   2 -  B   1   /   -       /   /
+ *     |  |      /    :      /   /
+ *   1 -  |     /     -     / 4 / G---J
+ *     |  |    /      :    /   /  |    \
+ *   0 -..:...:...:...*.../...:...:...:.\.:
+ *     |  |  /        :  /   /    |      \
+ *  -1 -  | /     2   - /   / 6   |   7   K   9
+ *     |  |/          :/   /      |      /
+ *  -2 -  A           N   E-------F     /
+ *     |              | 5              / 8
+ *  -3 -              M---------------L
+ *     |                                  
+ *     +--|---|---|---|---|---|---|---|---|-
+ *       -3  -2  -1   0   1   2   3   4   5
+ */
+static const float kTestClassPos4[20] = {
+    -3.0,  5.0, // 0 -- Outside
+    -2.0,  2.0, // 1 -- Inside
+    -1.0, -1.0, // 2 -- Outside
+     1.0,  3.5, // 3 -- Inside
+     2.0,  1.0, // 4 -- Inside
+     0.5, -2.5, // 5 -- Inside
+     2.0, -1.0, // 6 -- Outside
+     4.0, -1.0, // 7 -- Inside
+     4.8, -2.8, // 8 -- Outside
+     6.0, -1.0, // 9 -- Outside
+};
+
+static const float kTestClass4[42] = {
+    -3.0, -2.0, -1.0, // A
+    -3.0,  2.0, -2.0, // B
+    -2.0,  4.0, -3.0, // C
+     4.0,  4.0, 4.0, // D
+     1.0, -2.0, 5.0, // E
+     3.0, -2.0, 6.0, // F
+     3.0,  1.0, 7.0, // G
+     4.0,  1.0, 8.0, // J
+     5.0, -1.0, 9.0, // K
+     4.0, -3.0, 8.0, // L
+     0.0, -3.0, 7.0, // M
+     0.0, -2.0, 6.0, // N
+     2.5,  3.0, 5.0, // P
+     0.5,  3.0, -4.0, // Q
+};
+
+GTEST_TEST(TestTrigger, contains_part_4) {
+	size_t size = ARRAYSIZE(kTestClass4);
+	UtilTrigger trigger(kTestClass4, size);
+	const size_t num = 10;
+	bool result[num] = {
+		false, true, false, true, true,
+		true, false, true, false, false };
+	int i = 0;
+
+	for (size_t n = 0; n < num; n++) {
+		float x = kTestClassPos4[i++];
+		float y = kTestClassPos4[i++];
+		EXPECT_EQ(trigger.contains(x, y), result[n]) << "At index " << n;
+	}
+}
+
+} // End of namespace Engines
+


### PR DESCRIPTION
This test defines a utility Trigger class that can accept an array of points in
X-Y-Z space. These are pushed onto the classes' __geometry_ vector for use with
the _contains(float x, float y)_ function.

Each test provides a static array of points to the class that define a non-convex,
closed polygon -- equivalent to an in-game trigger region. The class _contains_
function is then passed a series of test points, and the output is compared to
the expected results.

For clarity, in _tests/engines/trigger.cpp_ the comments for each test include an
ASCII illustration demonstrating the shape of the polygon and the location of
the test points.