### PR TITLE
GRAPHICS: force add duplicate mesh names

### DIFF
--- a/src/graphics/mesh/meshman.cpp
+++ b/src/graphics/mesh/meshman.cpp
@@ -24,11 +24,13 @@
 
 
 #include "src/common/util.h"
+#include "src/common/uuid.h"
 
 #include "src/graphics/mesh/meshman.h"
 #include "src/graphics/mesh/meshwirebox.h"
 #include "src/graphics/mesh/meshfont.h"
 #include "src/graphics/mesh/meshquad.h"
+
 
 DECLARE_SINGLETON(Graphics::Mesh::MeshManager)
 
@@ -81,7 +83,7 @@ void MeshManager::cleanup() {
 	}
 }
 
-void MeshManager::addMesh(Mesh *mesh) {
+void MeshManager::addMesh(Mesh *mesh, bool forceAddMesh) {
 	if (!mesh) {
 		return;
 	}
@@ -89,6 +91,10 @@ void MeshManager::addMesh(Mesh *mesh) {
 	std::map<Common::UString, Mesh *>::iterator iter = _resourceMap.find(mesh->getName());
 	if (iter == _resourceMap.end()) {
 		_resourceMap[mesh->getName()] = mesh;
+	} else if (forceAddMesh) {
+		Common::UString name = mesh->getName() + "#" + Common::generateIDRandomString();
+		mesh->setName(name);
+		this->addMesh(mesh);  // Recursive call, but it'll add the mesh eventually with a unique name.
 	}
 }
 

--- a/src/graphics/mesh/meshman.h
+++ b/src/graphics/mesh/meshman.h
@@ -52,7 +52,7 @@ public:
 	void cleanup();
 
 	/** Adds a mesh to be managed. Cleanup will delete the mesh if usage count is zero. */
-	void addMesh(Mesh *mesh);
+	void addMesh(Mesh *mesh, bool forceAddMesh = true);
 
 	/** Forcibly remove the mesh from the map. Consider using cleanup instead. */
 	void delMesh(Mesh *mesh);


### PR DESCRIPTION
When a duplicate mesh name is detected, force add the mesh by
changing its name to something unique.