### PR TITLE
ENGINES: PC and party management refactoring for KotOR games

### DIFF
--- a/src/engines/kotor/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor/gui/chargen/charactergeneration.cpp
@@ -239,9 +239,7 @@ void CharacterGenerationMenu::start() {
 	hide();
 
 	try {
-		Common::ScopedPtr<Creature> pc(new Creature());
-		pc->createPC(*_pc);
-		_module->usePC(pc.release());
+		_module->usePC(*_pc);
 		_module->load("end_m01aa");
 	} catch (...) {
 		Common::exceptionDispatcherWarning();

--- a/src/engines/kotor/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor/gui/chargen/chargeninfo.cpp
@@ -32,6 +32,13 @@ namespace Engines {
 
 namespace KotOR {
 
+CharacterGenerationInfo::CharacterGenerationInfo() : KotORBase::CharacterGenerationInfo() {
+}
+
+CharacterGenerationInfo::CharacterGenerationInfo(const KotORBase::CharacterGenerationInfo &info) :
+		KotORBase::CharacterGenerationInfo(info) {
+}
+
 CharacterGenerationInfo *CharacterGenerationInfo::createRandomMaleSoldier() {
 	CharacterGenerationInfo *info = new CharacterGenerationInfo();
 	info->_gender = KotORBase::kGenderMale;

--- a/src/engines/kotor/gui/chargen/chargeninfo.h
+++ b/src/engines/kotor/gui/chargen/chargeninfo.h
@@ -33,6 +33,9 @@ namespace KotOR {
 
 class CharacterGenerationInfo : public KotORBase::CharacterGenerationInfo {
 public:
+	CharacterGenerationInfo();
+	CharacterGenerationInfo(const KotORBase::CharacterGenerationInfo &info);
+
 	// Create a random character for each of the six archetypes
 	static CharacterGenerationInfo *createRandomMaleSoldier();
 	static CharacterGenerationInfo *createRandomMaleScout();

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -472,15 +472,15 @@ void HUD::initWidget(Engines::Widget &widget) {
 
 void HUD::callbackActive(Widget &widget) {
 	if (widget.getTag() == "LBL_CHAR1") {
-		_module->switchPlayerCharacter(0);
+		_module->setPartyLeaderByIndex(0);
 		return;
 	}
 	if (widget.getTag() == "LBL_CHAR2") {
-		_module->switchPlayerCharacter(2);
+		_module->setPartyLeaderByIndex(2);
 		return;
 	}
 	if (widget.getTag() == "LBL_CHAR3") {
-		_module->switchPlayerCharacter(1);
+		_module->setPartyLeaderByIndex(1);
 		return;
 	}
 

--- a/src/engines/kotor/gui/ingame/menu.cpp
+++ b/src/engines/kotor/gui/ingame/menu.cpp
@@ -97,6 +97,10 @@ void Menu::setReturnEnabled(bool enabled) {
 
 void Menu::showMenu(MenuType type) {
 	assert((type >= 0) && (type < kMenuTypeMAX));
+
+	if (type == kMenuTypeEquipment)
+		dynamic_cast<MenuEquipment *>(_menu[type].menu.get())->setPC(_module.getPC());
+
 	if (_currentMenu == &_menu[type])
 		return;
 
@@ -108,9 +112,6 @@ void Menu::showMenu(MenuType type) {
 	_currentMenu = &_menu[type];
 	addChild(_currentMenu->menu.get());
 	_currentMenu->protoItem->setHighlight(true);
-
-	if (type == kMenuTypeEquipment)
-		dynamic_cast<MenuEquipment &>(*_currentMenu->menu.get()).setPC(_module.getPC());
 }
 
 void Menu::callbackRun() {

--- a/src/engines/kotor/gui/ingame/menu.cpp
+++ b/src/engines/kotor/gui/ingame/menu.cpp
@@ -70,7 +70,7 @@ Menu::Menu(KotORBase::Module &module, Console *console) :
 		}
 	}
 
-	_menu[kMenuTypeEquipment].menu.reset(new MenuEquipment(console));
+	_menu[kMenuTypeEquipment].menu.reset(new MenuEquipment(_module, console));
 	_menu[kMenuTypeInventory].menu.reset(new MenuInventory(console));
 	_menu[kMenuTypeCharacter].menu.reset(new MenuCharacter(console));
 	_menu[kMenuTypeAbilities].menu.reset(new MenuAbilities(console));
@@ -99,7 +99,7 @@ void Menu::showMenu(MenuType type) {
 	assert((type >= 0) && (type < kMenuTypeMAX));
 
 	if (type == kMenuTypeEquipment)
-		dynamic_cast<MenuEquipment *>(_menu[type].menu.get())->setPC(_module.getPC());
+		dynamic_cast<MenuEquipment *>(_menu[type].menu.get())->refresh();
 
 	if (_currentMenu == &_menu[type])
 		return;

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -32,6 +32,8 @@
 
 #include "src/engines/kotorbase/item.h"
 #include "src/engines/kotorbase/creature.h"
+#include "src/engines/kotorbase/module.h"
+#include "src/engines/kotorbase/area.h"
 
 #include "src/engines/kotorbase/gui/inventoryitem.h"
 
@@ -41,9 +43,9 @@ namespace Engines {
 
 namespace KotOR {
 
-MenuEquipment::MenuEquipment(Console *console) :
+MenuEquipment::MenuEquipment(KotORBase::Module &module, Console *console) :
 		KotORBase::GUI(console),
-		_pc(0),
+		_module(&module),
 		_selectedSlot(KotORBase::kInventorySlotBody),
 		_slotFixated(false) {
 
@@ -74,9 +76,7 @@ MenuEquipment::MenuEquipment(Console *console) :
 	}
 }
 
-void MenuEquipment::setPC(KotORBase::Creature *pc) {
-	_pc = pc;
-
+void MenuEquipment::refresh() {
 	fillEquipedItems();
 	fillEquipableItemsList();
 }
@@ -136,7 +136,10 @@ void MenuEquipment::callbackActive(Widget &widget) {
 		if (tag == "BTN_EQUIP") {
 			int selectedIndex = getListBox("LB_ITEMS")->getSelectedIndex();
 			Common::UString itemTag = selectedIndex > 0 ? _visibleItems[selectedIndex - 1] : "";
-			_pc->equipItem(itemTag, _selectedSlot);
+
+			KotORBase::Creature *pc = _module->getPC();
+			pc->equipItem(itemTag, _selectedSlot);
+			_module->getCurrentArea()->addToObjectMap(pc);
 
 			fillEquipedItems();
 			fillEquipableItemsList();
@@ -198,12 +201,12 @@ void MenuEquipment::fillEquipedItems() {
 }
 
 Common::UString MenuEquipment::getEquipedItemIcon(KotORBase::InventorySlot slot) const {
-	KotORBase::Item *item = _pc->getEquipedItem(slot);
+	KotORBase::Item *item = _module->getPC()->getEquipedItem(slot);
 	return item ? item->getIcon() : "";
 }
 
 void MenuEquipment::fillEquipableItemsList() {
-	KotORBase::Inventory &inv = _pc->getInventory();
+	KotORBase::Inventory &inv = _module->getPC()->getInventory();
 
 	Odyssey::WidgetListBox *lbItems = getListBox("LB_ITEMS");
 	lbItems->removeAllItems();

--- a/src/engines/kotor/gui/ingame/menu_equ.h
+++ b/src/engines/kotor/gui/ingame/menu_equ.h
@@ -36,15 +36,16 @@ namespace Odyssey {
 
 namespace KotORBase {
 	class Creature;
+	class Module;
 }
 
 namespace KotOR {
 
 class MenuEquipment : public KotORBase::GUI {
 public:
-	MenuEquipment(::Engines::Console *console = 0);
+	MenuEquipment(KotORBase::Module &module, ::Engines::Console *console = 0);
 
-	void setPC(KotORBase::Creature *pc);
+	void refresh();
 
 	void show();
 	void hide();
@@ -55,7 +56,7 @@ protected:
 	void callbackKeyInput(const Events::Key &key, const Events::EventType &type);
 
 private:
-	KotORBase::Creature *_pc;
+	KotORBase::Module *_module;
 	KotORBase::InventorySlot _selectedSlot;
 	bool _slotFixated;
 	std::vector<Common::UString> _visibleItems;

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -42,7 +42,7 @@ Module::Module(::Engines::Console &console) : KotORBase::Module(console) {
 	_partySelection.reset(new PartySelectionGUI());
 }
 
-KotORBase::LoadScreen *Module::createLoadScreen(const Common::UString &name) {
+KotORBase::LoadScreen *Module::createLoadScreen(const Common::UString &name) const {
 	return new LoadScreen(name);
 }
 

--- a/src/engines/kotor/module.cpp
+++ b/src/engines/kotor/module.cpp
@@ -32,6 +32,8 @@
 
 #include "src/engines/kotor/gui/loadscreen/loadscreen.h"
 
+#include "src/engines/kotor/gui/chargen/chargeninfo.h"
+
 namespace Engines {
 
 namespace KotOR {
@@ -56,6 +58,10 @@ KotORBase::Creature *Module::createCreature() const {
 
 KotORBase::Creature *Module::createCreature(const Common::UString &resRef) const {
 	return new Creature(resRef);
+}
+
+KotORBase::CharacterGenerationInfo *Module::createCharGenInfo(const KotORBase::CharacterGenerationInfo &info) const {
+	return new CharacterGenerationInfo(info);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -44,6 +44,10 @@ public:
 	KotORBase::Creature *createCreature() const;
 	KotORBase::Creature *createCreature(const Common::UString &resRef) const;
 	KotORBase::Creature *createCreature(const Aurora::GFF3Struct &creature) const;
+
+	// Miscellaneous creation
+
+	KotORBase::CharacterGenerationInfo *createCharGenInfo(const KotORBase::CharacterGenerationInfo &info) const;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/module.h
+++ b/src/engines/kotor/module.h
@@ -37,10 +37,7 @@ public:
 
 	// GUI creation
 
-	KotORBase::IngameGUI *createIngameGUI();
-	KotORBase::DialogGUI *createDialogGUI();
-	KotORBase::PartySelectionGUI *createPartySelectionGUI();
-	KotORBase::LoadScreen *createLoadScreen(const Common::UString &name);
+	KotORBase::LoadScreen *createLoadScreen(const Common::UString &name) const;
 
 	// Object creation
 

--- a/src/engines/kotor/savedgame.cpp
+++ b/src/engines/kotor/savedgame.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "src/engines/kotor/savedgame.h"
-#include "src/engines/kotor/creature.h"
 
 #include "src/engines/kotor/gui/chargen/chargeninfo.h"
 
@@ -35,29 +34,13 @@ SavedGame::SavedGame(const Common::UString &dir, bool loadSav) :
 		KotORBase::SavedGame(dir, loadSav) {
 }
 
-KotORBase::Creature *SavedGame::createPC() {
-	if (_pc)
-		return _pc;
-
-	Common::ScopedPtr<CharacterGenerationInfo> info;
-
+KotORBase::CharacterGenerationInfo *SavedGame::createCharGenInfo() {
 	switch (_pcGender) {
 		case KotORBase::kGenderFemale:
-			info.reset(CharacterGenerationInfo::createRandomFemaleSoldier());
-			break;
+			return CharacterGenerationInfo::createRandomFemaleSoldier();
 		default:
-			info.reset(CharacterGenerationInfo::createRandomMaleSoldier());
-			break;
+			return CharacterGenerationInfo::createRandomMaleSoldier();
 	}
-
-	Common::ScopedPtr<Creature> pc(new Creature());
-	pc->createPC(*info);
-	_pc = pc.release();
-
-	if (_pcLoaded)
-		_pc->setPosition(_pcPosition[0], _pcPosition[1], _pcPosition[2]);
-
-	return _pc;
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/savedgame.h
+++ b/src/engines/kotor/savedgame.h
@@ -35,7 +35,7 @@ class SavedGame : public KotORBase::SavedGame {
 public:
 	SavedGame(const Common::UString &dir, bool loadSav = false);
 
-	KotORBase::Creature *createPC();
+	KotORBase::CharacterGenerationInfo *createCharGenInfo();
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/script/function_tables.h
+++ b/src/engines/kotor/script/function_tables.h
@@ -131,7 +131,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{  10, "SetFacing"                           , 0                                                },
 	{  11, "SwitchPlayerCharacter"               , 0                                                },
 	{  12, "SetTime"                             , 0                                                },
-	{  13, "SetPartyLeader"                      , 0                                                },
+	{  13, "SetPartyLeader"                      , &Functions::setPartyLeader                       },
 	{  14, "SetAreaUnescapable"                  , 0                                                },
 	{  15, "GetAreaUnescapable"                  , 0                                                },
 	{  16, "GetTimeHour"                         , 0                                                },

--- a/src/engines/kotor2/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor2/gui/chargen/charactergeneration.cpp
@@ -136,9 +136,7 @@ void CharacterGeneration::resetStep() {
 
 void CharacterGeneration::start() {
 	try {
-		Common::ScopedPtr<Creature> pc(new Creature());
-		pc->createPC(*_chargenInfo);
-		_module->usePC(pc.release());
+		_module->usePC(*_chargenInfo);
 		_module->load("001EBO");
 	} catch (...) {
 		Common::exceptionDispatcherWarning();

--- a/src/engines/kotor2/gui/chargen/chargeninfo.cpp
+++ b/src/engines/kotor2/gui/chargen/chargeninfo.cpp
@@ -32,6 +32,13 @@ namespace Engines {
 
 namespace KotOR2 {
 
+CharacterGenerationInfo::CharacterGenerationInfo() : KotORBase::CharacterGenerationInfo() {
+}
+
+CharacterGenerationInfo::CharacterGenerationInfo(const KotORBase::CharacterGenerationInfo &info) :
+		KotORBase::CharacterGenerationInfo(info) {
+}
+
 CharacterGenerationInfo *CharacterGenerationInfo::createRandomMaleConsular() {
 	CharacterGenerationInfo *info = new CharacterGenerationInfo();
 	info->_gender = KotORBase::kGenderMale;

--- a/src/engines/kotor2/gui/chargen/chargeninfo.h
+++ b/src/engines/kotor2/gui/chargen/chargeninfo.h
@@ -33,6 +33,9 @@ namespace KotOR2 {
 
 class CharacterGenerationInfo : public KotORBase::CharacterGenerationInfo {
 public:
+	CharacterGenerationInfo();
+	CharacterGenerationInfo(const KotORBase::CharacterGenerationInfo &info);
+
 	static CharacterGenerationInfo *createRandomMaleConsular();
 	static CharacterGenerationInfo *createRandomFemaleConsular();
 	static CharacterGenerationInfo *createRandomMaleGuardian();

--- a/src/engines/kotor2/kotor2.cpp
+++ b/src/engines/kotor2/kotor2.cpp
@@ -401,6 +401,9 @@ void KotOR2Engine::initCursors() {
 
 void KotOR2Engine::initConfig() {
 	ConfigMan.setInt(Common::kConfigRealmDefault, "texturepack", 2);
+
+	// Should we disable hiding of far rooms when the fly cam is enabled?
+	ConfigMan.setBool(Common::kConfigRealmDefault, "flycamallrooms", true);
 }
 
 void KotOR2Engine::initGameConfig() {

--- a/src/engines/kotor2/module.cpp
+++ b/src/engines/kotor2/module.cpp
@@ -32,6 +32,8 @@
 #include "src/engines/kotor2/gui/ingame/ingame.h"
 #include "src/engines/kotor2/gui/ingame/partyselection.h"
 
+#include "src/engines/kotor2/gui/chargen/chargeninfo.h"
+
 namespace Engines {
 
 namespace KotOR2 {
@@ -58,6 +60,10 @@ KotORBase::Creature *Module::createCreature() const {
 
 KotORBase::Creature *Module::createCreature(const Common::UString &resRef) const {
 	return new Creature(resRef);
+}
+
+KotORBase::CharacterGenerationInfo *Module::createCharGenInfo(const KotORBase::CharacterGenerationInfo &info) const {
+	return new CharacterGenerationInfo(info);
 }
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/module.cpp
+++ b/src/engines/kotor2/module.cpp
@@ -44,7 +44,7 @@ Module::Module(::Engines::Console &console) : KotORBase::Module(console) {
 	loadTexturePack();
 }
 
-KotORBase::LoadScreen *Module::createLoadScreen(const Common::UString &name) {
+KotORBase::LoadScreen *Module::createLoadScreen(const Common::UString &name) const {
 	return new KotORBase::LoadScreen(name);
 }
 

--- a/src/engines/kotor2/module.h
+++ b/src/engines/kotor2/module.h
@@ -51,6 +51,10 @@ public:
 	KotORBase::Creature *createCreature() const;
 	KotORBase::Creature *createCreature(const Common::UString &resRef) const;
 	KotORBase::Creature *createCreature(const Aurora::GFF3Struct &creature) const;
+
+	// Miscellaneous creation
+
+	KotORBase::CharacterGenerationInfo *createCharGenInfo(const KotORBase::CharacterGenerationInfo &info) const;
 };
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/module.h
+++ b/src/engines/kotor2/module.h
@@ -44,10 +44,7 @@ public:
 
 	// GUI creation
 
-	KotORBase::IngameGUI *createIngameGUI();
-	KotORBase::DialogGUI *createDialogGUI();
-	KotORBase::PartySelectionGUI *createPartySelectionGUI();
-	KotORBase::LoadScreen *createLoadScreen(const Common::UString &name);
+	KotORBase::LoadScreen *createLoadScreen(const Common::UString &name) const;
 
 	// Object creation
 

--- a/src/engines/kotor2/script/function_tables.h
+++ b/src/engines/kotor2/script/function_tables.h
@@ -132,7 +132,7 @@ const Functions::FunctionPointer Functions::kFunctionPointers[] = {
 	{  10, "SetFacing"                           , 0                                                },
 	{  11, "SwitchPlayerCharacter"               , 0                                                },
 	{  12, "SetTime"                             , 0                                                },
-	{  13, "SetPartyLeader"                      , 0                                                },
+	{  13, "SetPartyLeader"                      , &Functions::setPartyLeader                       },
 	{  14, "SetAreaUnescapable"                  , 0                                                },
 	{  15, "GetAreaUnescapable"                  , 0                                                },
 	{  16, "GetTimeHour"                         , 0                                                },

--- a/src/engines/kotorbase/action.cpp
+++ b/src/engines/kotorbase/action.cpp
@@ -31,6 +31,11 @@ namespace KotORBase {
 Action::Action() : type(kActionInvalid), object(0), range(0.0f) {
 }
 
+Action::Action(ActionType _type, Object *_object) :
+		type(_type),
+		object(_object) {
+}
+
 } // End of namespace KotORBase
 
 } // End of namespace Engines

--- a/src/engines/kotorbase/action.h
+++ b/src/engines/kotorbase/action.h
@@ -42,6 +42,7 @@ struct Action {
 	float range;
 
 	Action();
+	Action(ActionType type, Object *object);
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/actionexecutor.cpp
+++ b/src/engines/kotorbase/actionexecutor.cpp
@@ -66,7 +66,7 @@ void ActionExecutor::executeMoveToPoint(Creature &creature, Area &area, const Ac
 
 void ActionExecutor::executeFollowLeader(Creature &creature, Area &area, const Action &UNUSED(action), float dt) {
 	float x, y, z;
-	area._module->getPC()->getPosition(x, y, z);
+	area._module->getPartyLeader()->getPosition(x, y, z);
 	moveTo(creature, area, x, y, 1.0f, dt);
 }
 

--- a/src/engines/kotorbase/area.cpp
+++ b/src/engines/kotorbase/area.cpp
@@ -424,12 +424,8 @@ void Area::loadObject(Object &object) {
 	_objects.push_back(&object);
 	_module->addObject(object);
 
-	if (!object.isStatic()) {
-		const std::list<uint32> &ids = object.getIDs();
-
-		for (std::list<uint32>::const_iterator id = ids.begin(); id != ids.end(); ++id)
-			_objectMap.insert(std::make_pair(*id, &object));
-	}
+	if (!object.isStatic())
+		addToObjectMap(&object);
 
 	notifyObjectMoved(object);
 }
@@ -748,6 +744,12 @@ void Area::processCreaturesActions(float dt) {
 void Area::addCreature(Creature *creature) {
 	loadObject(*creature);
 	_creatures.push_back(creature);
+}
+
+void Area::addToObjectMap(Object *object) {
+	const std::list<uint32> &ids = object->getIDs();
+	for (std::list<uint32>::const_iterator id = ids.begin(); id != ids.end(); ++id)
+		_objectMap.insert(std::make_pair(*id, object));
 }
 
 void Area::removeObject(Object *object) {

--- a/src/engines/kotorbase/area.cpp
+++ b/src/engines/kotorbase/area.cpp
@@ -662,21 +662,21 @@ void Area::notifyObjectMoved(Object &o) {
 	o.setRoom(_pathfinding->getRoomAt(x, y));
 }
 
-void Area::notifyPCMoved() {
-	Creature *pc = _module->getPC();
+void Area::notifyPartyLeaderMoved() {
+	Creature *partyLeader = _module->getPartyLeader();
 
-	const Room *prevPCRoom = pc->getRoom();
-	notifyObjectMoved(*pc);
-	const Room *pcRoom = pc->getRoom();
+	const Room *prevLeaderRoom = partyLeader->getRoom();
+	notifyObjectMoved(*partyLeader);
+	const Room *leaderRoom = partyLeader->getRoom();
 
-	if (pcRoom == prevPCRoom)
+	if (prevLeaderRoom == leaderRoom)
 		return;
 
 	std::vector<Common::UString> visRooms;
-	if (pcRoom) {
-		visRooms.push_back(pcRoom->getResRef());
+	if (leaderRoom) {
+		visRooms.push_back(leaderRoom->getResRef());
 
-		const std::vector<Common::UString> va = _vis.getVisibilityArray(pcRoom->getResRef());
+		const std::vector<Common::UString> va = _vis.getVisibilityArray(leaderRoom->getResRef());
 		for (std::vector<Common::UString>::const_iterator v = va.begin();
 				v != va.end(); ++v) {
 			Common::UString lcResRef(v->toLower());

--- a/src/engines/kotorbase/area.cpp
+++ b/src/engines/kotorbase/area.cpp
@@ -465,9 +465,7 @@ void Area::loadDoors(const Aurora::GFF3List &list) {
 void Area::loadCreatures(const Aurora::GFF3List &list) {
 	for (Aurora::GFF3List::const_iterator c = list.begin(); c != list.end(); ++c) {
 		Creature *creature = _module->createCreature(**c);
-
-		loadObject(*creature);
-		_creatures.push_back(creature);
+		addCreature(creature);
 	}
 }
 
@@ -745,6 +743,11 @@ void Area::processCreaturesActions(float dt) {
 			c != _creatures.end(); ++c) {
 		ActionExecutor::executeActions(**c, *this, dt);
 	}
+}
+
+void Area::addCreature(Creature *creature) {
+	loadObject(*creature);
+	_creatures.push_back(creature);
 }
 
 void Area::removeObject(Object *object) {

--- a/src/engines/kotorbase/area.h
+++ b/src/engines/kotorbase/area.h
@@ -138,6 +138,7 @@ public:
 	Object *getObjectByTag(const Common::UString &tag);
 
 	void addCreature(Creature *creature);
+	void addToObjectMap(Object *object);
 	void removeObject(Object *object);
 
 

--- a/src/engines/kotorbase/area.h
+++ b/src/engines/kotorbase/area.h
@@ -133,6 +133,13 @@ public:
 	void toggleTriggers();
 	void evaluateTriggers(float x, float y);
 
+	// Object management
+
+	Object *getObjectByTag(const Common::UString &tag);
+
+	void addCreature(Creature *creature);
+	void removeObject(Object *object);
+
 
 	void showAllRooms();
 
@@ -142,11 +149,8 @@ public:
 	void getCameraStyle(float &distance, float &pitch, float &height) const;
 	const std::vector<Common::UString> &getRoomsVisibleFrom(const Common::UString &room) const;
 	Object *getActiveObject();
-	Object *getObjectByTag(const Common::UString &tag);
 
 	void processCreaturesActions(float dt);
-
-	void removeObject(Object *object);
 
 protected:
 	void notifyCameraMoved();

--- a/src/engines/kotorbase/area.h
+++ b/src/engines/kotorbase/area.h
@@ -145,7 +145,7 @@ public:
 	void showAllRooms();
 
 	void notifyObjectMoved(Object &o);
-	void notifyPCMoved();
+	void notifyPartyLeaderMoved();
 
 	void getCameraStyle(float &distance, float &pitch, float &height) const;
 	const std::vector<Common::UString> &getRoomsVisibleFrom(const Common::UString &room) const;

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -130,6 +130,12 @@ bool Creature::isPartyMember() const {
 	return _isPC;
 }
 
+void Creature::setUsable(bool usable) {
+	Object::setUsable(usable);
+	if (_model)
+		_model->setClickable(isClickable());
+}
+
 Gender Creature::getGender() const {
 	return _gender;
 }
@@ -512,6 +518,7 @@ void Creature::createFakePC() {
 
 void Creature::createPC(const CharacterGenerationInfo &info) {
 	_name = info.getName();
+	_usable = false;
 	_isPC = true;
 
 	_race = kRaceHuman;

--- a/src/engines/kotorbase/creature.h
+++ b/src/engines/kotorbase/creature.h
@@ -98,6 +98,11 @@ public:
 	/** Is the creature a party member? */
 	bool isPartyMember() const;
 
+	// Interactive properties
+
+	/** Toggle usability of this object. */
+	void setUsable(bool usable);
+
 	// Attributes
 
 	/** Get the current rank of the specified skill. */

--- a/src/engines/kotorbase/door.cpp
+++ b/src/engines/kotorbase/door.cpp
@@ -151,7 +151,7 @@ bool Door::click(Object *triggerer) {
 		return runScript(kScriptClick, this, triggerer);
 
 	if (!_linkedTo.empty()) {
-		_module->movePC(_linkedToModule, _linkedTo, _linkedToType);
+		_module->moveParty(_linkedToModule, _linkedTo, _linkedToType);
 
 		return true;
 	}

--- a/src/engines/kotorbase/gui/inventoryitem.cpp
+++ b/src/engines/kotorbase/gui/inventoryitem.cpp
@@ -33,7 +33,7 @@ namespace Engines {
 
 namespace KotORBase {
 
-WidgetInventoryItem::WidgetInventoryItem(GUI &gui, const Common::UString &tag) : WidgetProtoItem(gui, tag) {
+WidgetInventoryItem::WidgetInventoryItem(Engines::GUI &gui, const Common::UString &tag) : WidgetProtoItem(gui, tag) {
 	setDisableHighlight(true);
 }
 

--- a/src/engines/kotorbase/gui/inventoryitem.h
+++ b/src/engines/kotorbase/gui/inventoryitem.h
@@ -33,7 +33,7 @@ namespace KotORBase {
 
 class WidgetInventoryItem : public Odyssey::WidgetProtoItem {
 public:
-	WidgetInventoryItem(GUI &gui, const Common::UString &tag);
+	WidgetInventoryItem(Engines::GUI &gui, const Common::UString &tag);
 
 	void load(const Aurora::GFF3Struct &gff);
 

--- a/src/engines/kotorbase/module.cpp
+++ b/src/engines/kotorbase/module.cpp
@@ -92,7 +92,7 @@ Module::Module(::Engines::Console &console) :
 		_pcPositionLoaded(false),
 		_inDialog(false),
 		_cameraHeight(0.0f),
-		_playerController(this) {
+		_partyLeaderController(this) {
 
 	loadSurfaceTypes();
 }
@@ -177,7 +177,6 @@ void Module::loadModule(const Common::UString &module, const Common::UString &en
 
 void Module::usePC(Creature *pc) {
 	_pc.reset(pc);
-	_playerController.setPC(_pc.get());
 }
 
 Creature *Module::getPC() {
@@ -528,7 +527,7 @@ void Module::clickObject(Object *object) {
 	if (placeable) {
 		if (placeable->hasInventory()) {
 			stopCameraMovement();
-			_playerController.stopMovement();
+			_partyLeaderController.stopMovement();
 
 			_ingame->showContainer(placeable->getInventory());
 			placeable->close(_pc.get());
@@ -606,7 +605,7 @@ void Module::handleEvents() {
 			}
 		}
 
-		_playerController.handleEvent(*event);
+		_partyLeaderController.handleEvent(*event);
 
 		// Camera
 		if (!_console->isVisible()) {
@@ -642,7 +641,7 @@ void Module::handlePCMovement() {
 	if (!_pc)
 		return;
 
-	_playerController.processMovement(_frameTime);
+	_partyLeaderController.processMovement(_frameTime);
 
 	const float *position = CameraMan.getPosition();
 	SoundMan.setListenerPosition(position[0], position[1], position[2]);
@@ -754,7 +753,6 @@ void Module::switchPlayerCharacter(int npc) {
 		std::advance(iter, npc);
 	_pc.release();
 	_pc.reset(*iter);
-	_playerController.setPC(_pc.get());
 
 	Creature *pc = *iter;
 	_party.erase(iter);
@@ -982,7 +980,7 @@ void Module::startConversation(const Common::UString &name, Aurora::NWScript::Ob
 
 	if (_dialog->isConversationActive()) {
 		stopCameraMovement();
-		_playerController.stopMovement();
+		_partyLeaderController.stopMovement();
 
 		_ingame->hide();
 		_dialog->show();

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -210,6 +210,10 @@ public:
 
 	virtual KotORBase::Creature *createCreature(const Aurora::GFF3Struct &creature) const = 0;
 
+	// Miscellaneous creation
+
+	virtual KotORBase::CharacterGenerationInfo *createCharGenInfo(const CharacterGenerationInfo &info) const = 0;
+
 
 	void addItemToActiveObject(const Common::UString &item, int count);
 	void toggleFreeRoamCamera();

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -44,7 +44,7 @@
 #include "src/engines/kotorbase/object.h"
 #include "src/engines/kotorbase/objectcontainer.h"
 #include "src/engines/kotorbase/savedgame.h"
-#include "src/engines/kotorbase/playercontroller.h"
+#include "src/engines/kotorbase/partyleader.h"
 
 #include "src/engines/kotorbase/gui/ingame.h"
 #include "src/engines/kotorbase/gui/dialog.h"
@@ -295,7 +295,7 @@ private:
 	bool _pcPositionLoaded;
 	bool _inDialog;
 	float _cameraHeight;
-	PlayerController _playerController;
+	PartyLeaderController _partyLeaderController;
 
 
 	// Surface types

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -204,7 +204,7 @@ public:
 
 	// GUI creation
 
-	virtual KotORBase::LoadScreen *createLoadScreen(const Common::UString &name) = 0;
+	virtual KotORBase::LoadScreen *createLoadScreen(const Common::UString &name) const = 0;
 
 	// Object creation
 
@@ -355,7 +355,6 @@ private:
 	void handlePCMovement();
 
 	void stopCameraMovement();
-	void stopPCMovement();
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/object.cpp
+++ b/src/engines/kotorbase/object.cpp
@@ -116,6 +116,10 @@ bool Object::isClickable() const {
 	return !_static && _usable;
 }
 
+void Object::setUsable(bool usable) {
+	_usable = usable;
+}
+
 void Object::getPosition(float &x, float &y, float &z) const {
 	x = _position[0];
 	y = _position[1];

--- a/src/engines/kotorbase/object.h
+++ b/src/engines/kotorbase/object.h
@@ -87,6 +87,9 @@ public:
 	/** Can the player click the object? */
 	bool isClickable() const;
 
+	/** Toggle usability of this object. */
+	virtual void setUsable(bool usable);
+
 	// Positioning
 
 	/** Return the object's position within its area. */

--- a/src/engines/kotorbase/partycontroller.cpp
+++ b/src/engines/kotorbase/partycontroller.cpp
@@ -1,0 +1,129 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Handles the party management in KotOR games.
+ */
+
+#include "src/common/error.h"
+
+#include "src/engines/kotorbase/partycontroller.h"
+#include "src/engines/kotorbase/creature.h"
+
+namespace Engines {
+
+namespace KotORBase {
+
+PartyController::PartyController(Module *module) :
+		_module(module) {
+}
+
+size_t PartyController::getPartyMemberCount() const {
+	return _party.size();
+}
+
+Creature *PartyController::getPartyLeader() const {
+	return _party[0].second;
+}
+
+const std::pair<int, Creature *> &PartyController::getPartyMemberByIndex(int index) const {
+	if (index >= static_cast<int>(_party.size()))
+		throw Common::Exception("PartyController::getPartyMember(): Invalid index");
+
+	return _party[index];
+}
+
+std::vector<int> PartyController::getPartyMembers() const {
+	std::vector<int> partyMembers;
+	for (auto partyMember : _party) {
+		partyMembers.push_back(partyMember.first);
+	}
+	return partyMembers;
+}
+
+bool PartyController::isObjectPartyMember(Creature *object) const {
+	for (auto partyMember : _party) {
+		if (partyMember.second == object)
+			return true;
+	}
+	return false;
+}
+
+void PartyController::clearCurrentParty() {
+	_party.clear();
+}
+
+void PartyController::addPartyMember(int npc, Creature *creature) {
+	_party.push_back(std::make_pair(npc, creature));
+}
+
+void PartyController::setPartyLeader(int npc) {
+	int index = -1;
+
+	int partySize = static_cast<int>(_party.size());
+	for (int i = 1; i < partySize; ++i) {
+		if (_party[i].first == npc) {
+			index = i;
+			break;
+		}
+	}
+
+	if (index == -1)
+		return;
+
+	setPartyLeaderByIndex(index);
+}
+
+void PartyController::setPartyLeaderByIndex(int index) {
+	std::pair<int, Creature *> tmp = _party[0];
+	_party[0] = _party[index];
+	_party[index] = tmp;
+
+	_party[0].second->setUsable(false);
+	_party[index].second->setUsable(true);
+}
+
+const Common::UString &PartyController::getAvailableNPCTemplate(int npc) const {
+	auto it = _availableParty.find(npc);
+	if (it == _availableParty.end())
+		throw Common::Exception("PartyController::getAvailableNPCTemplate: Invalid NPC");
+
+	return it->second;
+}
+
+bool PartyController::isAvailableCreature(int npc) const {
+	return _availableParty.find(npc) != _availableParty.end();
+}
+
+void PartyController::clearAvailableParty() {
+	_availableParty.clear();
+}
+
+void PartyController::addAvailableNPCByTemplate(int npc, const Common::UString &templ) {
+	auto i = _availableParty.find(npc);
+	if (i != _availableParty.end())
+		_availableParty.erase(i);
+
+	_availableParty.insert(std::make_pair(npc, templ));
+}
+
+} // End of namespace KotORBase
+
+} // End of namespace Engines

--- a/src/engines/kotorbase/partycontroller.h
+++ b/src/engines/kotorbase/partycontroller.h
@@ -1,0 +1,90 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Handles the party management in KotOR games.
+ */
+
+#ifndef ENGINES_KOTORBASE_PARTYCONTROLLER_H
+#define ENGINES_KOTORBASE_PARTYCONTROLLER_H
+
+#include <vector>
+#include <map>
+
+#include "src/common/ustring.h"
+
+namespace Engines {
+
+namespace KotORBase {
+
+class Module;
+class Creature;
+
+class PartyController {
+public:
+	PartyController(Module *module);
+
+	// Current party
+
+	/** Get count of members in the party including the party leader. */
+	size_t getPartyMemberCount() const;
+	/** Get the party leader. */
+	Creature *getPartyLeader() const;
+	/** Get the party member at a given index (0 is always the party leader). */
+	const std::pair<int, Creature *> &getPartyMemberByIndex(int index) const;
+	/** Get a list of the party members. */
+	std::vector<int> getPartyMembers() const;
+
+	/** Is a specified creature a party member? */
+	bool isObjectPartyMember(Creature *creature) const;
+	
+	/** Clear the current party. */
+	void clearCurrentParty();
+	/** Add a creature to the party. */
+	void addPartyMember(int npc, Creature *creature);
+	/** Set which party member should be the controlled character. */
+	void setPartyLeader(int npc);
+	/** Set which party member should be the controlled character. */
+	void setPartyLeaderByIndex(int index);
+
+	// Available party
+
+	/** Get a NPC template from the list of available party members. */
+	const Common::UString &getAvailableNPCTemplate(int npc) const;
+
+	/** Is a NPC in the list of available party members? */
+	bool isAvailableCreature(int npc) const;
+
+	/** Clear the list of available party members. */
+	void clearAvailableParty();
+	/** Add a NPC to the list of available party members using a template. */
+	void addAvailableNPCByTemplate(int npc, const Common::UString &templ);
+
+private:
+	Module *_module;
+	std::vector<std::pair<int, Creature *>> _party;
+	std::map<int, Common::UString> _availableParty;
+};
+
+} // End of namespace KotORBase
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTORBASE_PARTYCONTROLLER_H

--- a/src/engines/kotorbase/partyleader.cpp
+++ b/src/engines/kotorbase/partyleader.cpp
@@ -45,7 +45,7 @@ PartyLeaderController::PartyLeaderController(Module *module) :
 void PartyLeaderController::stopMovement() {
 	_forwardMovementWanted = false;
 	_backwardMovementWanted = false;
-	_module->getPC()->playDefaultAnimation();
+	_module->getPartyLeader()->playDefaultAnimation();
 	_moving = false;
 }
 
@@ -76,7 +76,7 @@ bool PartyLeaderController::handleEvent(const Events::Event &e) {
 }
 
 bool PartyLeaderController::processMovement(float frameTime) {
-	Creature *partyLeader = _module->getPC();
+	Creature *partyLeader = _module->getPartyLeader();
 
 	bool moveForwards = _forwardMovementWanted && !_backwardMovementWanted;
 	bool moveBackwards = !_forwardMovementWanted && _backwardMovementWanted;
@@ -108,8 +108,10 @@ bool PartyLeaderController::processMovement(float frameTime) {
 	float z = _module->getCurrentArea()->evaluateElevation(newX, newY);
 	if (z != FLT_MIN) {
 		if (_module->getCurrentArea()->walkable(glm::vec3(x, y, z + 0.1f),
-		                                        glm::vec3(newX, newY, z + 0.1f)))
-			_module->movePC(newX, newY, z);
+		                                        glm::vec3(newX, newY, z + 0.1f))) {
+			partyLeader->setPosition(newX, newY, z);
+			_module->movedPartyLeader();
+		}
 	}
 
 	if (!_moving) {

--- a/src/engines/kotorbase/partyleader.h
+++ b/src/engines/kotorbase/partyleader.h
@@ -19,11 +19,11 @@
  */
 
 /** @file
- *  Handles player character movement in KotOR games.
+ *  Handles the party leader movement in KotOR games.
  */
 
-#ifndef ENGINES_KOTORBASE_PLAYERCONTROLLER_H
-#define ENGINES_KOTORBASE_PLAYERCONTROLLER_H
+#ifndef ENGINES_KOTORBASE_PARTYLEADER_H
+#define ENGINES_KOTORBASE_PARTYLEADER_H
 
 #include "src/events/events.h"
 
@@ -32,13 +32,10 @@ namespace Engines {
 namespace KotORBase {
 
 class Module;
-class Creature;
 
-class PlayerController {
+class PartyLeaderController {
 public:
-	PlayerController(Module *module);
-
-	void setPC(Creature *pc);
+	PartyLeaderController(Module *module);
 
 	void stopMovement();
 	bool handleEvent(const Events::Event &e);
@@ -46,7 +43,6 @@ public:
 
 private:
 	Module *_module;
-	Creature *_pc;
 	bool _forwardMovementWanted;
 	bool _backwardMovementWanted;
 	bool _moving;
@@ -56,4 +52,4 @@ private:
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTORBASE_PLAYERCONTROLLER_H
+#endif // ENGINES_KOTORBASE_PARTYLEADER_H

--- a/src/engines/kotorbase/rules.mk
+++ b/src/engines/kotorbase/rules.mk
@@ -44,7 +44,7 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/actionexecutor.h \
     src/engines/kotorbase/savedgame.h \
     src/engines/kotorbase/game.h \
-    src/engines/kotorbase/playercontroller.h \
+    src/engines/kotorbase/partyleader.h \
     $(EMPTY)
 
 src_engines_kotorbase_libkotorbase_la_SOURCES += \
@@ -68,7 +68,7 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/actionexecutor.cpp \
     src/engines/kotorbase/savedgame.cpp \
     src/engines/kotorbase/game.cpp \
-    src/engines/kotorbase/playercontroller.cpp \
+    src/engines/kotorbase/partyleader.cpp \
     $(EMPTY)
 
 include src/engines/kotorbase/script/rules.mk

--- a/src/engines/kotorbase/rules.mk
+++ b/src/engines/kotorbase/rules.mk
@@ -45,6 +45,7 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/savedgame.h \
     src/engines/kotorbase/game.h \
     src/engines/kotorbase/partyleader.h \
+    src/engines/kotorbase/partycontroller.h \
     $(EMPTY)
 
 src_engines_kotorbase_libkotorbase_la_SOURCES += \
@@ -69,6 +70,7 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/savedgame.cpp \
     src/engines/kotorbase/game.cpp \
     src/engines/kotorbase/partyleader.cpp \
+    src/engines/kotorbase/partycontroller.cpp \
     $(EMPTY)
 
 include src/engines/kotorbase/script/rules.mk

--- a/src/engines/kotorbase/savedgame.cpp
+++ b/src/engines/kotorbase/savedgame.cpp
@@ -37,8 +37,7 @@ namespace KotORBase {
 SavedGame::SavedGame(const Common::UString &dir, bool loadSav) :
 		_timePlayed(0),
 		_pcGender(kGenderMale),
-		_pcLoaded(false),
-		_pc(0) {
+		_pcLoaded(false) {
 
 	load(dir, loadSav);
 }

--- a/src/engines/kotorbase/savedgame.h
+++ b/src/engines/kotorbase/savedgame.h
@@ -35,7 +35,7 @@ namespace Engines {
 
 namespace KotORBase {
 
-class Creature;
+class CharacterGenerationInfo;
 
 class SavedGame {
 public:
@@ -52,7 +52,7 @@ public:
 
 	bool isPCLoaded() const;
 
-	virtual Creature *createPC() = 0;
+	virtual CharacterGenerationInfo *createCharGenInfo() = 0;
 
 protected:
 	Common::UString _name;
@@ -61,7 +61,6 @@ protected:
 	uint8 _pcGender;
 	float _pcPosition[3];
 	bool _pcLoaded;
-	Creature *_pc;
 
 private:
 	void load(const Common::UString &dir, bool loadSav);

--- a/src/engines/kotorbase/script/functions.h
+++ b/src/engines/kotorbase/script/functions.h
@@ -282,6 +282,7 @@ protected:
 	void showPartySelectionGUI(Aurora::NWScript::FunctionContext &ctx);
 	void isAvailableCreature(Aurora::NWScript::FunctionContext &ctx);
 	void addAvailableNPCByTemplate(Aurora::NWScript::FunctionContext &ctx);
+	void setPartyLeader(Aurora::NWScript::FunctionContext &ctx);
 
 
 	// Events, functions_events.cpp

--- a/src/engines/kotorbase/script/functions_party.cpp
+++ b/src/engines/kotorbase/script/functions_party.cpp
@@ -54,7 +54,7 @@ void Functions::isObjectPartyMember(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::getPartyMemberByIndex(Aurora::NWScript::FunctionContext &ctx) {
 	int index = ctx.getParams()[0].getInt();
 
-	ctx.getReturn() = _game->getModule().getPartyMember(index);
+	ctx.getReturn() = _game->getModule().getPartyMemberByIndex(index);
 }
 
 void Functions::showPartySelectionGUI(Aurora::NWScript::FunctionContext &ctx) {
@@ -76,7 +76,12 @@ void Functions::addAvailableNPCByTemplate(Aurora::NWScript::FunctionContext &ctx
 	const int slot = ctx.getParams()[0].getInt();
 	const Common::UString &templ = ctx.getParams()[1].getString();
 
-	_game->getModule().addAvailablePartyMember(slot, templ);
+	_game->getModule().addAvailableNPCByTemplate(slot, templ);
+}
+
+void Functions::setPartyLeader(Aurora::NWScript::FunctionContext &ctx) {
+	int npc = ctx.getParams()[0].getInt();
+	_game->getModule().setPartyLeader(npc);
 }
 
 } // End of namespace KotORBase


### PR DESCRIPTION
- Party management was extracted to a separate class (PartyController).
- Ownership of PC and party members was moved from the Module to the Area.
- PC != controllable creature. PC is a character generated by the player. We control the party leader. Changed the source code accordingly.

As a bonus, party members are now interactable, follow the party leader and will be saved on module change.

Known issues: 
- Trask will not immediately follow the PC after joining the party. This is because of a script that resets his actions.