### PR TITLE
NWN2: Add GetGameDifficulty() script function

### DIFF
--- a/src/engines/nwn2/game.cpp
+++ b/src/engines/nwn2/game.cpp
@@ -67,6 +67,10 @@ Module &Game::getModule() {
 	return _campaign->getModule();
 }
 
+int32 Game::getGameDifficulty() {
+	return ConfigMan.getInt("difficulty");
+}
+
 void Game::run() {
 	_campaign.reset(new Campaign(*_console));
 

--- a/src/engines/nwn2/game.h
+++ b/src/engines/nwn2/game.h
@@ -54,6 +54,8 @@ public:
 	Campaign &getCampaign();
 	/** Return the module context. */
 	Module &getModule();
+	/** Return the game difficulty setting. */
+	int32 getGameDifficulty();
 
 	/** Overwrite all currently playing music. */
 	void playMusic(const Common::UString &music = "");

--- a/src/engines/nwn2/nwn2.cpp
+++ b/src/engines/nwn2/nwn2.cpp
@@ -147,6 +147,7 @@ void NWN2Engine::init() {
 
 	progress.step("Loading user game config");
 	initConfig();
+	checkConfig();
 
 	initResources(progress);
 	if (EventMan.quitRequested())
@@ -358,6 +359,7 @@ void NWN2Engine::initCursors() {
 void NWN2Engine::initConfig() {
 	// Enable/Disable the Proof-of-Concept software tinting
 	ConfigMan.setBool(Common::kConfigRealmDefault, "tint", true);
+	ConfigMan.setInt(Common::kConfigRealmDefault, "difficulty", 2);
 }
 
 void NWN2Engine::initGameConfig() {
@@ -373,6 +375,10 @@ void NWN2Engine::initGameConfig() {
 		Common::FilePath::findSubDirectory(_target, "localvault", true));
 	ConfigMan.setString(Common::kConfigRealmGameTemp, "NWN2_serverPCDir",
 		Common::FilePath::findSubDirectory(_target, "servervault", true));
+}
+
+void NWN2Engine::checkConfig() {
+	checkConfigInt("difficulty", 0, 4);
 }
 
 void NWN2Engine::deinit() {

--- a/src/engines/nwn2/nwn2.h
+++ b/src/engines/nwn2/nwn2.h
@@ -79,6 +79,8 @@ private:
 
 	void deinit();
 
+	void checkConfig();
+
 	void playIntroVideos();
 };
 

--- a/src/engines/nwn2/script/function_tables.h
+++ b/src/engines/nwn2/script/function_tables.h
@@ -651,7 +651,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{  510, "EffectSwarm"                         , 0                                                },
 	{  511, "GetWeaponRanged"                     , 0                                                },
 	{  512, "DoSinglePlayerAutoSave"              , 0                                                },
-	{  513, "GetGameDifficulty"                   , 0                                                },
+	{  513, "GetGameDifficulty"                   , &Functions::getGameDifficulty                    },
 	{  514, "SetTileMainLightColor"               , 0                                                },
 	{  515, "SetTileSourceLightColor"             , 0                                                },
 	{  516, "RecomputeStaticLighting"             , 0                                                },

--- a/src/engines/nwn2/script/functions.cpp
+++ b/src/engines/nwn2/script/functions.cpp
@@ -126,6 +126,10 @@ Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::Func
 	return object;
 }
 
+void Functions::getGameDifficulty(Aurora::NWScript::FunctionContext &ctx) {
+	ctx.getReturn() = (int32) _game->getGameDifficulty();
+}
+
 void Functions::jumpTo(NWN2::Object *object, Area *area, float x, float y, float z) {
 	// Sanity check
 	if (!object->getArea() || !area) {

--- a/src/engines/nwn2/script/functions.h
+++ b/src/engines/nwn2/script/functions.h
@@ -79,6 +79,8 @@ private:
 	// .--- Utility methods
 	void jumpTo(NWN2::Object *object, Area *area, float x, float y, float z);
 
+	void getGameDifficulty(Aurora::NWScript::FunctionContext &ctx);
+
 	static int32 getRandom(int min, int max, int32 n = 1);
 
 	static Common::UString formatFloat(float f, int width = 18, int decimals = 9);


### PR DESCRIPTION
This will remove a warning during startup about a TODO function. The code sets
the default difficulty value to '2' for the GAME_DIFFICULTY_NORMAL mode and
checks that the difficulty value is in the range 0 (GAME_DIFFICULTY_VERY EASY)
to 4 (GAME_DIFFICULTY_DIFFICULT).