### PR TITLE
AURORA: Use float math functions in LocalPathfinding code

### DIFF
--- a/src/engines/aurora/localpathfinding.cpp
+++ b/src/engines/aurora/localpathfinding.cpp
@@ -495,10 +495,10 @@ void LocalPathfinding::rasterizeTriangle(std::vector<glm::vec3> &vertices, float
 	const float minY = MIN(y1, MIN(y2, y0)) - halfWidth;
 	const float maxY = MAX(MAX(y1, MAX(y2, y0)) + halfWidth, 0.f);
 
-	const uint32 startY = static_cast<uint32>(MAX(floor(minY / _cellSize), 0.f));
-	const uint32 startX = static_cast<uint32>(MAX(floor(minX / _cellSize), 0.f));
-	const uint32 endY = static_cast<uint32>(MIN(ceil(maxY / _cellSize), static_cast<float>(_gridHeight)));
-	const uint32 endX = static_cast<uint32>(MIN(ceil(maxX / _cellSize), static_cast<float>(_gridWidth)));
+	const uint32 startY = static_cast<uint32>(MAX(floorf(minY / _cellSize), 0.f));
+	const uint32 startX = static_cast<uint32>(MAX(floorf(minX / _cellSize), 0.f));
+	const uint32 endY = static_cast<uint32>(MIN(ceilf(maxY / _cellSize), static_cast<float>(_gridHeight)));
+	const uint32 endX = static_cast<uint32>(MIN(ceilf(maxX / _cellSize), static_cast<float>(_gridWidth)));
 
 	const float dy10 = y1 - y0;
 	const float dy21 = y2 - y1;


### PR DESCRIPTION
`floor()` and `ceil()` return `double` values, however they're used in MIN/MAX with `float` values as the second argument. This breaks the build with MinGW32, and possibly on other platforms as well.