### PR TITLE
GRAPHICS: Add new flexible takeImage method

### DIFF
--- a/src/graphics/graphics.cpp
+++ b/src/graphics/graphics.cpp
@@ -106,6 +106,10 @@ GraphicsManager::GraphicsManager() : Events::Notifyable() {
 
 	_takeScreenshot = false;
 
+	_takeImage = false;
+	_takeImageWithGUI = false;
+	_takeImageWithCursor = false;
+
 	_renderableID = 0;
 
 	_hasAbandoned = false;
@@ -805,6 +809,19 @@ void GraphicsManager::takeScreenshot() {
 	unlockFrame();
 }
 
+std::future<Surface> GraphicsManager::takeImage(bool withGUI, bool withCursor) {
+	lockFrame();
+
+	_takeImage = true;
+	_takeImageWithGUI = withGUI;
+	_takeImageWithCursor = withCursor;
+	_imageSurface = std::promise<Surface>();
+
+	unlockFrame();
+
+	return _imageSurface.get_future();
+}
+
 Renderable *GraphicsManager::getGUIObjectAt(float x, float y) const {
 	if (QueueMan.isQueueEmpty(kQueueVisibleGUIFrontObject))
 		return 0;
@@ -1243,6 +1260,50 @@ void GraphicsManager::renderScene() {
 	}
 
 	endScene();
+
+	if (_takeImage) {
+		beginScene();
+
+		if (_rendererExperimental) {
+			if (_takeImageWithGUI)
+				renderGUIBackShader();
+			renderWorldShader();
+			if (_takeImageWithGUI) {
+				renderGUIFrontShader();
+				renderGUIConsoleShader();
+			}
+			if (_takeImageWithCursor)
+				renderCursorShader();
+		} else {
+			if (_takeImageWithGUI)
+				renderGUIBack();
+			renderWorld();
+			if (_takeImageWithGUI) {
+				renderGUIFront();
+				renderGUIConsole();
+			}
+			if (_takeImageWithCursor)
+				renderCursor();
+		}
+
+		if (_fsaa > 0)
+			glDisable(GL_MULTISAMPLE_ARB);
+
+		Surface surface(WindowMan.getWindowWidth(), WindowMan.getWindowHeight());
+		glReadPixels(
+				0,
+				0,
+				WindowMan.getWindowWidth(),
+				WindowMan.getWindowHeight(),
+				GL_BGRA,
+				GL_UNSIGNED_BYTE,
+				surface.getData()
+		);
+
+		_imageSurface.set_value(surface);
+
+		_takeImage = false;
+	}
 
 	_frameEndSignal.store(true, boost::memory_order_release);
 }

--- a/src/graphics/graphics.h
+++ b/src/graphics/graphics.h
@@ -29,6 +29,7 @@
 
 #include <vector>
 #include <list>
+#include <future>
 
 #include "glm/mat4x4.hpp"
 
@@ -42,6 +43,8 @@
 #include "src/graphics/windowman.h"
 
 #include "src/graphics/aurora/animationthread.h"
+
+#include "src/graphics/images/surface.h"
 
 #include "src/events/notifyable.h"
 
@@ -113,6 +116,8 @@ public:
 
 	/** Take a screenshot. */
 	void takeScreenshot();
+	/** Take an image. */
+	std::future<Surface> takeImage(bool withGUI = true, bool withCursor = true);
 
 	/** Map the given world coordinates onto screen coordinates. */
 	bool project(float x, float y, float z, float &sX, float &sY, float &sZ);
@@ -236,6 +241,11 @@ private:
 	Cursor     *_cursor;       ///< The current cursor.
 
 	bool _takeScreenshot; ///< Should screenshot be taken?
+
+	bool _takeImage;           ///< Should an image be taken?
+	bool _takeImageWithGUI;    ///< Should the GUI be hidden in the image?
+	bool _takeImageWithCursor; ///< Should the Cursor be hidden in the image?
+	std::promise<Surface> _imageSurface;
 
 	uint32 _renderableID;             ///< The last ID given to a renderable.
 	Common::Mutex _renderableIDMutex; ///< The mutex to govern renderable ID creation.


### PR DESCRIPTION
This Method aims to be a more flexible approach for creating screenshots especially targeted towards the save game screenshot creation. Maybe it might even replace someday the takeScreenshot Method? It contains std::future and therefore needs C++11.