### PR TITLE
KOTOR2: border fix

### DIFF
--- a/src/engines/aurora/kotorjadegui/kotorjadewidget.cpp
+++ b/src/engines/aurora/kotorjadegui/kotorjadewidget.cpp
@@ -420,8 +420,7 @@ void KotORJadeWidget::setPosition(float x, float y, float z) {
 	Widget::setPosition(x, y, z);
 
 	if (_quad) {
-		_quad->getPosition(x, y, z);
-		_quad->setPosition(x + dx, y + dy, z + dz);
+		_quad->setPosition(x + _borderDimension, y + _borderDimension, z);
 	}
 
 	if (_highlight) {
@@ -450,8 +449,7 @@ void KotORJadeWidget::setWidth(float width) {
 	_width = width;
 
 	if (_quad) {
-		width = _quad->getWidth();
-		_quad->setWidth(width + deltaWidth);
+		_quad->setWidth(MAX(0.0f, width - 2 * _borderDimension));
 	}
 
 	if (_highlight) {
@@ -478,8 +476,7 @@ void KotORJadeWidget::setHeight(float height) {
 	_height = height;
 
 	if (_quad) {
-		height = _quad->getHeight();
-		_quad->setHeight(height + deltaHeight);
+		_quad->setHeight(MAX(0.0f, height - 2 * _borderDimension));
 	}
 
 	if (_highlight) {

--- a/src/engines/kotor2/gui/gui.cpp
+++ b/src/engines/kotor2/gui/gui.cpp
@@ -50,7 +50,7 @@ void GUI::initWidget(Widget &widget) {
 		x *= ((wWidth / 2.0f) / 400.0f);
 		y *= ((wHeight / 2.0f) / 300.0f);
 
-		kotorWidget.setPosition(x, y, z);
+		kotorWidget.setPosition(std::floor(x), std::floor(y), z);
 
 		float w, h;
 		w = kotorWidget.getWidth();
@@ -59,8 +59,8 @@ void GUI::initWidget(Widget &widget) {
 		w *= (wWidth / 800.0f);
 		h *= (wHeight / 600.0f);
 
-		kotorWidget.setWidth(w);
-		kotorWidget.setHeight(h);
+		kotorWidget.setWidth(std::floor(w));
+		kotorWidget.setHeight(std::floor(h));
 	}
 }
 


### PR DESCRIPTION
This PR solves some of the problems introduced with #374 concerning the invalid drawn quads inside borders.