### PR TITLE
KOTOR2: GUI Scaling

### DIFF
--- a/src/engines/kotor2/gui/gui.cpp
+++ b/src/engines/kotor2/gui/gui.cpp
@@ -22,25 +22,48 @@
  *  A KotOR2 GUI.
  */
 
-#ifndef ENGINES_KOTOR2_GUI_GUI_H
-#define ENGINES_KOTOR2_GUI_GUI_H
+#include "src/graphics/windowman.h"
 
-#include "src/engines/kotor/gui/gui.h"
+#include "src/engines/aurora/kotorjadegui/kotorjadewidget.h"
+#include "src/engines/kotor2/gui/gui.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class GUI : public Engines::KotOR::GUI {
-public:
-	GUI(::Engines::Console *console);
+GUI::GUI(::Engines::Console *console) : Engines::KotOR::GUI(console) {
+}
 
-protected:
-	virtual void initWidget(Widget &widget);
-};
+void GUI::initWidget(Widget &widget) {
+	KotORJadeWidget &kotorWidget = static_cast<KotORJadeWidget &>(widget);
+
+	float wWidth = WindowMan.getWindowWidth();
+	float wHeight = WindowMan.getWindowHeight();
+
+	if (widget.getTag() == "TGuiPanel") {
+		kotorWidget.setWidth(wWidth);
+		kotorWidget.setHeight(wHeight);
+	} else {
+		float x, y, z;
+		kotorWidget.getPosition(x, y, z);
+
+		x *= ((wWidth / 2.0f) / 400.0f);
+		y *= ((wHeight / 2.0f) / 300.0f);
+
+		kotorWidget.setPosition(x, y, z);
+
+		float w, h;
+		w = kotorWidget.getWidth();
+		h = kotorWidget.getHeight();
+
+		w *= (wWidth / 800.0f);
+		h *= (wHeight / 600.0f);
+
+		kotorWidget.setWidth(w);
+		kotorWidget.setHeight(h);
+	}
+}
 
 } // End of namespace KotOR2
 
 } // End of namespace Engines
-
-#endif // ENGINES_KOTOR2_GUI_GUI_H

--- a/src/engines/kotor2/gui/ingame/hud.cpp
+++ b/src/engines/kotor2/gui/ingame/hud.cpp
@@ -34,17 +34,12 @@ namespace Engines {
 namespace KotOR2 {
 
 HUD::HUD(Module &UNUSED(module), ::Engines::Console *console) : GUI(console) {
-	unsigned int wWidth = WindowMan.getWindowWidth();
-	unsigned int wHeight = WindowMan.getWindowHeight();
-	if (wWidth == 800 && wHeight == 600)
-		load("mipc28x6_p");
-	else {
-		warning("TODO: Add scaling for custom resolutions. The supported resolution is 800x600");
-		return;
-	}
+	load("mipc28x6_p");
 }
 
 void HUD::initWidget(Widget &widget) {
+	Engines::KotOR2::GUI::initWidget(widget);
+
 	// Don't know what these two are doing, but they spawn over the complete screen blocking the 3d picking.
 	if (widget.getTag() == "LBL_MAP")
 		widget.setInvisible(true);

--- a/src/engines/kotor2/gui/main/main.cpp
+++ b/src/engines/kotor2/gui/main/main.cpp
@@ -50,6 +50,8 @@ MainMenu::~MainMenu() {
 }
 
 void MainMenu::initWidget(Widget &widget) {
+	Engines::KotOR2::GUI::initWidget(widget);
+
 	// ...BioWare...
 	if (widget.getTag() == "LBL_GAMELOGO") {
 		dynamic_cast< KotORJadeWidget & >(widget).setFill("kotor2logo");

--- a/src/engines/kotor2/gui/rules.mk
+++ b/src/engines/kotor2/gui/rules.mk
@@ -25,6 +25,7 @@ src_engines_kotor2_libkotor2_la_SOURCES += \
     $(EMPTY)
 
 src_engines_kotor2_libkotor2_la_SOURCES += \
+    src/engines/kotor2/gui/gui.cpp \
     src/engines/kotor2/gui/dialog.cpp \
     $(EMPTY)
 

--- a/src/graphics/aurora/borderquad.cpp
+++ b/src/graphics/aurora/borderquad.cpp
@@ -94,8 +94,14 @@ void BorderQuad::getPosition(float &x, float &y, float &z) {
 }
 
 void BorderQuad::setSize(float w, float h) {
-	_w = w;
-	_h = h;
+	_w = std::floor(w);
+	_h = std::floor(h);
+
+	if (_h < 2 * _edgeHeight) {
+		_verticalCut = true;
+	} else {
+		_verticalCut = false;
+	}
 }
 
 void BorderQuad::getSize(float &w, float &h) const {


### PR DESCRIPTION
This PR implements the UI Scaling for kotor2, as the original game did. This PR will lead to some ugly looking results regarding the border quads. I want to wait for @mirv-sillyfish until i fix this, since it is heavily opengl related.. Nevertheless, it is not interfering the playability of kotor2.