### PR TITLE
KOTOR: Fix the carth dialog

### DIFF
--- a/src/engines/kotor/area.cpp
+++ b/src/engines/kotor/area.cpp
@@ -631,10 +631,10 @@ void Area::evaluateTriggers(float x, float y) {
 
 	if (_activeTrigger != trigger) {
 		if (_activeTrigger)
-			_activeTrigger->runScript(kScriptExit, this, _module->getPC());
+			_activeTrigger->runScript(kScriptExit, _activeTrigger, _module->getPC());
 		_activeTrigger = trigger;
 		if (_activeTrigger)
-			_activeTrigger->runScript(kScriptEnter, this, _module->getPC());
+			_activeTrigger->runScript(kScriptEnter, _activeTrigger, _module->getPC());
 	}
 }
 


### PR DESCRIPTION
After a lot of research i found out, why the carth dialog was not triggered properly. It was because the trigger scripts need the actual trigger object as owner and not the area. I fixed this in this commit. I verified this behaviour by decompiling the trigger script and adding the following line:
`if (GetTag(OBJECT_SELF) == "end_trig02")
			PlayMovie("01A");`
It behaved as I expected and played the movie.