### PR TITLE
KOTOR: Selection

### DIFF
--- a/src/engines/kotor/area.cpp
+++ b/src/engines/kotor/area.cpp
@@ -511,10 +511,14 @@ void Area::setActive(KotOR::Object *object) {
 	if (_activeObject)
 		_activeObject->leave();
 
+	_module->leaveObject(_activeObject);
+
 	_activeObject = object;
 
 	if (_activeObject)
 		_activeObject->enter();
+
+	_module->enterObject(_activeObject);
 }
 
 void Area::checkActive(int x, int y) {

--- a/src/engines/kotor/door.cpp
+++ b/src/engines/kotor/door.cpp
@@ -171,6 +171,11 @@ bool Door::testCollision(const glm::vec3 &orig, const glm::vec3 &dest) const {
 	return !isOpen() && _walkmesh.testCollision(orig, dest);
 }
 
+void Door::getTooltipAnchor(float &x, float &y, float &z) const {
+	_model->getAbsolutePosition(x, y, z);
+	z += _model->getDepth() / 2;
+}
+
 bool Door::open(Object *opener) {
 	// TODO: Door::open(): Open in direction of the opener
 

--- a/src/engines/kotor/door.h
+++ b/src/engines/kotor/door.h
@@ -77,6 +77,8 @@ public:
 
 	bool testCollision(const glm::vec3 &orig, const glm::vec3 &dest) const;
 
+	virtual void getTooltipAnchor(float &x, float &y, float &z) const;
+
 protected:
 	/** Load door-specific properties. */
 	void loadObject(const Aurora::GFF3Struct &gff);

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -198,6 +198,11 @@ HUD::HUD(Module &module, Engines::Console *console)
 	update(WindowMan.getWindowWidth(), WindowMan.getWindowHeight());
 
 	_minimapPointer = getLabel("LBL_ARROW");
+
+	_objectName = getLabel("LBL_NAME");
+	_objectNameBackground = getLabel("LBL_NAMEBG");
+	_objectHealth = getProgressbar("PB_HEALTH");
+	_objectHealthBackground = getLabel("LBL_HEALTHBG");
 }
 
 void HUD::setReturnStrref(uint32 id) {
@@ -307,6 +312,63 @@ void HUD::setPartyMember1(Creature *creature) {
 
 void HUD::setPartyMember2(Creature *creature) {
 	setPortrait(2, creature != 0, creature ? creature->getPortrait() : "");
+}
+
+void HUD::showObjectInformation(Object *object) {
+    if (_objectNameBackground) {
+        _objectNameBackground->setInvisible(false);
+        _objectNameBackground->show();
+    }
+    if (_objectName) {
+        _objectName->setInvisible(false);
+        _objectName->show();
+        _objectName->setText(object->getName());
+    }
+
+    if (_objectHealthBackground) {
+        _objectHealthBackground->setInvisible(false);
+        _objectHealthBackground->show();
+    }
+    if (_objectHealth) {
+        _objectHealth->setInvisible(false);
+        _objectHealth->show();
+    }
+}
+
+void HUD::hideObjectInformation() {
+    if (_objectNameBackground) {
+        _objectNameBackground->setInvisible(true);
+        _objectNameBackground->hide();
+    }
+    if (_objectName) {
+        _objectName->setInvisible(true);
+        _objectName->hide();
+    }
+
+    if (_objectHealthBackground) {
+        _objectHealthBackground->setInvisible(true);
+        _objectHealthBackground->hide();
+    }
+    if (_objectHealth) {
+        _objectHealth->setInvisible(true);
+        _objectHealth->hide();
+    }
+}
+
+void HUD::updateObjectInformation(Object *object, float x, float y) {
+    if (_objectNameBackground)
+	    _objectNameBackground->setPosition(x - 100, y + 36, -100);
+    if (_objectName)
+	    _objectName->setPosition(x - 100, y + 36, -FLT_MAX);
+
+    if (_objectHealthBackground)
+	    _objectHealthBackground->setPosition(x - 100, y + 29, -FLT_MAX);
+    if (_objectHealth) {
+        _objectHealth->setPosition(x - 100, y + 29, -FLT_MAX);
+
+        _objectHealth->setMaxValue(object->getMaxHitPoints());
+        _objectHealth->setCurrentValue(object->getCurrentHitPoints());
+    }
 }
 
 void HUD::update(int width, int height) {

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -63,6 +63,10 @@ public:
 	void setPartyMember1(Creature *creature);
 	void setPartyMember2(Creature *creature);
 
+	void showObjectInformation(Object *object);
+	void updateObjectInformation(Object *object, float x, float y);
+	void hideObjectInformation();
+
 private:
 	Module *_module;
 	Menu _menu;
@@ -70,6 +74,13 @@ private:
 
 	Common::ScopedPtr<Minimap> _minimap;
 	WidgetLabel *_minimapPointer;
+
+	// ,--- Widgets for showing object information
+	WidgetLabel       *_objectName;
+	WidgetLabel       *_objectNameBackground;
+	WidgetProgressbar *_objectHealth;
+	WidgetLabel       *_objectHealthBackground;
+	// '---
 
 	void update(int width, int height);
 

--- a/src/engines/kotor/gui/ingame/ingame.h
+++ b/src/engines/kotor/gui/ingame/ingame.h
@@ -31,6 +31,7 @@
 #include "src/engines/kotor/inventory.h"
 
 #include "src/engines/kotor/gui/ingame/hud.h"
+#include "src/engines/kotor/gui/ingame/selectioncircle.h"
 
 namespace Engines {
 
@@ -64,11 +65,19 @@ public:
 	void setPartyMember1(Creature *creature);
 	void setPartyMember2(Creature *creature);
 
+	// Selection handling
+	void showSelection(Object *object);
+	void hideSelection();
+	void updateSelection();
+
 	void addEvent(const Events::Event &event);
 	void processEventQueue();
 
 private:
 	Common::ScopedPtr<HUD> _hud;
+	Common::ScopedPtr<SelectionCircle> _selectionCircle;
+
+	Object *_selected;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/rules.mk
+++ b/src/engines/kotor/gui/ingame/rules.mk
@@ -34,6 +34,7 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/menu_opt.h \
     src/engines/kotor/gui/ingame/minimap.h \
     src/engines/kotor/gui/ingame/partyselection.h \
+    src/engines/kotor/gui/ingame/selectioncircle.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -51,4 +52,5 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/menu_opt.cpp \
     src/engines/kotor/gui/ingame/minimap.cpp \
     src/engines/kotor/gui/ingame/partyselection.cpp \
+    src/engines/kotor/gui/ingame/selectioncircle.cpp \
     $(EMPTY)

--- a/src/engines/kotor/gui/ingame/selectioncircle.cpp
+++ b/src/engines/kotor/gui/ingame/selectioncircle.cpp
@@ -1,0 +1,49 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The circle visible when selecting objects
+ */
+
+#include "src/engines/kotor/gui/ingame/selectioncircle.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+SelectionCircle::SelectionCircle() : _inactive(new Graphics::Aurora::GUIQuad("friendlyreticle", 0.0f, 0.0f, 64.0f, 64.0f)) {
+
+}
+
+void SelectionCircle::show() {
+	_inactive->show();
+}
+
+void SelectionCircle::hide() {
+	_inactive->hide();
+}
+
+void SelectionCircle::setPosition(float x, float y) {
+	_inactive->setPosition(x - 32, y - 32);
+}
+
+} // End of namespace KotOR
+
+} // End of namespace Engines

--- a/src/engines/kotor/gui/ingame/selectioncircle.h
+++ b/src/engines/kotor/gui/ingame/selectioncircle.h
@@ -1,0 +1,52 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  The circle visible when selecting objects
+ */
+
+#ifndef ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H
+#define ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H
+
+#include "src/graphics/aurora/guiquad.h"
+
+namespace Engines {
+
+namespace KotOR {
+
+class SelectionCircle {
+public:
+	SelectionCircle();
+
+	void show();
+	void hide();
+
+	void setPosition(float x, float y);
+
+private:
+	// TODO: Add more circles and dynamically switch between them.
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _inactive;
+};
+
+} // End of namespace KotOR
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -522,6 +522,14 @@ void Module::clickObject(Object *object) {
 	}
 }
 
+void Module::enterObject(Object *object) {
+	_ingame->showSelection(object);
+}
+
+void Module::leaveObject(Object *UNUSED(object)) {
+	_ingame->hideSelection();
+}
+
 void Module::addEvent(const Events::Event &event) {
 	_eventQueue.push_back(event);
 }
@@ -672,6 +680,7 @@ void Module::handlePCMovement() {
 	SoundMan.setListenerOrientation(orientation[0], orientation[1], orientation[2], 0.0f, 1.0f, 0.0f);
 
 	_ingame->setRotation(Common::rad2deg(SatelliteCam.getYaw()));
+	_ingame->updateSelection();
 
 	if (haveMovement && !_pcRunning) {
 		_pc->playAnimation(Common::UString("run"), false, -1.0f);

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -170,6 +170,11 @@ public:
 	/** Open the inventory of a container. */
 	void clickObject(Object *object);
 
+	/** Enter an object with the mouse. */
+	void enterObject(Object *object);
+	/** Leave an object with the mouse. */
+	void leaveObject(Object *object);
+
 	/** Add a single event for consideration into the event queue. */
 	void addEvent(const Events::Event &event);
 	/** Process the current event queue. */

--- a/src/engines/kotor/situated.cpp
+++ b/src/engines/kotor/situated.cpp
@@ -94,6 +94,10 @@ void Situated::playAnimation(const Common::UString &anim, bool restart, float le
 		_model->playAnimation(anim, restart, length, speed);
 }
 
+void Situated::getTooltipAnchor(float &x, float &y, float &z) const {
+	_model->getTooltipAnchor(x, y, z);
+}
+
 bool Situated::isLocked() const {
 	return _locked;
 }

--- a/src/engines/kotor/situated.h
+++ b/src/engines/kotor/situated.h
@@ -85,6 +85,10 @@ public:
 	                   float length = 0.0f,
 	                   float speed = 1.0f);
 
+	// Tooltip Anchor point
+
+	virtual void getTooltipAnchor(float &x, float &y, float &z) const;
+
 protected:
 	Common::UString _modelName; ///< The model's resource name.
 

--- a/src/graphics/aurora/text.cpp
+++ b/src/graphics/aurora/text.cpp
@@ -172,8 +172,8 @@ void Text::getPosition(float &x, float &y, float &z) const {
 void Text::setPosition(float x, float y, float z) {
 	lockFrameIfVisible();
 
-	_x = roundf(x);
-	_y = roundf(y);
+	_x = x;
+	_y = y;
 
 	_distance = z;
 	resort();
@@ -223,7 +223,7 @@ void Text::render(RenderPass pass) {
 	Font &font = _font.getFont();
 	float lineHeight = font.getHeight() + font.getLineSpacing();
 
-	glTranslatef(_x, _y, 0.0f);
+	glTranslatef(roundf(_x), roundf(_y), 0.0f);
 
 	glColor4f(_r, _g, _b, _a);
 
@@ -285,8 +285,8 @@ void Text::renderImmediate(const glm::mat4 &parentTransform)
 	ColorPositions::const_iterator color = _colors.begin();
 
 	_font.getFont().renderBind(parentTransform);
-	float x = _x;
-	float y = _y + roundf(((_height - blockSize) * _valign) + blockSize - lineHeight);
+	float x = roundf(_x);
+	float y = roundf(_y) + roundf(((_height - blockSize) * _valign) + blockSize - lineHeight);
 	// Draw lines
 	for (std::vector<Common::UString>::iterator l = lines.begin(); l != lines.end(); ++l) {
 		float saved_x = x;


### PR DESCRIPTION
This PR introduces the selection circles and the object information. It tries to mirror the behaviour of the original game and is my second try after #243. It is not yet complete and should only show the name and the health of the object when hovering over it.