### PR TITLE
KOTOR: Reset to default cursor, when dialog occurs

### DIFF
--- a/src/engines/kotor/gui/dialog.cpp
+++ b/src/engines/kotor/gui/dialog.cpp
@@ -30,6 +30,7 @@
 #include "src/events/types.h"
 
 #include "src/graphics/windowman.h"
+#include "src/graphics/aurora/cursorman.h"
 
 #include "src/sound/sound.h"
 
@@ -75,6 +76,7 @@ bool DialogGUIBase::isConversationActive() const {
 }
 
 void DialogGUIBase::show() {
+	CursorMan.setGroup("default");
 	GUI::show();
 	_frame->show();
 }


### PR DESCRIPTION
I recognized, that when in a dialog, the cursor stays the sae, if for example a door is hovered. This should fix this for kotor.