### PR TITLE
ENGINES: Update selection mechanics to match KotOR games

### DIFF
--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -33,6 +33,9 @@
 
 #include "src/engines/odyssey/label.h"
 #include "src/engines/odyssey/progressbar.h"
+#include "src/engines/odyssey/button.h"
+
+#include "src/engines/kotorbase/situated.h"
 
 #include "src/engines/kotor/creature.h"
 
@@ -196,7 +199,12 @@ static const Resolution kResolution[] = {
 HUD::HUD(KotORBase::Module &module, Engines::Console *console) :
 		KotORBase::GUI(console),
 		_module(&module),
-		_menu(module, console) {
+		_menu(module, console),
+		_hoveredCircle(new SelectionCircle()),
+		_targetCircle(new SelectionCircle()) {
+
+	_hoveredCircle->setHovered(true);
+	_targetCircle->setTarget(true);
 
 	update(WindowMan.getWindowWidth(), WindowMan.getWindowHeight());
 
@@ -206,6 +214,9 @@ HUD::HUD(KotORBase::Module &module, Engines::Console *console) :
 	_objectNameBackground = getLabel("LBL_NAMEBG");
 	_objectHealth = getProgressbar("PB_HEALTH");
 	_objectHealthBackground = getLabel("LBL_HEALTHBG");
+	_firstTargetButton = getButton("BTN_TARGET0");
+	_secondTargetButton = getButton("BTN_TARGET1");
+	_thirdTargetButton = getButton("BTN_TARGET2");
 }
 
 void HUD::setReturnStrref(uint32 id) {
@@ -305,6 +316,24 @@ void HUD::setPortrait(uint8 n, bool visible, const Common::UString &portrait) {
 	}
 }
 
+void HUD::positionTargetButtons(float originX, float originY) {
+	if (!_firstTargetButton || !_secondTargetButton || !_thirdTargetButton)
+		return;
+
+	float dist = getTargetButtonsDistance();
+
+	float width, _;
+	getTargetButtonSize(width, _);
+	float halfWidth = width / 2.0f;
+
+	float halfSelectionSize = kSelectionCircleSize / 2.0f;
+	float y = originY + halfSelectionSize + 1.0f;
+
+	_firstTargetButton->setPosition(originX - dist - halfWidth, y, -FLT_MAX);
+	_secondTargetButton->setPosition(originX - halfWidth, y, -FLT_MAX);
+	_thirdTargetButton->setPosition(originX + dist - halfWidth, y, -FLT_MAX);
+}
+
 void HUD::setPartyLeader(KotORBase::Creature *creature) {
 	setPortrait(1, creature != 0, creature ? creature->getPortrait() : "");
 }
@@ -317,7 +346,68 @@ void HUD::setPartyMember2(KotORBase::Creature *creature) {
 	setPortrait(2, creature != 0, creature ? creature->getPortrait() : "");
 }
 
-void HUD::showObjectInformation(KotORBase::Object *object) {
+KotORBase::Object *HUD::getHoveredObject() const {
+	return _hoveredObject;
+}
+
+KotORBase::Object *HUD::getTargetObject() const {
+	return _targetObject;
+}
+
+void HUD::setHoveredObject(KotORBase::Object *object) {
+	_hoveredObject = object;
+}
+
+void HUD::setTargetObject(KotORBase::Object *object) {
+	_targetObject = object;
+}
+
+void HUD::updateSelection() {
+	if (_targetObject) {
+		_targetCircle->setHovered(_hoveredObject == _targetObject);
+
+		KotORBase::Situated *situated = KotORBase::ObjectContainer::toSituated(_targetObject);
+		if (situated) {
+			float sX, sY;
+			_targetCircle->moveTo(situated, sX, sY);
+			_targetCircle->show();
+			updateTargetInformation(_targetObject, sX, sY);
+			showTargetInformation(_targetObject);
+		} else {
+			_targetCircle->hide();
+			hideTargetInformation();
+		}
+	} else {
+		_targetCircle->hide();
+		hideTargetInformation();
+	}
+
+	if (_hoveredObject && (_hoveredObject != _targetObject)) {
+		KotORBase::Situated *situated = KotORBase::ObjectContainer::toSituated(_hoveredObject);
+		if (situated) {
+			float _, __;
+			_hoveredCircle->moveTo(situated, _, __);
+			_hoveredCircle->show();
+		} else {
+			_hoveredCircle->hide();
+		}
+	} else {
+		_hoveredCircle->hide();
+	}
+}
+
+void HUD::hideSelection() {
+	_hoveredCircle->hide();
+	_targetCircle->hide();
+	hideTargetInformation();
+}
+
+void HUD::resetSelection() {
+	_hoveredObject = nullptr;
+	_targetObject = nullptr;
+}
+
+void HUD::showTargetInformation(KotORBase::Object *object) {
 	if (_objectNameBackground) {
 		_objectNameBackground->setInvisible(false);
 		_objectNameBackground->show();
@@ -336,9 +426,26 @@ void HUD::showObjectInformation(KotORBase::Object *object) {
 		_objectHealth->setInvisible(false);
 		_objectHealth->show();
 	}
+
+	std::vector<int> possibleActions = object->getPossibleActions();
+	if (possibleActions.empty())
+		return;
+
+	if (_firstTargetButton) {
+		_firstTargetButton->setInvisible(false);
+		_firstTargetButton->show();
+	}
+	if (_secondTargetButton) {
+		_secondTargetButton->setInvisible(false);
+		_secondTargetButton->show();
+	}
+	if (_thirdTargetButton) {
+		_thirdTargetButton->setInvisible(false);
+		_thirdTargetButton->show();
+	}
 }
 
-void HUD::hideObjectInformation() {
+void HUD::hideTargetInformation() {
 	if (_objectNameBackground) {
 		_objectNameBackground->setInvisible(true);
 		_objectNameBackground->hide();
@@ -356,22 +463,69 @@ void HUD::hideObjectInformation() {
 		_objectHealth->setInvisible(true);
 		_objectHealth->hide();
 	}
+
+	if (_firstTargetButton) {
+		_firstTargetButton->setInvisible(true);
+		_firstTargetButton->hide();
+	}
+	if (_secondTargetButton) {
+		_secondTargetButton->setInvisible(true);
+		_secondTargetButton->hide();
+	}
+	if (_thirdTargetButton) {
+		_thirdTargetButton->setInvisible(true);
+		_thirdTargetButton->hide();
+	}
 }
 
-void HUD::updateObjectInformation(KotORBase::Object *object, float x, float y) {
-	if (_objectNameBackground)
-		_objectNameBackground->setPosition(x - 100, y + 36, -100);
-	if (_objectName)
-		_objectName->setPosition(x - 100, y + 36, -FLT_MAX);
+void HUD::updateTargetInformation(KotORBase::Object *object, float x, float y) {
+	float halfSelectionSize = kSelectionCircleSize / 2.0f;
+	float elementY = y + halfSelectionSize + 1.0f;
+
+	std::vector<int> possibleActions = object->getPossibleActions();
+	if (!possibleActions.empty()) {
+		float _, targetBtnHeight;
+		getTargetButtonSize(_, targetBtnHeight);
+		elementY += targetBtnHeight + 1.0f;
+	}
 
 	if (_objectHealthBackground)
-		_objectHealthBackground->setPosition(x - 100, y + 29, -FLT_MAX);
+		_objectHealthBackground->setPosition(x - 100, elementY, -FLT_MAX);
 	if (_objectHealth) {
-		_objectHealth->setPosition(x - 100, y + 29, -FLT_MAX);
+		_objectHealth->setPosition(x - 100, elementY, -FLT_MAX);
 
 		_objectHealth->setMaxValue(object->getMaxHitPoints());
 		_objectHealth->setCurrentValue(object->getCurrentHitPoints());
 	}
+
+	elementY += _objectHealth->getHeight() + 1.0f;
+
+	if (_objectNameBackground)
+		_objectNameBackground->setPosition(x - 100, elementY, -100);
+	if (_objectName)
+		_objectName->setPosition(x - 100, elementY, -FLT_MAX);
+
+	if (!possibleActions.empty())
+		positionTargetButtons(x, y);
+}
+
+void HUD::getTargetButtonSize(float &width, float &height) const {
+	if (!_firstTargetButton)
+		return;
+
+	width = _firstTargetButton->getWidth();
+	height = _firstTargetButton->getHeight();
+}
+
+float HUD::getTargetButtonsDistance() const {
+	if (!_firstTargetButton || !_secondTargetButton)
+		throw Common::Exception("HUD::getTargetButtonsDistance(): Buttons not initialized");
+
+	float x1, x2, _, __;
+	_firstTargetButton->getPosition(x1, _, __);
+	_secondTargetButton->getPosition(x2, _, __);
+
+	return x2 - x1;
 }
 
 void HUD::update(int width, int height) {
@@ -471,6 +625,16 @@ void HUD::initWidget(Engines::Widget &widget) {
 }
 
 void HUD::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_TARGET0") {
+		return;
+	}
+	if (widget.getTag() == "BTN_TARGET1") {
+		return;
+	}
+	if (widget.getTag() == "BTN_TARGET2") {
+		return;
+	}
+
 	if (widget.getTag() == "LBL_CHAR1") {
 		_module->setPartyLeaderByIndex(0);
 		return;

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -34,6 +34,7 @@
 #include "src/engines/kotor/gui/ingame/container.h"
 #include "src/engines/kotor/gui/ingame/menu.h"
 #include "src/engines/kotor/gui/ingame/minimap.h"
+#include "src/engines/kotor/gui/ingame/selectioncircle.h"
 
 namespace Engines {
 
@@ -65,14 +66,24 @@ public:
 	void setPartyMember1(KotORBase::Creature *creature);
 	void setPartyMember2(KotORBase::Creature *creature);
 
-	void showObjectInformation(KotORBase::Object *object);
-	void updateObjectInformation(KotORBase::Object *object, float x, float y);
-	void hideObjectInformation();
+	// Selection handling
+
+	KotORBase::Object *getHoveredObject() const;
+	KotORBase::Object *getTargetObject() const;
+
+	void setHoveredObject(KotORBase::Object *object);
+	void setTargetObject(KotORBase::Object *object);
+
+	void updateSelection();
+	void hideSelection();
+	void resetSelection();
 
 private:
 	KotORBase::Module *_module;
 	Menu _menu;
 	Common::ScopedPtr<ContainerMenu> _container;
+	Common::ScopedPtr<SelectionCircle> _hoveredCircle;
+	Common::ScopedPtr<SelectionCircle> _targetCircle;
 
 	Common::ScopedPtr<Minimap> _minimap;
 	Odyssey::WidgetLabel *_minimapPointer;
@@ -83,14 +94,28 @@ private:
 	Odyssey::WidgetLabel       *_objectNameBackground;
 	Odyssey::WidgetProgressbar *_objectHealth;
 	Odyssey::WidgetLabel       *_objectHealthBackground;
+	Odyssey::WidgetButton      *_firstTargetButton { nullptr };
+	Odyssey::WidgetButton      *_secondTargetButton { nullptr };
+	Odyssey::WidgetButton      *_thirdTargetButton { nullptr };
 
+	KotORBase::Object *_hoveredObject { nullptr };
+	KotORBase::Object *_targetObject { nullptr };
+
+
+	void getTargetButtonSize(float &width, float &height) const;
+	float getTargetButtonsDistance() const;
 
 	void update(int width, int height);
 
 	void initWidget(Widget &widget);
 	void setPortrait(uint8 n, bool visible, const Common::UString &portrait = "");
+	void positionTargetButtons(float originX, float originY);
 
 	void notifyResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
+
+	void showTargetInformation(KotORBase::Object *object);
+	void hideTargetInformation();
+	void updateTargetInformation(KotORBase::Object *object, float x, float y);
 
 protected:
 	virtual void callbackActive(Widget &widget);

--- a/src/engines/kotor/gui/ingame/ingame.cpp
+++ b/src/engines/kotor/gui/ingame/ingame.cpp
@@ -22,8 +22,6 @@
  *  The ingame GUI.
  */
 
-#include "src/engines/kotorbase/situated.h"
-
 #include "src/engines/kotor/gui/ingame/ingame.h"
 
 namespace Engines {
@@ -32,9 +30,6 @@ namespace KotOR {
 
 IngameGUI::IngameGUI(KotORBase::Module &module, Console *console) {
 	_hud.reset(new HUD(module, console));
-	_selectionCircle.reset(new SelectionCircle());
-
-	_selected = 0;
 }
 
 void IngameGUI::show() {
@@ -88,57 +83,32 @@ void IngameGUI::setPartyMember2(KotORBase::Creature *creature) {
 	_hud->setPartyMember2(creature);
 }
 
-void IngameGUI::showSelection(KotORBase::Object *object) {
-	if (!object)
-		return;
-
-	if (object == _selected)
-		return;
-
-	KotORBase::Situated *situated = KotORBase::ObjectContainer::toSituated(object);
-	if (!situated) // TODO: Creature selection
-		return;
-
-	float x, y, z;
-	situated->getTooltipAnchor(x, y, z);
-
-	float sX, sY, sZ;
-	GfxMan.project(x, y, z, sX, sY, sZ);
-
-	_selectionCircle->setPosition(sX, sY);
-	_selectionCircle->show();
-
-	_hud->updateObjectInformation(object, sX, sY);
-	_hud->showObjectInformation(object);
-
-	_selected = object;
+KotORBase::Object *IngameGUI::getHoveredObject() const {
+	return _hud->getHoveredObject();
 }
 
-void IngameGUI::hideSelection() {
-	_selectionCircle->hide();
-	_hud->hideObjectInformation();
+KotORBase::Object *IngameGUI::getTargetObject() const {
+	return _hud->getTargetObject();
+}
 
-	_selected = 0;
+void IngameGUI::setHoveredObject(KotORBase::Object *object) {
+	_hud->setHoveredObject(object);
+}
+
+void IngameGUI::setTargetObject(KotORBase::Object *object) {
+	_hud->setTargetObject(object);
 }
 
 void IngameGUI::updateSelection() {
-	if (!_selected)
-		return;
+	_hud->updateSelection();
+}
 
-	KotORBase::Situated *situated = KotORBase::ObjectContainer::toSituated(_selected);
-	if (!situated) // TODO: Creature selection
-		return;
+void IngameGUI::hideSelection() {
+	_hud->hideSelection();
+}
 
-	float x, y, z;
-	situated->getTooltipAnchor(x, y, z);
-
-	float sX, sY, sZ;
-	GfxMan.project(x, y, z, sX, sY, sZ);
-
-	_selectionCircle->show();
-	_selectionCircle->setPosition(sX, sY);
-
-	_hud->updateObjectInformation(situated, sX, sY);
+void IngameGUI::resetSelection() {
+	_hud->resetSelection();
 }
 
 void IngameGUI::addEvent(const Events::Event &event) {

--- a/src/engines/kotor/gui/ingame/ingame.h
+++ b/src/engines/kotor/gui/ingame/ingame.h
@@ -33,7 +33,6 @@
 #include "src/engines/kotorbase/gui/ingame.h"
 
 #include "src/engines/kotor/gui/ingame/hud.h"
-#include "src/engines/kotor/gui/ingame/selectioncircle.h"
 
 namespace Engines {
 
@@ -68,18 +67,23 @@ public:
 	void setPartyMember2(KotORBase::Creature *creature);
 
 	// Selection handling
-	void showSelection(KotORBase::Object *object);
-	void hideSelection();
+
+	KotORBase::Object *getHoveredObject() const;
+	KotORBase::Object *getTargetObject() const;
+
+	void setHoveredObject(KotORBase::Object *object);
+	void setTargetObject(KotORBase::Object *object);
+
 	void updateSelection();
+	void hideSelection();
+	void resetSelection();
+
 
 	void addEvent(const Events::Event &event);
 	void processEventQueue();
 
 private:
 	Common::ScopedPtr<HUD> _hud;
-	Common::ScopedPtr<SelectionCircle> _selectionCircle;
-
-	KotORBase::Object *_selected;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/selectioncircle.cpp
+++ b/src/engines/kotor/gui/ingame/selectioncircle.cpp
@@ -22,26 +22,78 @@
  *  The circle visible when selecting objects
  */
 
+#include "src/engines/kotorbase/objectcontainer.h"
+#include "src/engines/kotorbase/situated.h"
+
 #include "src/engines/kotor/gui/ingame/selectioncircle.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-SelectionCircle::SelectionCircle() : _inactive(new Graphics::Aurora::GUIQuad("friendlyreticle", 0.0f, 0.0f, 64.0f, 64.0f)) {
-
+SelectionCircle::SelectionCircle() :
+		_hoveredQuad(new Graphics::Aurora::GUIQuad("friendlyreticle", 0.0f, 0.0f, kSelectionCircleSize, kSelectionCircleSize)),
+		_targetQuad(new Graphics::Aurora::GUIQuad("friendlyreticle2", 0.0f, 0.0f, kSelectionCircleSize, kSelectionCircleSize)) {
 }
 
 void SelectionCircle::show() {
-	_inactive->show();
+	if (_target)
+		_targetQuad->show();
+
+	if (_hovered)
+		_hoveredQuad->show();
+
+	_visible = true;
 }
 
 void SelectionCircle::hide() {
-	_inactive->hide();
+	_hoveredQuad->hide();
+	_targetQuad->hide();
+	_visible = false;
 }
 
 void SelectionCircle::setPosition(float x, float y) {
-	_inactive->setPosition(x - 32, y - 32);
+	float halfSize = kSelectionCircleSize / 2.0f;
+	_hoveredQuad->setPosition(x - halfSize, y - halfSize, -FLT_MIN);
+	_targetQuad->setPosition(x - halfSize, y - halfSize, -100.0f);
+}
+
+void SelectionCircle::setHovered(bool hovered) {
+	if (_hovered == hovered)
+		return;
+
+	_hovered = hovered;
+
+	if (_visible) {
+		if (_hovered)
+			_hoveredQuad->show();
+		else
+			_hoveredQuad->hide();
+	}
+}
+
+void SelectionCircle::setTarget(bool target) {
+	if (_target == target)
+		return;
+
+	_target = target;
+
+	if (_visible) {
+		if (_target)
+			_targetQuad->show();
+		else
+			_targetQuad->hide();
+	}
+}
+
+void SelectionCircle::moveTo(KotORBase::Situated *situated, float &sX, float &sY) {
+	float x, y, z;
+	situated->getTooltipAnchor(x, y, z);
+
+	float _;
+	GfxMan.project(x, y, z, sX, sY, _);
+
+	setPosition(sX, sY);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/selectioncircle.h
+++ b/src/engines/kotor/gui/ingame/selectioncircle.h
@@ -31,18 +31,33 @@ namespace Engines {
 
 namespace KotOR {
 
+const float kSelectionCircleSize = 64.0f;
+
+class Situated;
+
 class SelectionCircle {
 public:
 	SelectionCircle();
 
+	// Basic visuals
+
 	void show();
 	void hide();
 
+
 	void setPosition(float x, float y);
+	void setHovered(bool hovered);
+	void setTarget(bool target);
+
+	void moveTo(KotORBase::Situated *situated, float &sX, float &sY);
 
 private:
-	// TODO: Add more circles and dynamically switch between them.
-	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _inactive;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _hoveredQuad;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _targetQuad;
+
+	bool _hovered { false }; ///< Is this selection circle being hovered over?
+	bool _target { false }; ///< Is the object below this selection circle the target?
+	bool _visible { false };
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor2/gui/ingame/ingame.cpp
+++ b/src/engines/kotor2/gui/ingame/ingame.cpp
@@ -72,13 +72,27 @@ void IngameGUI::setPartyMember1(KotORBase::Creature *UNUSED(creature)) {
 void IngameGUI::setPartyMember2(KotORBase::Creature *UNUSED(creature)) {
 }
 
-void IngameGUI::showSelection(KotORBase::Object *UNUSED(object)) {
+KotORBase::Object *IngameGUI::getHoveredObject() const {
+	return 0;
+}
+
+KotORBase::Object *IngameGUI::getTargetObject() const {
+	return 0;
+}
+
+void IngameGUI::setHoveredObject(KotORBase::Object *UNUSED(object)) {
+}
+
+void IngameGUI::setTargetObject(KotORBase::Object *UNUSED(object)) {
+}
+
+void IngameGUI::updateSelection() {
 }
 
 void IngameGUI::hideSelection() {
 }
 
-void IngameGUI::updateSelection() {
+void IngameGUI::resetSelection() {
 }
 
 void IngameGUI::addEvent(const Events::Event &event) {

--- a/src/engines/kotor2/gui/ingame/ingame.h
+++ b/src/engines/kotor2/gui/ingame/ingame.h
@@ -67,9 +67,17 @@ public:
 	void setPartyMember2(KotORBase::Creature *creature);
 
 	// Selection handling
-	void showSelection(KotORBase::Object *object);
-	void hideSelection();
+
+	KotORBase::Object *getHoveredObject() const;
+	KotORBase::Object *getTargetObject() const;
+
+	void setHoveredObject(KotORBase::Object *object);
+	void setTargetObject(KotORBase::Object *object);
+
 	void updateSelection();
+	void hideSelection();
+	void resetSelection();
+
 
 	void addEvent(const Events::Event &event);
 	void processEventQueue();

--- a/src/engines/kotorbase/gui/ingame.h
+++ b/src/engines/kotorbase/gui/ingame.h
@@ -57,14 +57,22 @@ public:
 	virtual void showContainer(Inventory &inv) = 0;
 
 	// Party handling.
-	virtual void setPartyLeader(KotORBase::Creature *creature) = 0;
-	virtual void setPartyMember1(KotORBase::Creature *creature) = 0;
-	virtual void setPartyMember2(KotORBase::Creature *creature) = 0;
+	virtual void setPartyLeader(Creature *creature) = 0;
+	virtual void setPartyMember1(Creature *creature) = 0;
+	virtual void setPartyMember2(Creature *creature) = 0;
 
 	// Selection handling
-	virtual void showSelection(KotORBase::Object *object) = 0;
-	virtual void hideSelection() = 0;
+
+	virtual Object *getHoveredObject() const = 0;
+	virtual Object *getTargetObject() const = 0;
+
+	virtual void setHoveredObject(Object *object) = 0;
+	virtual void setTargetObject(Object *object) = 0;
+
 	virtual void updateSelection() = 0;
+	virtual void hideSelection() = 0;
+	virtual void resetSelection() = 0;
+
 
 	virtual void addEvent(const Events::Event &event) = 0;
 	virtual void processEventQueue() = 0;

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -106,6 +106,8 @@ public:
 	/** Return the fade quad. */
 	Graphics::Aurora::FadeQuad &getFadeQuad();
 
+	void removeObject(Object &object);
+
 	// Interact with the current module
 
 	/** Show the ingame main menu. */
@@ -381,8 +383,6 @@ private:
 
 	void updateMinimap();
 	void updateSoundListener();
-
-	void resetSelection();
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/object.cpp
+++ b/src/engines/kotorbase/object.cpp
@@ -104,6 +104,10 @@ void Object::setRoom(const Room *room) {
 	_room = room;
 }
 
+const std::vector<int> Object::getPossibleActions() const {
+	return std::vector<int>();
+}
+
 bool Object::isStatic() const {
 	return _static;
 }

--- a/src/engines/kotorbase/object.h
+++ b/src/engines/kotorbase/object.h
@@ -80,6 +80,8 @@ public:
 
 	// Interactive properties
 
+	virtual const std::vector<int> getPossibleActions() const;
+
 	/** Is the object static (not manipulable at all)? */
 	bool isStatic() const;
 	/** Can the object be used by the PC? */

--- a/src/engines/kotorbase/objectcontainer.h
+++ b/src/engines/kotorbase/objectcontainer.h
@@ -64,14 +64,14 @@ private:
 class ObjectContainer : public ::Aurora::NWScript::ObjectContainer {
 public:
 	ObjectContainer();
-	~ObjectContainer();
+	virtual ~ObjectContainer();
 
 	void clearObjects();
 
 	/** Add an object to this container. */
 	void addObject(Object &object);
 	/** Remove an object from this container. */
-	void removeObject(Object &object);
+	virtual void removeObject(Object &object);
 
 	/** Return the first object of this type. */
 	::Aurora::NWScript::Object *getFirstObjectByType(ObjectType type) const;

--- a/src/engines/kotorbase/situated.cpp
+++ b/src/engines/kotorbase/situated.cpp
@@ -118,6 +118,14 @@ const Common::UString &Situated::getModelName() const {
 	return _modelName;
 }
 
+const std::vector<int> Situated::getPossibleActions() const {
+	std::vector<int> actions;
+	if (_locked)
+		actions.push_back(kActionOpenLock);
+
+	return actions;
+}
+
 void Situated::load(const Aurora::GFF3Struct &instance, const Aurora::GFF3Struct *blueprint) {
 	// General properties
 

--- a/src/engines/kotorbase/situated.h
+++ b/src/engines/kotorbase/situated.h
@@ -64,6 +64,10 @@ public:
 	/** Get the model name. */
 	const Common::UString &getModelName() const;
 
+	// Interactive properties
+
+	const std::vector<int> getPossibleActions() const;
+
 	// State
 
 	/** Is the situated object open? */


### PR DESCRIPTION
This PR updates selection mechanics in KotOR to match the original games. We now have two selection circles: persistant one for the current target and temporary one for the hovered object. In order to use the object, you have to target it first. Also, locked situated objects will now have (empty) target buttons above them.

Known issues:
- Cursor should only change on hover when the object is targeted
- Selection circles only work for situated objects currently (but creatures still need to be targeted prior to activation)

Note: Should probably port that to KotOR 2 as well.