### PR TITLE
EVENTS: Game controller support

### DIFF
--- a/src/engines/aurora/satellitecamera.cpp
+++ b/src/engines/aurora/satellitecamera.cpp
@@ -98,6 +98,16 @@ bool SatelliteCamera::handleCameraInput(const Events::Event &e) {
 			}
 			break;
 
+		case Events::kEventControllerAxisMotion:
+			switch (e.caxis.axis) {
+				case Events::kControllerAxisLeftX:
+				case Events::kControllerAxisRightX:
+					_rightBtnPressed = e.caxis.value >  10000;
+					_leftBtnPressed  = e.caxis.value < -10000;
+					return true;
+			}
+			break;
+
 		default:
 			break;
 	}

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -592,6 +592,13 @@ void Module::handleEvents() {
 					_backwardsBtnPressed = event->type == Events::kEventKeyDown;
 				}
 				break;
+
+			case Events::kEventControllerAxisMotion:
+				if (event->caxis.axis == Events::kControllerAxisLeftY) {
+					_backwardsBtnPressed = event->caxis.value >  10000;
+					_forwardBtnPressed   = event->caxis.value < -10000;
+				}
+				break;
 		}
 
 		// Camera

--- a/src/events/events.cpp
+++ b/src/events/events.cpp
@@ -39,6 +39,7 @@ STOP_IGNORE_IMPLICIT_FALLTHROUGH
 #include "src/events/notifications.h"
 #include "src/events/timerman.h"
 #include "src/events/joystick.h"
+#include "src/events/gamecontroller.h"
 
 #include "src/graphics/types.h"
 #include "src/graphics/graphics.h"
@@ -75,6 +76,13 @@ void EventsManager::init() {
 	_queueSize = 0;
 
 	_ready = true;
+
+	// Load game controller mapping database if available.
+	if (ConfigMan.hasKey("gamecontrollerdb")) {
+		Common::UString gameControllerDatabase = ConfigMan.getString("gamecontrollerdb");
+		if (SDL_GameControllerAddMappingsFromFile(gameControllerDatabase.c_str()) == -1)
+			warning("Could not load controller database: %s", SDL_GetError());
+	}
 
 	initJoysticks();
 

--- a/src/events/events.cpp
+++ b/src/events/events.cpp
@@ -365,9 +365,20 @@ void EventsManager::initJoysticks() {
 	if (joyCount <= 0)
 		return;
 
+	bool controllerFound = false;
+
 	_joysticks.reserve(joyCount);
-	for (int i = 0; i < joyCount; i++)
-		_joysticks.push_back(new Joystick(i));
+	for (int i = 0; i < joyCount; i++) {
+		if (SDL_IsGameController(i)) {
+			_joysticks.push_back(new GameController(i));
+			controllerFound = true;
+		} else {
+			_joysticks.push_back(new Joystick(i));
+		}
+	}
+
+	if (controllerFound)
+		SDL_GameControllerEventState(SDL_ENABLE);
 
 	SDL_JoystickEventState(SDL_ENABLE);
 }

--- a/src/events/gamecontroller.cpp
+++ b/src/events/gamecontroller.cpp
@@ -1,0 +1,71 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Game controller handling.
+ */
+
+#include "src/common/error.h"
+
+#include "src/events/gamecontroller.h"
+
+namespace Events {
+
+GameController::GameController(int index) : Joystick(index), _sdlController(0) {
+	if (!isController())
+		throw Common::Exception("GameController::GameController() joystick %i is not a controller", getIndex());
+}
+
+GameController::~GameController() {
+	if (_sdlController)
+		SDL_GameControllerClose(_sdlController);
+}
+
+Common::UString GameController::getControllerName() const {
+	return SDL_GameControllerName(_sdlController);
+}
+
+bool GameController::isEnabled() const {
+	return Joystick::isEnabled() && _sdlController != 0;
+}
+
+bool GameController::enable() {
+	if (isEnabled())
+		return true;
+
+	Joystick::enable();
+
+	_sdlController = SDL_GameControllerOpen(getIndex());
+	if (!_sdlController)
+		return false;
+
+	return true;
+}
+
+void GameController::disable() {
+	Joystick::disable();
+
+	if (_sdlController)
+		SDL_GameControllerClose(_sdlController);
+
+	_sdlController = 0;
+}
+
+}

--- a/src/events/gamecontroller.h
+++ b/src/events/gamecontroller.h
@@ -1,0 +1,52 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Game controller handling.
+ */
+
+#ifndef EVENTS_GAMECONTROLLER_H
+#define EVENTS_GAMECONTROLLER_H
+
+#include <SDL_gamecontroller.h>
+
+#include "src/events/joystick.h"
+
+namespace Events {
+
+class GameController : public Joystick {
+public:
+	GameController(int index);
+	~GameController();
+
+	Common::UString getControllerName() const;
+
+	bool isEnabled() const;
+
+	bool enable();
+	void disable();
+
+private:
+	SDL_GameController *_sdlController;
+};
+
+} // End of namespace Events
+
+#endif // EVENTS_GAMECONTROLLER_H

--- a/src/events/joystick.cpp
+++ b/src/events/joystick.cpp
@@ -24,6 +24,8 @@
 
 #include <cassert>
 
+#include <SDL_gamecontroller.h>
+
 #include "src/events/joystick.h"
 
 namespace Events {
@@ -46,6 +48,10 @@ const Common::UString &Joystick::getName() const {
 
 bool Joystick::isEnabled() const {
 	return _sdlJoy != 0;
+}
+
+bool Joystick::isController() const {
+	return SDL_IsGameController(_index);
 }
 
 bool Joystick::enable() {

--- a/src/events/joystick.h
+++ b/src/events/joystick.h
@@ -39,6 +39,9 @@ namespace Events {
 
 class Joystick : boost::noncopyable {
 public:
+	Joystick(int index);
+	virtual ~Joystick();
+
 	/** Return the joystick's name. */
 	const Common::UString &getName() const;
 
@@ -46,12 +49,14 @@ public:
 	int getIndex() const;
 
 	/** Is the joystick currently enabled? */
-	bool isEnabled() const;
+	virtual bool isEnabled() const;
+	/** Can this joystick be a game controller? */
+	bool isController() const;
 
 	/** Enable the joystick. */
-	bool enable();
+	virtual bool enable();
 	/** Disable the joystick. */
-	void disable();
+	virtual void disable();
 
 	// Properties, only available when the joystick is enabled.
 
@@ -68,12 +73,6 @@ private:
 	int _index;
 	Common::UString _name;
 	SDL_Joystick *_sdlJoy;
-
-
-	Joystick(int index);
-	~Joystick();
-
-	friend class EventsManager;
 
 	template<typename T>
 	friend void Common::DeallocatorDefault::destroy(T *);

--- a/src/events/rules.mk
+++ b/src/events/rules.mk
@@ -31,6 +31,7 @@ src_events_libevents_la_SOURCES += \
     src/events/notifications.h \
     src/events/timerman.h \
     src/events/joystick.h \
+    src/events/gamecontroller.h \
     $(EMPTY)
 
 src_events_libevents_la_SOURCES += \
@@ -40,4 +41,5 @@ src_events_libevents_la_SOURCES += \
     src/events/notifications.cpp \
     src/events/timerman.cpp \
     src/events/joystick.cpp \
+    src/events/gamecontroller.cpp \
     $(EMPTY)

--- a/src/events/types.h
+++ b/src/events/types.h
@@ -297,6 +297,37 @@ enum Key {
 	kKeySleep = SDLK_SLEEP
 };
 
+/** The possible controller axis. */
+enum ControllerAxis {
+	kControllerAxisInvalid  = SDL_CONTROLLER_AXIS_INVALID,
+	kControllerAxisLeftX    = SDL_CONTROLLER_AXIS_LEFTX,
+	kControllerAxisLeftY    = SDL_CONTROLLER_AXIS_LEFTY,
+	kControllerAxisRightX   = SDL_CONTROLLER_AXIS_RIGHTX,
+	kControllerAxisRightY   = SDL_CONTROLLER_AXIS_RIGHTY,
+	kControllerAxisTriggerX = SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+	kControllerAxisTriggerY = SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+};
+
+/** The possible controller buttons. */
+enum ControllerButton {
+	kControllerButtonInvalid       = SDL_CONTROLLER_BUTTON_INVALID,
+	kControllerButtonA             = SDL_CONTROLLER_BUTTON_A,
+	kControllerButtonB             = SDL_CONTROLLER_BUTTON_B,
+	kControllerButtonX             = SDL_CONTROLLER_BUTTON_X,
+	kControllerButtonY             = SDL_CONTROLLER_BUTTON_Y,
+	kControllerButtonBack          = SDL_CONTROLLER_BUTTON_BACK,
+	kControllerButtonGuide         = SDL_CONTROLLER_BUTTON_GUIDE,
+	kControllerButtonStart         = SDL_CONTROLLER_BUTTON_START,
+	kControllerButtonLeftStick     = SDL_CONTROLLER_BUTTON_LEFTSTICK,
+	kControllerButtonRightStick    = SDL_CONTROLLER_BUTTON_RIGHTSTICK,
+	kControllerButtonLeftShoulder  = SDL_CONTROLLER_BUTTON_LEFTSHOULDER,
+	kControllerButtonRightShoulder = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER,
+	kControllerButtonDpadUp        = SDL_CONTROLLER_BUTTON_DPAD_UP,
+	kControllerButtonDpadDown      = SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+	kControllerButtonDpadLeft      = SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+	kControllerButtonDpadRight     = SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+};
+
 /** A functor for a function that needs to be called in the main thread. */
 template<typename T> struct MainThreadFunctor {
 private:

--- a/src/events/types.h
+++ b/src/events/types.h
@@ -43,18 +43,21 @@ typedef SDL_Event Event;
 
 /** Custom event types. */
 enum EventType {
-	kEventKeyDown   = SDL_KEYDOWN        , ///< Keyboard key was pressed.
-	kEventKeyUp     = SDL_KEYUP          , ///< Keyboard key was released.
-	kEventMouseMove = SDL_MOUSEMOTION    , ///< Mouse was moved.
-	kEventMouseDown = SDL_MOUSEBUTTONDOWN, ///< Mouse button was pressed.
-	kEventMouseUp   = SDL_MOUSEBUTTONUP  , ///< Mouse button was released.
-	kEventMouseWheel= SDL_MOUSEWHEEL     , ///< Mouse wheel was used.
-	kEventTextInput = SDL_TEXTINPUT      , ///< Text was written.
-	kEventQuit      = SDL_QUIT           , ///< Application quit was requested.
-	kEventWindow    = SDL_WINDOWEVENT    , ///< Resize the window.
-	kEventUserMIN   = SDL_USEREVENT - 1  , ///< For range checks.
-	kEventITC       = SDL_USEREVENT      , ///< Inter-thread communication.
-	kEventUserMAX   = SDL_LASTEVENT        ///< For range checks.
+	kEventKeyDown              = SDL_KEYDOWN             , ///< Keyboard key was pressed.
+	kEventKeyUp                = SDL_KEYUP               , ///< Keyboard key was released.
+	kEventMouseMove            = SDL_MOUSEMOTION         , ///< Mouse was moved.
+	kEventMouseDown            = SDL_MOUSEBUTTONDOWN     , ///< Mouse button was pressed.
+	kEventMouseUp              = SDL_MOUSEBUTTONUP       , ///< Mouse button was released.
+	kEventMouseWheel           = SDL_MOUSEWHEEL          , ///< Mouse wheel was used.
+	kEventControllerAxisMotion = SDL_CONTROLLERAXISMOTION, ///< Controller axis was moved.
+	kEventControllerButtonDown = SDL_CONTROLLERBUTTONDOWN, ///< Controller button was pressed.
+	kEventControllerButtonUp   = SDL_CONTROLLERBUTTONUP  , ///< Controller button was released
+	kEventTextInput            = SDL_TEXTINPUT           , ///< Text was written.
+	kEventQuit                 = SDL_QUIT                , ///< Application quit was requested.
+	kEventWindow               = SDL_WINDOWEVENT         , ///< Resize the window.
+	kEventUserMIN              = SDL_USEREVENT - 1       , ///< For range checks.
+	kEventITC                  = SDL_USEREVENT           , ///< Inter-thread communication.
+	kEventUserMAX              = SDL_LASTEVENT             ///< For range checks.
 };
 
 /** Sub events for kEventWindow. */

--- a/src/graphics/windowman.cpp
+++ b/src/graphics/windowman.cpp
@@ -67,7 +67,7 @@ WindowManager::~WindowManager() {
 void WindowManager::init() {
 	Common::enforceMainThread();
 
-	const uint32 sdlInitFlags = SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+	const uint32 sdlInitFlags = SDL_INIT_TIMER | SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER;
 	if (SDL_Init(sdlInitFlags) < 0)
 		throw Common::Exception("Failed to initialize SDL: %s", SDL_GetError());
 


### PR DESCRIPTION
This PR extends the events system with game controller support. It requires a copy of the SDL gamecontrollerdb file with the --gamecontroller option. I also implemented some basic walking with a game controller in kotor.