### PR TITLE
NWN2: Set the cursor type for a mouse-over of a door or placeable

### DIFF
--- a/src/engines/nwn2/cursor.h
+++ b/src/engines/nwn2/cursor.h
@@ -38,7 +38,7 @@ namespace NWN2 {
 
 static const Common::UString kCursorDefault       = "default";       //   0,   1
 static const Common::UString kCursorWalk          = "walk";          //   3,   4 (testing: 0, 2)
-static const Common::UString kCUrsorNoWalk        = "nowalk";        //   5,   6
+static const Common::UString kCursorNoWalk        = "nowalk";        //   5,   6
 static const Common::UString kCursorAttack        = "attack";        //   7,   8
 static const Common::UString kCursorNoAttack      = "noattack";      //   9,  10
 static const Common::UString kCursorTalk          = "talk";          //  11,  12

--- a/src/engines/nwn2/door.cpp
+++ b/src/engines/nwn2/door.cpp
@@ -31,6 +31,7 @@
 #include "src/aurora/2dareg.h"
 
 #include "src/graphics/aurora/model.h"
+#include "src/graphics/aurora/cursorman.h"
 
 #include "src/engines/aurora/util.h"
 
@@ -39,6 +40,7 @@
 #include "src/engines/nwn2/module.h"
 #include "src/engines/nwn2/trap.h"
 #include "src/engines/nwn2/area.h"
+#include "src/engines/nwn2/cursor.h"
 
 namespace Engines {
 
@@ -156,10 +158,21 @@ void Door::hide() {
 }
 
 void Door::enter() {
+	if (getIsTrapped() && getTrapFlagged() &&
+	    getIsEnemy(getArea()->getModule().getPC())) {
+		// Hostile trap spotted
+		CursorMan.setGroup(kCursorDisarm);
+	} else if (isLocked()) {
+		// Lock needs to be opened
+		CursorMan.setGroup(kCursorLock);
+	} else {
+		CursorMan.setGroup(kCursorDoor);
+	}
 	highlight(true);
 }
 
 void Door::leave() {
+	CursorMan.setGroup(kCursorDefault);
 	highlight(false);
 }
 

--- a/src/engines/nwn2/placeable.cpp
+++ b/src/engines/nwn2/placeable.cpp
@@ -30,12 +30,15 @@
 #include "src/aurora/2dareg.h"
 
 #include "src/graphics/aurora/model.h"
+#include "src/graphics/aurora/cursorman.h"
 
 #include "src/engines/aurora/util.h"
 
 #include "src/engines/nwn2/placeable.h"
 #include "src/engines/nwn2/trap.h"
+#include "src/engines/nwn2/module.h"
 #include "src/engines/nwn2/area.h"
+#include "src/engines/nwn2/cursor.h"
 
 namespace Engines {
 
@@ -136,10 +139,22 @@ void Placeable::loadAppearance() {
 }
 
 void Placeable::enter() {
+	if (_hasInventory && getIsTrapped() && getTrapFlagged() &&
+	    getIsEnemy(getArea()->getModule().getPC())) {
+		// Hostile trap spotted on container
+		CursorMan.setGroup(kCursorDisarm);
+	} else if (isLocked()) {
+		// Lock needs to be opened
+		CursorMan.setGroup(kCursorLock);
+	} else {
+		// Set to default action
+		CursorMan.setGroup(kCursorAction);
+	}
 	highlight(true);
 }
 
 void Placeable::leave() {
+	CursorMan.setGroup(kCursorDefault);
 	highlight(false);
 }
 

--- a/src/engines/nwn2/placeable.cpp
+++ b/src/engines/nwn2/placeable.cpp
@@ -46,7 +46,8 @@ namespace NWN2 {
 
 Placeable::Placeable(const Aurora::GFF3Struct &placeable) :
 	Situated(kObjectTypePlaceable), Trap(placeable),
-	_state(kStateDefault), _hasInventory(false) {
+	_state(kStateDefault), _defAction(kDefActionAutomatic),
+	_hasInventory(false) {
 
 	load(placeable);
 }
@@ -117,6 +118,8 @@ void Placeable::loadObject(const Aurora::GFF3Struct &gff) {
 
 	_state = (State) gff.getUint("AnimationState", (uint) _state);
 
+	_defAction = (DefAction) gff.getUint("DefAction", (uint) _defAction);
+
 	_hasInventory = gff.getBool("HasInventory", _hasInventory);
 
 	// Faction
@@ -147,8 +150,28 @@ void Placeable::enter() {
 		// Lock needs to be opened
 		CursorMan.setGroup(kCursorLock);
 	} else {
-		// Set to default action
-		CursorMan.setGroup(kCursorAction);
+		// Set cursor to match default action preference
+		switch(_defAction) {
+			case kDefActionAutomatic:
+				CursorMan.setGroup(kCursorAction);
+				break;
+                	case kDefActionUse:
+				CursorMan.setGroup(kCursorAction);
+				break;
+                	case kDefActionBash:
+				CursorMan.setGroup(kCursorAttack);
+				break;
+                	case kDefActionDisableTrap:
+				CursorMan.setGroup(kCursorDisarm);
+				break;
+                	case kDefActionExamine:
+				CursorMan.setGroup(kCursorExamine);
+				break;
+			default:
+				CursorMan.setGroup(kCursorDefault);
+				break;
+		}
+
 	}
 	highlight(true);
 }

--- a/src/engines/nwn2/placeable.h
+++ b/src/engines/nwn2/placeable.h
@@ -48,6 +48,15 @@ public:
 		kStateDeactivated = 5  ///< Deactivated.
 	};
 
+	/** The default action for a placeable. */
+	enum DefAction {
+		kDefActionAutomatic   = 0, ///< Select by type.
+		kDefActionUse         = 1, ///< Use.
+		kDefActionBash        = 2, ///< Bash.
+		kDefActionDisableTrap = 3, ///< Disable trap.
+		kDefActionExamine     = 4, ///< Examine.
+	};
+
 	/** Load from a placeable instance. */
 	Placeable(const Aurora::GFF3Struct &placeable);
 	~Placeable();
@@ -96,6 +105,8 @@ protected:
 
 private:
 	State _state; ///< The current state of the placeable.
+
+	DefAction _defAction; ///< The default action on a click.
 
 	bool _hasInventory; ///< Does this placeable have an inventory?
 


### PR DESCRIPTION
This should complete the basic cursor type functionality for NWN2,
at least until the UI is added. Note that I verified the DefAction enum
values via a save file cross-check. The order is slightly different than
the menu picks in the toolset.