### PR TITLE
APPVEYOR: Add the path for NASM to the cache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -92,6 +92,9 @@ build_script:
 
 cache:
   - libs
+  - C:\ProgramData\chocolatey\bin
+  - C:\ProgramData\chocolatey\lib
+  - C:\Program Files\NASM
   - C:\Program Files\FAAD
   - C:\Program Files\XviD
   - C:\Program Files (x86)\FAAD


### PR DESCRIPTION
Second attempt, without the test commits. I hadn't realised that the cache isn't updated when building pull requests. Hopefully fixes issue #428