### PR TITLE
BUILD: Fix compilation with MinGW32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,7 +147,15 @@ AC_ARG_WITH([std], [AS_HELP_STRING([--without-std], [Compile without specifying 
 
 STD=""
 if test "x$with_std" = "xyes"; then
-	AX_CHECK_COMPILER_FLAGS_VAR([C++], [STD], [-std=c++11])
+	case "$target" in
+		*mingw*)
+			dnl Needed by _wfopen in src/common/platform.cpp
+			AX_CHECK_COMPILER_FLAGS_VAR([C++], [STD], [-std=gnu++11])
+			;;
+		*)
+			AX_CHECK_COMPILER_FLAGS_VAR([C++], [STD], [-std=c++11])
+			;;
+	esac;
 fi
 
 AC_SUBST(STD)


### PR DESCRIPTION
Unlike MinGW-w64, _wfopen on MinGW32 requires GNU extensions to be enabled.

Currently, this only fixes the autoconf build. The CMake build fails at the linking stage with the following errors:

``
FAILED: bin/xoreos.exe                                                                                                  cmd.exe /C "cd . && C:\MinGW\bin\c++.exe -Wall -Wignored-qualifiers -Wpointer-arith -Wshadow -Wsign-compare -Wtype-limits -Wuninitialized -Wunused-parameter -Wunused-but-set-parameter -Wduplicated-cond -Wlogical-op -Wshift-negative-value -Wshift-overflow=2 -Wvla -Wnon-virtual-dtor -Wno-overloaded-virtual -Wno-long-long -Wno-unused-local-typedefs   CMakeFiles/xoreos.dir/src/cline.cpp.obj CMakeFiles/xoreos.dir/src/engines.cpp.obj CMakeFiles/xoreos.dir/src/xoreos.cpp.obj CMakeFiles/xoreos.dir/dists/win32/xoreos.rc.obj  -o bin\xoreos.exe -Wl,--out-implib,lib\libxoreos.dll.a -Wl,--major-image-version,0,--minor-image-version,0  lib/libengines_dragonage2.a lib/libengines_dragonage.a lib/libengines_sonic.a lib/libengines_witcher.a lib/libengines_jade.a lib/libengines_kotor2.a lib/libengines_kotor.a lib/libengines_nwn2.a lib/libengines_nwn.a lib/libengines.a lib/libengines_aurora.a lib/libevents.a lib/libvideo.a lib/libvideo_aurora.a lib/libvideo_codecs.a lib/libsound.a lib/libsound_decoders.a lib/libgraphics.a lib/libgraphics_images.a lib/libgraphics_aurora.a lib/libgraphics_shader.a lib/libgraphics_mesh.a lib/libgraphics_render.a lib/libaurora.a lib/libaurora_nwscript.a lib/libaurora_lua_libluascript.la.a lib/libaurora_actionscript.a lib/libcommon.a lib/libversion.a -lz -lboost_system-mgw63-mt-1_65 -lboost_filesystem-mgw63-mt-1_65 -lboost_regex-mgw63-mt-1_65 -lboost_date_time-mgw63-mt-1_65 -lboost_atomic-mgw63-mt-1_65 -lboost_locale-mgw63-mt-1_65 -lSDL2 -lOpenAL32 -lopengl32 -lglu32 -lfreetype -Wl,-Bstatic -lmad -Wl,-Bdynamic -lfaad -logg -lvorbis -lvorbisfile -lxvidcore -Wl,-Bstatic -lvpx -Wl,-Bdynamic -llzma -lxml2 -liconv -lglew32 lib/liblua.a lib/libtoluapp.a -lkernel32 -luser32 -lgdi32 -lwinspool -lshell32 -lole32 -loleaut32 -luuid -lcomdlg32 -ladvapi32 && cd ."          lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x152): undefined reference to `Video::Bink::Bink(Common::SeekableReadStream*)'                                                                                               lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x18e): undefined reference to `Video::QuickTimeDecoder::QuickTimeDecoder(Common::SeekableReadStream*)'                                                                       lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x1c7): undefined reference to `Video::XboxMediaVideo::XboxMediaVideo(Common::SeekableReadStream*)'                                                                           lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x200): undefined reference to `Video::ActimagineDecoder::ActimagineDecoder(Common::SeekableReadStream*)'                                                                     lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x27a): undefined reference to `Video::VideoDecoder::setScale(Video::VideoDecoder::Scale)'                                                                                    lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x342): undefined reference to `Video::VideoDecoder::abort()'                                                                                                                 lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x370): undefined reference to `Video::VideoDecoder::start()'                                                                                                                 lib/libvideo_aurora.a(videoplayer.cpp.obj):videoplayer.cpp:(.text+0x468): undefined reference to `Video::VideoDecoder::isPlaying() const'                                                                                                       lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x10): undefined reference to `Graphics::Texture::Texture()'                                                                                                                       lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0xb0): undefined reference to `Graphics::Texture::~Texture()'                                                                                                                      lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0xda): undefined reference to `Graphics::Texture::Texture()'                                                                                                                       lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x1d0): undefined reference to `Graphics::Texture::~Texture()'                                                                                                                     lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x25b): undefined reference to `Graphics::Texture::~Texture()'                                                                                                                     lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0xe27): undefined reference to `Graphics::CubeMapCombiner::CubeMapCombiner(Graphics::ImageDecoder* (&) [6])'                                                                       lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x159d): undefined reference to `Graphics::CubeMapCombiner::CubeMapCombiner(Graphics::ImageDecoder* (&) [6])'                                                                      lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x16ce): undefined reference to `Graphics::TGA::TGA(Common::SeekableReadStream&, bool)'                                                                                            lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x16fd): undefined reference to `Graphics::DDS::DDS(Common::SeekableReadStream&)'                                                                                                  lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x172c): undefined reference to `Graphics::TPC::TPC(Common::SeekableReadStream&)'                                                                                                  lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x175b): undefined reference to `Graphics::TXB::TXB(Common::SeekableReadStream&)'                                                                                                  lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x1792): undefined reference to `Graphics::SBM::SBM(Common::SeekableReadStream&, bool)'                                                                                            lib/libgraphics_aurora.a(texture.cpp.obj):texture.cpp:(.text+0x17be): undefined reference to `Graphics::XEOSITEX::XEOSITEX(Common::SeekableReadStream&)'                                                                                        lib/libgraphics_aurora.a(textureman.cpp.obj):textureman.cpp:(.text+0xdcd): undefined reference to `Graphics::Texture::getID() const'                                                                                                            lib/libgraphics_aurora.a(pltfile.cpp.obj):pltfile.cpp:(.text+0x555): undefined reference to `Graphics::Surface::Surface(int, int)'                                                                                                              lib/libgraphics_aurora.a(pltfile.cpp.obj):pltfile.cpp:(.text+0x590): undefined reference to `Graphics::Surface::fill(unsigned char, unsigned char, unsigned char, unsigned char)'                                                               lib/libgraphics_aurora.a(pltfile.cpp.obj):pltfile.cpp:(.text+0x6f4): undefined reference to `Graphics::Surface::getData()'                                                                                                                      lib/libgraphics_aurora.a(nftrfont.cpp.obj):nftrfont.cpp:(.text+0x197a): undefined reference to `Graphics::Surface::Surface(int, int)'                                                                                                           lib/libgraphics_aurora.a(nftrfont.cpp.obj):nftrfont.cpp:(.text+0x1edf): undefined reference to `Graphics::Surface::getData()'                                                                                                                   lib/libgraphics_aurora.a(nftrfont.cpp.obj):nftrfont.cpp:(.text+0x1eeb): undefined reference to `Graphics::Surface::getWidth() const'                                                                                                            lib/libgraphics_aurora.a(nftrfont.cpp.obj):nftrfont.cpp:(.text+0x2093): undefined reference to `Graphics::Surface::getWidth() const'                                                                                                            lib/libgraphics_aurora.a(model_nwn2.cpp.obj):model_nwn2.cpp:(.text+0x2ee6): undefined reference to `Graphics::Surface::Surface(int, int)'                                                                                                       lib/libgraphics_aurora.a(model_nwn2.cpp.obj):model_nwn2.cpp:(.text+0x2ef6): undefined reference to `Graphics::Surface::getMipMap()'                                                                                                             lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x10): undefined reference to `Graphics::Cursor::Cursor()'   lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x89): undefined reference to `Graphics::Cursor::~Cursor()'  lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0xd1): undefined reference to `Graphics::Cursor::~Cursor()'  lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x372): undefined reference to `Graphics::TGA::TGA(Common::SeekableReadStream&, bool)'                                                                                               lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x3b8): undefined reference to `Graphics::DDS::DDS(Common::SeekableReadStream&)'                                                                                                     lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x402): undefined reference to `Graphics::WinIconImage::WinIconImage(Common::SeekableReadStream&)'                                                                                   lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x430): undefined reference to `Graphics::WinIconImage::getHotspotX() const'                                                                                                         lib/libgraphics_aurora.a(cursor.cpp.obj):cursor.cpp:(.text+0x453): undefined reference to `Graphics::WinIconImage::getHotspotY() const'                                                                                                         lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0x67): undefined reference to `Graphics::Surface::Surface(int, int)'                                                                                                               lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0x9a): undefined reference to `Graphics::Surface::fill(unsigned char, unsigned char, unsigned char, unsigned char)'                                                                lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0x455): undefined reference to `Graphics::TTFRenderer::TTFRenderer(Common::SeekableReadStream&, int)'                                                                              lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0x47f): undefined reference to `Graphics::TTFRenderer::getHeight() const'                                                                                                          lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0xb43): undefined reference to `Graphics::TTFRenderer::hasChar(unsigned int) const'                                                                                                lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0xb6e): undefined reference to `Graphics::TTFRenderer::getCharWidth(unsigned int) const'                                                                                           lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text+0xd88): undefined reference to `Graphics::TTFRenderer::drawCharacter(unsigned int, Graphics::Surface&, int, int)'                                                                  lib/libgraphics_aurora.a(ttffont.cpp.obj):ttffont.cpp:(.text$_ZN6Common18DeallocatorDefault7destroyIN8Graphics11TTFRendererEEEvPT_[__ZN6Common18DeallocatorDefault7destroyIN8Graphics11TTFRendererEEEvPT_]+0x11): undefined reference to `Graphics::TTFRenderer::~TTFRenderer()'                                                                                        lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x1024): undefined reference to `Graphics::Texture::getID() const'                                                                                                                   lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x1086): undefined reference to `Graphics::Texture::getID() const'                                                                                                                   lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x10e8): undefined reference to `Graphics::Texture::getID() const'                                                                                                                   lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x114a): undefined reference to `Graphics::Texture::getID() const'                                                                                                                   lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x11ac): undefined reference to `Graphics::Texture::getID() const'                                                                                                                   lib/libgraphics_shader.a(shader.cpp.obj):shader.cpp:(.text+0x120e): more undefined references to `Graphics::Texture::getID() const' follow                                                                                                      collect2.exe: error: ld returned 1 exit status                                                                          ninja: build stopped: subcommand failed.                                                                                 
``
