### PR TITLE
VIDEOS: Fix quicktime compilation without libfaad

### DIFF
--- a/src/video/quicktime.cpp
+++ b/src/video/quicktime.cpp
@@ -756,7 +756,11 @@ Sound::PacketizedAudioStream *QuickTimeDecoder::AudioSampleDesc::createAudioStre
 	case MKTAG('m', 'p', '4', 'a'):
 		switch (_objectTypeMP4) {
 		case 0x40:
+#ifdef ENABLE_FAAD
 			return Sound::makeAACStream(*_extraData);
+#else
+			return 0;
+#endif
 		}
 		break;
 	}


### PR DESCRIPTION
I recognized, that a compilation error was thrown with the latest revision, when building without libfaad. This should fix it.