### PR TITLE
AURORA: Enable extraction of bitmaps from pe files

### DIFF
--- a/src/aurora/pefile.cpp
+++ b/src/aurora/pefile.cpp
@@ -48,57 +48,86 @@ const Archive::ResourceList &PEFile::getResources() const {
 }
 
 Common::SeekableReadStream *PEFile::getResource(uint32 index, bool UNUSED(tryNoCopy)) const {
-	// Convert from the PE cursor group/cursor format to the standalone
-	// cursor format.
+	ResourceList::const_iterator iter = _resources.begin();
+	if (index >= _resources.size())
+		throw Common::Exception("Resource index out of range (%u/%u)", index, (uint)_resources.size());
 
-	Common::ScopedPtr<Common::SeekableReadStream>
-		cursorGroup(_peFile->getResource(Common::kPEGroupCursor, index));
+	std::advance(iter, index);
 
-	if (!cursorGroup)
-		throw Common::Exception("No such PE resource %u", index);
+	switch (iter->type) {
+		case kFileTypeBMP: {
+			Common::ScopedPtr<Common::SeekableReadStream> stream(_peFile->getResource(Common::kPEBitmap, _peIDs.at(index)));
+
+			Common::MemoryWriteStreamDynamic bmp(true);
+			bmp.writeByte('B');
+			bmp.writeByte('M');
+
+			bmp.writeUint32LE(stream->size() + 14);
+			bmp.writeZeros(4);
+			bmp.writeUint32LE(54);
+			bmp.writeStream(*stream);
+
+			bmp.setDisposable(false);
+			return new Common::MemoryReadStream(bmp.getData(), bmp.size(), true);
+		}
+
+		case kFileTypeCUR: {
+			// Convert from the PE cursor group/cursor format to the standalone
+			// cursor format.
+
+			Common::ScopedPtr<Common::SeekableReadStream>
+					cursorGroup(_peFile->getResource(Common::kPEGroupCursor, _peIDs[index]));
+
+			if (!cursorGroup)
+				throw Common::Exception("No such PE resource %u", _peIDs[index]);
 
 
-	Common::MemoryWriteStreamDynamic out(true);
+			Common::MemoryWriteStreamDynamic out(true);
 
-	// Cursor Group Header
-	out.writeUint16LE(cursorGroup->readUint16LE());
-	out.writeUint16LE(cursorGroup->readUint16LE());
+			// Cursor Group Header
+			out.writeUint16LE(cursorGroup->readUint16LE());
+			out.writeUint16LE(cursorGroup->readUint16LE());
 
-	const size_t cursorCount = cursorGroup->readUint16LE();
-	out.writeUint16LE(cursorCount);
+			const size_t cursorCount = cursorGroup->readUint16LE();
+			out.writeUint16LE(cursorCount);
 
 
-	Common::PtrVector<Common::SeekableReadStream> cursorStreams;
-	cursorStreams.resize(cursorCount);
+			Common::PtrVector<Common::SeekableReadStream> cursorStreams;
+			cursorStreams.resize(cursorCount);
 
-	uint32 startOffset = 6 + cursorCount * 16;
+			uint32 startOffset = 6 + cursorCount * 16;
 
-	for (size_t i = 0; i < cursorCount; i++) {
-		out.writeByte(cursorGroup->readUint16LE());     // width
-		out.writeByte(cursorGroup->readUint16LE() / 2); // height
-		cursorGroup->readUint16LE();                    // planes
-		out.writeByte(cursorGroup->readUint16LE());     // bits per pixel
-		out.writeByte(0);                               // reserved
+			for (size_t i = 0; i < cursorCount; i++) {
+				out.writeByte(cursorGroup->readUint16LE());     // width
+				out.writeByte(cursorGroup->readUint16LE() / 2); // height
+				cursorGroup->readUint16LE();                    // planes
+				out.writeByte(cursorGroup->readUint16LE());     // bits per pixel
+				out.writeByte(0);                               // reserved
 
-		cursorGroup->readUint32LE();                    // data size
-		uint16 id = cursorGroup->readUint16LE();
+				cursorGroup->readUint32LE();                    // data size
+				uint16 id = cursorGroup->readUint16LE();
 
-		cursorStreams[i] = _peFile->getResource(Common::kPECursor, id);
-		if (!cursorStreams[i])
-			throw Common::Exception("Could not get cursor resource %d", id);
+				cursorStreams[i] = _peFile->getResource(Common::kPECursor, id);
+				if (!cursorStreams[i])
+					throw Common::Exception("Could not get cursor resource %d", id);
 
-		out.writeUint16LE(cursorStreams[i]->readUint16LE()); // hotspot X
-		out.writeUint16LE(cursorStreams[i]->readUint16LE()); // hotspot Y
-		out.writeUint32LE(cursorStreams[i]->size() - 4);     // size
-		out.writeUint32LE(startOffset);                      // offset
-		startOffset += cursorStreams[i]->size() - 4;
+				out.writeUint16LE(cursorStreams[i]->readUint16LE()); // hotspot X
+				out.writeUint16LE(cursorStreams[i]->readUint16LE()); // hotspot Y
+				out.writeUint32LE(cursorStreams[i]->size() - 4);     // size
+				out.writeUint32LE(startOffset);                      // offset
+				startOffset += cursorStreams[i]->size() - 4;
+			}
+
+			for (size_t i = 0; i < cursorCount; i++)
+				out.writeStream(*cursorStreams[i], cursorStreams[i]->size() - 4);
+
+			out.setDisposable(false);
+			return new Common::MemoryReadStream(out.getData(), out.size(), true);
+		}
+
+		default:
+			return 0;
 	}
-
-	for (size_t i = 0; i < cursorCount; i++)
-		out.writeStream(*cursorStreams[i], cursorStreams[i]->size() - 4);
-
-	out.setDisposable(false);
-	return new Common::MemoryReadStream(out.getData(), out.size(), true);
 }
 
 void PEFile::load(const std::vector<Common::UString> &remap) {
@@ -110,16 +139,35 @@ void PEFile::load(const std::vector<Common::UString> &remap) {
 		if (it->getID() == 0xFFFFFFFF)
 			throw Common::Exception("Found non-integer cursor group");
 
-		uint32 id = it->getID() - 1;
+		uint32 id = it->getID();
 		if (id >= remap.size())
 			res.name = Common::UString::format("cursor%d", id);
 		else
 			res.name = remap[id];
 
 		res.type  = kFileTypeCUR;
-		res.index = id + 1;
+		res.index = _peIDs.size();
 
 		_resources.push_back(res);
+		_peIDs.push_back(id);
+	}
+
+	std::vector<Common::PEResourceID> bitmapList = _peFile->getNameList(Common::kPEBitmap);
+
+	for (std::vector<Common::PEResourceID>::const_iterator it = bitmapList.begin(); it != bitmapList.end(); ++it) {
+		Resource res;
+
+		uint32 id = it->getID();
+		if (id >= remap.size())
+			res.name = Common::UString::format("bitmap%d", id);
+		else
+			res.name = remap[id];
+
+		res.type  = kFileTypeBMP;
+		res.index = _peIDs.size();
+
+		_resources.push_back(res);
+		_peIDs.push_back(id);
 	}
 }
 

--- a/src/aurora/pefile.h
+++ b/src/aurora/pefile.h
@@ -60,6 +60,8 @@ private:
 
 	/** External list of resource names and types. */
 	ResourceList _resources;
+	/** A map which maps a unique resource id to the corresponding pe id. */
+	std::vector<uint32> _peIDs;
 
 	void load(const std::vector<Common::UString> &remap);
 };


### PR DESCRIPTION
This PR enables to extract bitmaps from pe exe files. It is thought as base for potentially implementing the spalash screens of dragonage and dragonage2.