### PR TITLE
ENGINES: Refactor GUI for KotOR games

### DIFF
--- a/src/engines/kotor/gui/dialog.cpp
+++ b/src/engines/kotor/gui/dialog.cpp
@@ -22,25 +22,7 @@
  *  Dialog GUI for Star Wars: Knights of the Old Republic.
  */
 
-#include "src/common/configman.h"
-
-#include "src/events/types.h"
-
 #include "src/graphics/windowman.h"
-#include "src/graphics/aurora/cursorman.h"
-
-#include "src/sound/sound.h"
-
-#include "src/engines/aurora/util.h"
-#include "src/engines/aurora/satellitecamera.h"
-
-#include "src/engines/odyssey/label.h"
-#include "src/engines/odyssey/listbox.h"
-#include "src/engines/odyssey/scrollbar.h"
-
-#include "src/engines/kotorbase/creature.h"
-#include "src/engines/kotorbase/module.h"
-#include "src/engines/kotorbase/area.h"
 
 #include "src/engines/kotor/gui/dialog.h"
 
@@ -48,56 +30,15 @@ namespace Engines {
 
 namespace KotOR {
 
-DialogGUI::DialogGUI(KotORBase::Module &module) :
-		KotORBase::DialogGUI(false),
-		_module(module) {
+DialogGUI::DialogGUI(KotORBase::Module &module) : KotORBase::DialogGUI(module) {
+	load("dialog");
+	update(WindowMan.getWindowWidth(), WindowMan.getWindowHeight());
 }
 
-void DialogGUI::makeLookAtPC(const Common::UString &tag) {
-	KotORBase::Creature *pc = _module.getPC();
-	if (!pc)
-		return;
-
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
-		return;
-
-	// Only creatures should orient themselves to the pc.
-	KotORBase::Creature *creature = KotORBase::ObjectContainer::toCreature(o);
-	if (creature)
-		creature->makeLookAt(pc);
-
-	pc->makeLookAt(o);
-
-	float x, y, z, a;
-	pc->getOrientation(x, y, z, a);
-	SatelliteCam.setYaw(Common::deg2rad(a - 15.0f));
-}
-
-void DialogGUI::playDefaultAnimations(const Common::UString &tag) {
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
-		return;
-
-	KotORBase::Creature *creature = KotORBase::ObjectContainer::toCreature(o);
-	if (!creature)
-		return;
-
-	creature->playDefaultHeadAnimation();
-	creature->playDefaultAnimation();
-}
-
-void DialogGUI::playTalkAnimations(const Common::UString &tag) {
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
-		return;
-
-	KotORBase::Creature *creature = KotORBase::ObjectContainer::toCreature(o);
-	if (!creature)
-		return;
-
-	creature->playAnimation("tlknorm", true, -1.0f);
-	creature->playHeadAnimation("talk", true, -1.0f, 0.25f);
+void DialogGUI::getTextColor(float &r, float &g, float &b) const {
+	r = 0.0f;
+	g = 0.648438f;
+	b = 0.968750f;
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/dialog.h
+++ b/src/engines/kotor/gui/dialog.h
@@ -36,12 +36,7 @@ public:
 	DialogGUI(KotORBase::Module &module);
 
 protected:
-	void makeLookAtPC(const Common::UString &tag);
-	void playDefaultAnimations(const Common::UString &tag);
-	void playTalkAnimations(const Common::UString &tag);
-
-private:
-	KotORBase::Module &_module;
+	void getTextColor(float &r, float &g, float &b) const;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/hud.h
+++ b/src/engines/kotor/gui/ingame/hud.h
@@ -19,7 +19,7 @@
  */
 
 /** @file
- *  The ingame HUD.
+ *  In-game HUD for Star Wars: Knights of the Old Republic.
  */
 
 #ifndef ENGINES_KOTOR_GUI_INGAME_HUD_H
@@ -29,23 +29,17 @@
 
 #include "src/engines/aurora/console.h"
 
-#include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/hud.h"
 
 #include "src/engines/kotor/gui/ingame/container.h"
 #include "src/engines/kotor/gui/ingame/menu.h"
 #include "src/engines/kotor/gui/ingame/minimap.h"
-#include "src/engines/kotor/gui/ingame/selectioncircle.h"
 
 namespace Engines {
 
-namespace KotORBase {
-	class Inventory;
-	class Module;
-}
-
 namespace KotOR {
 
-class HUD : public KotORBase::GUI, Events::Notifyable {
+class HUD : public KotORBase::HUD, Events::Notifyable {
 public:
 	HUD(KotORBase::Module &module, ::Engines::Console *console = 0);
 
@@ -66,59 +60,20 @@ public:
 	void setPartyMember1(KotORBase::Creature *creature);
 	void setPartyMember2(KotORBase::Creature *creature);
 
-	// Selection handling
-
-	KotORBase::Object *getHoveredObject() const;
-	KotORBase::Object *getTargetObject() const;
-
-	void setHoveredObject(KotORBase::Object *object);
-	void setTargetObject(KotORBase::Object *object);
-
-	void updateSelection();
-	void hideSelection();
-	void resetSelection();
+protected:
+	void callbackActive(Widget &widget);
 
 private:
-	KotORBase::Module *_module;
 	Menu _menu;
 	Common::ScopedPtr<ContainerMenu> _container;
-	Common::ScopedPtr<SelectionCircle> _hoveredCircle;
-	Common::ScopedPtr<SelectionCircle> _targetCircle;
 
 	Common::ScopedPtr<Minimap> _minimap;
 	Odyssey::WidgetLabel *_minimapPointer;
 
-	// Widgets for showing object information
-
-	Odyssey::WidgetLabel       *_objectName;
-	Odyssey::WidgetLabel       *_objectNameBackground;
-	Odyssey::WidgetProgressbar *_objectHealth;
-	Odyssey::WidgetLabel       *_objectHealthBackground;
-	Odyssey::WidgetButton      *_firstTargetButton { nullptr };
-	Odyssey::WidgetButton      *_secondTargetButton { nullptr };
-	Odyssey::WidgetButton      *_thirdTargetButton { nullptr };
-
-	KotORBase::Object *_hoveredObject { nullptr };
-	KotORBase::Object *_targetObject { nullptr };
-
-
-	void getTargetButtonSize(float &width, float &height) const;
-	float getTargetButtonsDistance() const;
-
 	void update(int width, int height);
-
 	void initWidget(Widget &widget);
 	void setPortrait(uint8 n, bool visible, const Common::UString &portrait = "");
-	void positionTargetButtons(float originX, float originY);
-
 	void notifyResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
-
-	void showTargetInformation(KotORBase::Object *object);
-	void hideTargetInformation();
-	void updateTargetInformation(KotORBase::Object *object, float x, float y);
-
-protected:
-	virtual void callbackActive(Widget &widget);
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/ingame.cpp
+++ b/src/engines/kotor/gui/ingame/ingame.cpp
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The ingame GUI.
+ *  In-game GUI for Star Wars: Knights of the Old Republic.
  */
 
 #include "src/engines/kotor/gui/ingame/ingame.h"
+#include "src/engines/kotor/gui/ingame/hud.h"
 
 namespace Engines {
 
@@ -30,93 +31,6 @@ namespace KotOR {
 
 IngameGUI::IngameGUI(KotORBase::Module &module, Console *console) {
 	_hud.reset(new HUD(module, console));
-}
-
-void IngameGUI::show() {
-	_hud->show();
-}
-
-void IngameGUI::hide() {
-	_hud->hide();
-}
-
-void IngameGUI::setMinimap(const Common::UString &map, int northAxis,
-                           float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
-                           float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y) {
-
-	_hud->setMinimap(map, northAxis, worldPt1X, worldPt1Y, worldPt2X, worldPt2Y, mapPt1X, mapPt1Y, mapPt2X, mapPt2Y);
-}
-
-void IngameGUI::setPosition(float x, float y) {
-	_hud->setPosition(x, y);
-}
-
-void IngameGUI::setRotation(float angle) {
-	_hud->setRotation(angle);
-}
-
-void IngameGUI::setReturnStrref(uint32 id) {
-	_hud->setReturnStrref(id);
-}
-
-void IngameGUI::setReturnQueryStrref(uint32 id) {
-	_hud->setReturnQueryStrref(id);
-}
-
-void IngameGUI::setReturnEnabled(bool enabled) {
-	_hud->setReturnEnabled(enabled);
-}
-
-void IngameGUI::showContainer(KotORBase::Inventory &inv) {
-	_hud->showContainer(inv);
-}
-
-void IngameGUI::setPartyLeader(KotORBase::Creature *creature) {
-	_hud->setPartyLeader(creature);
-}
-
-void IngameGUI::setPartyMember1(KotORBase::Creature *creature) {
-	_hud->setPartyMember1(creature);
-}
-
-void IngameGUI::setPartyMember2(KotORBase::Creature *creature) {
-	_hud->setPartyMember2(creature);
-}
-
-KotORBase::Object *IngameGUI::getHoveredObject() const {
-	return _hud->getHoveredObject();
-}
-
-KotORBase::Object *IngameGUI::getTargetObject() const {
-	return _hud->getTargetObject();
-}
-
-void IngameGUI::setHoveredObject(KotORBase::Object *object) {
-	_hud->setHoveredObject(object);
-}
-
-void IngameGUI::setTargetObject(KotORBase::Object *object) {
-	_hud->setTargetObject(object);
-}
-
-void IngameGUI::updateSelection() {
-	_hud->updateSelection();
-}
-
-void IngameGUI::hideSelection() {
-	_hud->hideSelection();
-}
-
-void IngameGUI::resetSelection() {
-	_hud->resetSelection();
-}
-
-void IngameGUI::addEvent(const Events::Event &event) {
-	_hud->addEvent(event);
-}
-
-void IngameGUI::processEventQueue() {
-	_hud->processEventQueue();
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/ingame.h
+++ b/src/engines/kotor/gui/ingame/ingame.h
@@ -19,20 +19,13 @@
  */
 
 /** @file
- *  The ingame GUI.
+ *  In-game GUI for Star Wars: Knights of the Old Republic.
  */
 
 #ifndef ENGINES_KOTOR_GUI_INGAME_INGAME_H
 #define ENGINES_KOTOR_GUI_INGAME_INGAME_H
 
-#include "src/engines/aurora/console.h"
-
-#include "src/engines/kotorbase/inventory.h"
-#include "src/engines/kotorbase/module.h"
-
 #include "src/engines/kotorbase/gui/ingame.h"
-
-#include "src/engines/kotor/gui/ingame/hud.h"
 
 namespace Engines {
 
@@ -41,49 +34,6 @@ namespace KotOR {
 class IngameGUI : public KotORBase::IngameGUI {
 public:
 	IngameGUI(KotORBase::Module &module, ::Engines::Console *console = 0);
-
-	void show(); ///< Show the ingame GUI elements.
-	void hide(); ///< Hide the ingame GUI elements.
-
-	/** Set the minimap with the specified id and both scaling points. */
-	void setMinimap(const Common::UString &map, int northAxis,
-	                float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
-	                float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y);
-	/** Set the position for the minimap. */
-	void setPosition(float x, float y);
-	/** Set the rotation for the minimap arrow. */
-	void setRotation(float angle);
-
-	void setReturnStrref(uint32 id);
-	void setReturnQueryStrref(uint32 id);
-	void setReturnEnabled(bool enabled);
-
-	// Container inventory handling
-	void showContainer(KotORBase::Inventory &inv);
-
-	// Party handling.
-	void setPartyLeader(KotORBase::Creature *creature);
-	void setPartyMember1(KotORBase::Creature *creature);
-	void setPartyMember2(KotORBase::Creature *creature);
-
-	// Selection handling
-
-	KotORBase::Object *getHoveredObject() const;
-	KotORBase::Object *getTargetObject() const;
-
-	void setHoveredObject(KotORBase::Object *object);
-	void setTargetObject(KotORBase::Object *object);
-
-	void updateSelection();
-	void hideSelection();
-	void resetSelection();
-
-
-	void addEvent(const Events::Event &event);
-	void processEventQueue();
-
-private:
-	Common::ScopedPtr<HUD> _hud;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/rules.mk
+++ b/src/engines/kotor/gui/ingame/rules.mk
@@ -34,7 +34,6 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/menu_opt.h \
     src/engines/kotor/gui/ingame/minimap.h \
     src/engines/kotor/gui/ingame/partyselection.h \
-    src/engines/kotor/gui/ingame/selectioncircle.h \
     $(EMPTY)
 
 src_engines_kotor_libkotor_la_SOURCES += \
@@ -52,5 +51,4 @@ src_engines_kotor_libkotor_la_SOURCES += \
     src/engines/kotor/gui/ingame/menu_opt.cpp \
     src/engines/kotor/gui/ingame/minimap.cpp \
     src/engines/kotor/gui/ingame/partyselection.cpp \
-    src/engines/kotor/gui/ingame/selectioncircle.cpp \
     $(EMPTY)

--- a/src/engines/kotor2/gui/chargen/charactergeneration.cpp
+++ b/src/engines/kotor2/gui/chargen/charactergeneration.cpp
@@ -28,6 +28,8 @@
 
 #include "src/engines/kotor2/creature.h"
 
+#include "src/engines/kotor2/gui/gui.h"
+
 #include "src/engines/kotor2/gui/chargen/charactergeneration.h"
 #include "src/engines/kotor2/gui/chargen/quickorcustom.h"
 #include "src/engines/kotor2/gui/chargen/quickchar.h"
@@ -42,7 +44,7 @@ namespace KotOR2 {
 CharacterGeneration::CharacterGeneration(KotORBase::Module *module,
                                          CharacterGenerationInfo *info,
                                          Engines::Console *console) :
-		GUI(console),
+		KotORBase::GUI(console),
 		_module(module),
 		_chargenInfo(info),
 		_step(0) {

--- a/src/engines/kotor2/gui/chargen/charactergeneration.h
+++ b/src/engines/kotor2/gui/chargen/charactergeneration.h
@@ -29,7 +29,7 @@
 
 #include "src/engines/kotorbase/module.h"
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
 
 #include "src/engines/kotor2/gui/chargen/chargenbase.h"
 #include "src/engines/kotor2/gui/chargen/chargeninfo.h"
@@ -38,7 +38,7 @@ namespace Engines {
 
 namespace KotOR2 {
 
-class CharacterGeneration : public GUI {
+class CharacterGeneration : public KotORBase::GUI {
 public:
 	CharacterGeneration(KotORBase::Module *module,
 	                    CharacterGenerationInfo *info,

--- a/src/engines/kotor2/gui/chargen/chargenbase.cpp
+++ b/src/engines/kotor2/gui/chargen/chargenbase.cpp
@@ -29,7 +29,7 @@ namespace Engines {
 namespace KotOR2 {
 
 CharacterGenerationBaseMenu::CharacterGenerationBaseMenu(KotORBase::CharacterGenerationInfo &info, Engines::Console *console) :
-		GUI(console),
+		KotORBase::GUI(console),
 		_info(info),
 		_accepted(false) {
 }

--- a/src/engines/kotor2/gui/chargen/chargenbase.h
+++ b/src/engines/kotor2/gui/chargen/chargenbase.h
@@ -27,13 +27,13 @@
 
 #include "src/engines/kotorbase/gui/chargeninfo.h"
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class CharacterGenerationBaseMenu : public GUI {
+class CharacterGenerationBaseMenu : public KotORBase::GUI {
 public:
 	CharacterGenerationBaseMenu(KotORBase::CharacterGenerationInfo &info, ::Engines::Console *console = 0);
 

--- a/src/engines/kotor2/gui/chargen/classselection.cpp
+++ b/src/engines/kotor2/gui/chargen/classselection.cpp
@@ -32,7 +32,9 @@ namespace Engines {
 
 namespace KotOR2 {
 
-ClassSelection::ClassSelection(KotORBase::Module *module, Console *console) : GUI(console) {
+ClassSelection::ClassSelection(KotORBase::Module *module, Console *console) :
+		KotORBase::GUI(console) {
+
 	load("classsel_p");
 
 	_module = module;

--- a/src/engines/kotor2/gui/chargen/classselection.h
+++ b/src/engines/kotor2/gui/chargen/classselection.h
@@ -30,7 +30,7 @@
 
 #include "src/engines/kotorbase/module.h"
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
 
 #include "src/engines/kotor2/gui/chargen/charactergeneration.h"
 #include "src/engines/kotor2/gui/chargen/chargeninfo.h"
@@ -39,7 +39,7 @@ namespace Engines {
 
 namespace KotOR2 {
 
-class ClassSelection : public GUI {
+class ClassSelection : public KotORBase::GUI {
 public:
 	ClassSelection(KotORBase::Module *module, Engines::Console *console = 0);
 	~ClassSelection();

--- a/src/engines/kotor2/gui/chargen/customchar.cpp
+++ b/src/engines/kotor2/gui/chargen/customchar.cpp
@@ -31,7 +31,9 @@ namespace Engines {
 namespace KotOR2 {
 
 CustomCharPanel::CustomCharPanel(CharacterGeneration *chargen, Console *console) :
-		GUI(console), _chargenMenu(chargen) {
+		KotORBase::GUI(console),
+		_chargenMenu(chargen) {
+
 	load("custpnl_p");
 }
 

--- a/src/engines/kotor2/gui/chargen/customchar.h
+++ b/src/engines/kotor2/gui/chargen/customchar.h
@@ -25,16 +25,17 @@
 #ifndef ENGINES_KOTOR2_GUI_CHARGEN_CUSTOMCHAR_H
 #define ENGINES_KOTOR2_GUI_CHARGEN_CUSTOMCHAR_H
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
+
 #include "src/engines/kotor2/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class CustomCharPanel : public GUI {
+class CustomCharPanel : public KotORBase::GUI {
 public:
-	CustomCharPanel(CharacterGeneration* chargen, Console *console = 0);
+	CustomCharPanel(CharacterGeneration *chargen, Console *console = 0);
 
 private:
 	void callbackActive(Widget &widget);

--- a/src/engines/kotor2/gui/chargen/quickchar.cpp
+++ b/src/engines/kotor2/gui/chargen/quickchar.cpp
@@ -30,7 +30,10 @@ namespace Engines {
 
 namespace KotOR2 {
 
-QuickCharPanel::QuickCharPanel(CharacterGeneration *chargen, Console *console) : GUI(console), _chargenMenu(chargen) {
+QuickCharPanel::QuickCharPanel(CharacterGeneration *chargen, Console *console) :
+		KotORBase::GUI(console),
+		_chargenMenu(chargen) {
+
 	load("quickpnl_p");
 
 	getButton("BTN_STEPNAME1")->setDisableHoverSound(true);

--- a/src/engines/kotor2/gui/chargen/quickchar.h
+++ b/src/engines/kotor2/gui/chargen/quickchar.h
@@ -31,7 +31,7 @@ namespace Engines {
 
 namespace KotOR2 {
 
-class QuickCharPanel : public GUI {
+class QuickCharPanel : public KotORBase::GUI {
 public:
 	QuickCharPanel(CharacterGeneration* chargen, Console *console = 0);
 

--- a/src/engines/kotor2/gui/chargen/quickorcustom.cpp
+++ b/src/engines/kotor2/gui/chargen/quickorcustom.cpp
@@ -31,7 +31,9 @@ namespace Engines {
 namespace KotOR2 {
 
 QuickOrCustomPanel::QuickOrCustomPanel(CharacterGeneration *chargenMenu, Console *console) :
-		GUI(console), _chargenMenu(chargenMenu) {
+		KotORBase::GUI(console),
+		_chargenMenu(chargenMenu) {
+
 	load("qorcpnl_p");
 }
 

--- a/src/engines/kotor2/gui/chargen/quickorcustom.h
+++ b/src/engines/kotor2/gui/chargen/quickorcustom.h
@@ -25,14 +25,15 @@
 #ifndef ENGINES_KOTOR2_GUI_CHARGEN_QUICKORCUSTOMPANEL_H
 #define ENGINES_KOTOR2_GUI_CHARGEN_QUICKORCUSTOMPANEL_H
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
+
 #include "src/engines/kotor2/gui/chargen/charactergeneration.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class QuickOrCustomPanel : public GUI {
+class QuickOrCustomPanel : public KotORBase::GUI {
 public:
 	QuickOrCustomPanel(CharacterGeneration *chargenMenu, Console *console = 0);
 

--- a/src/engines/kotor2/gui/dialog.cpp
+++ b/src/engines/kotor2/gui/dialog.cpp
@@ -19,19 +19,12 @@
  */
 
 /** @file
- *  Conversation/cutscene GUI for Star Wars: Knights of the Old
- *  Republic II: The Sith Lords.
+ *  Dialog GUI for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
-#include "src/common/maths.h"
+#include "src/common/configman.h"
 
-#include "src/sound/sound.h"
-
-#include "src/engines/aurora/satellitecamera.h"
-
-#include "src/engines/kotorbase/creature.h"
-#include "src/engines/kotorbase/module.h"
-#include "src/engines/kotorbase/area.h"
+#include "src/graphics/windowman.h"
 
 #include "src/engines/kotor2/gui/dialog.h"
 
@@ -39,52 +32,32 @@ namespace Engines {
 
 namespace KotOR2 {
 
-DialogGUI::DialogGUI(KotORBase::Module &module) :
-		KotORBase::DialogGUI(true),
-		_module(module) {
+DialogGUI::DialogGUI(KotORBase::Module &module) : KotORBase::DialogGUI(module) {
+	load("dialog_p");
+	update(WindowMan.getWindowWidth(), WindowMan.getWindowHeight());
 }
 
-void DialogGUI::makeLookAtPC(const Common::UString &tag) {
-	KotORBase::Creature *pc = _module.getPC();
-	if (!pc)
-		return;
-
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
-		return;
-
-	o->makeLookAt(pc);
-	pc->makeLookAt(o);
-
-	float x, y, z, a;
-	pc->getOrientation(x, y, z, a);
-	SatelliteCam.setYaw(Common::deg2rad(a - 15.0f));
+void DialogGUI::getTextColor(float &r, float &g, float &b) const {
+	r = 0.101961f;
+	g = 0.698039f;
+	b = 0.549020f;
 }
 
-void DialogGUI::playDefaultAnimations(const Common::UString &tag) {
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
+void DialogGUI::preprocessEntry(Common::UString &text) {
+	if (ConfigMan.getBool("showdevnotes", false))
 		return;
 
-	KotORBase::Creature *creature = KotORBase::ObjectContainer::toCreature(o);
-	if (!creature)
-		return;
+	while (true) {
+		Common::UString::iterator obit = text.findFirst('{');
+		if (obit == text.end())
+			return;
 
-	creature->playDefaultHeadAnimation();
-	creature->playDefaultAnimation();
-}
+		Common::UString::iterator cbit = text.findFirst('}');
+		if (cbit == text.end())
+			return;
 
-void DialogGUI::playTalkAnimations(const Common::UString &tag) {
-	KotORBase::Object *o = _module.getCurrentArea()->getObjectByTag(tag);
-	if (!o)
-		return;
-
-	KotORBase::Creature *creature = KotORBase::ObjectContainer::toCreature(o);
-	if (!creature)
-		return;
-
-	creature->playAnimation("tlknorm", true, -1.0f);
-	creature->playHeadAnimation("talk", true, -1.0f, 0.25f);
+		text.erase(obit, ++cbit);
+	}
 }
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/gui/dialog.h
+++ b/src/engines/kotor2/gui/dialog.h
@@ -19,8 +19,7 @@
  */
 
 /** @file
- *  Conversation/cutscene GUI for Star Wars: Knights of the Old
- *  Republic II: The Sith Lords.
+ *  Dialog GUI for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #ifndef ENGINES_KOTOR2_GUI_DIALOG_H
@@ -30,10 +29,6 @@
 
 namespace Engines {
 
-namespace KotORBase {
-	class Module;
-}
-
 namespace KotOR2 {
 
 class DialogGUI : public KotORBase::DialogGUI {
@@ -41,12 +36,9 @@ public:
 	DialogGUI(KotORBase::Module &module);
 
 protected:
-	void makeLookAtPC(const Common::UString &tag);
-	void playDefaultAnimations(const Common::UString &tag);
-	void playTalkAnimations(const Common::UString &tag);
+	void getTextColor(float &r, float &g, float &b) const;
 
-private:
-	KotORBase::Module &_module;
+	void preprocessEntry(Common::UString &text);
 };
 
 } // End of namespace KotOR2

--- a/src/engines/kotor2/gui/gui.cpp
+++ b/src/engines/kotor2/gui/gui.cpp
@@ -19,7 +19,7 @@
  */
 
 /** @file
- *  A KotOR2 GUI.
+ *  GUI utility functions for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #include "src/graphics/windowman.h"
@@ -32,10 +32,7 @@ namespace Engines {
 
 namespace KotOR2 {
 
-GUI::GUI(::Engines::Console *console) : KotORBase::GUI(console) {
-}
-
-void GUI::initWidget(Widget &widget) {
+void initWidget(Engines::Widget &widget) {
 	Odyssey::Widget &kotorWidget = static_cast<Odyssey::Widget &>(widget);
 
 	float wWidth = WindowMan.getWindowWidth();

--- a/src/engines/kotor2/gui/gui.h
+++ b/src/engines/kotor2/gui/gui.h
@@ -19,25 +19,19 @@
  */
 
 /** @file
- *  A KotOR2 GUI.
+ *  GUI utility functions for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #ifndef ENGINES_KOTOR2_GUI_GUI_H
 #define ENGINES_KOTOR2_GUI_GUI_H
 
-#include "src/engines/kotorbase/gui/gui.h"
-
 namespace Engines {
+
+class Widget;
 
 namespace KotOR2 {
 
-class GUI : public KotORBase::GUI {
-public:
-	GUI(::Engines::Console *console);
-
-protected:
-	virtual void initWidget(Widget &widget);
-};
+void initWidget(Widget &widget);
 
 } // End of namespace KotOR2
 

--- a/src/engines/kotor2/gui/ingame/hud.cpp
+++ b/src/engines/kotor2/gui/ingame/hud.cpp
@@ -19,14 +19,12 @@
  */
 
 /** @file
- *  The ingame HUD.
+ *  In-game HUD for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
-
-#include "src/graphics/windowman.h"
 
 #include "src/engines/aurora/widget.h"
 
-#include "src/engines/kotorbase/module.h"
+#include "src/engines/kotor2/gui/gui.h"
 
 #include "src/engines/kotor2/gui/ingame/hud.h"
 
@@ -34,12 +32,15 @@ namespace Engines {
 
 namespace KotOR2 {
 
-HUD::HUD(KotORBase::Module &UNUSED(module), ::Engines::Console *console) : GUI(console) {
+HUD::HUD(KotORBase::Module &module, ::Engines::Console *console) :
+		KotORBase::HUD(module, console) {
+
 	load("mipc28x6_p");
+	init();
 }
 
 void HUD::initWidget(Widget &widget) {
-	Engines::KotOR2::GUI::initWidget(widget);
+	KotOR2::initWidget(widget);
 
 	// Don't know what these two are doing, but they spawn over the complete screen blocking the 3d picking.
 	if (widget.getTag() == "LBL_MAP")

--- a/src/engines/kotor2/gui/ingame/hud.h
+++ b/src/engines/kotor2/gui/ingame/hud.h
@@ -19,19 +19,19 @@
  */
 
 /** @file
- *  The ingame HUD.
+ *  In-game HUD for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #ifndef ENGINES_KOTOR2_GUI_INGAME_HUD_H
 #define ENGINES_KOTOR2_GUI_INGAME_HUD_H
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/hud.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class HUD : public GUI {
+class HUD : public KotORBase::HUD {
 public:
 	HUD(KotORBase::Module &module, ::Engines::Console *console = 0);
 

--- a/src/engines/kotor2/gui/ingame/ingame.cpp
+++ b/src/engines/kotor2/gui/ingame/ingame.cpp
@@ -19,10 +19,11 @@
  */
 
 /** @file
- *  The ingame GUI.
+ *  In-game GUI for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #include "src/engines/kotor2/gui/ingame/ingame.h"
+#include "src/engines/kotor2/gui/ingame/hud.h"
 
 namespace Engines {
 
@@ -30,77 +31,6 @@ namespace KotOR2 {
 
 IngameGUI::IngameGUI(KotORBase::Module &module, Console *console) {
 	_hud.reset(new HUD(module, console));
-}
-
-void IngameGUI::show() {
-	_hud->show();
-}
-
-void IngameGUI::hide() {
-	_hud->hide();
-}
-
-void IngameGUI::setMinimap(const Common::UString &UNUSED(map), int UNUSED(northAxis),
-	                       float UNUSED(worldPt1X), float UNUSED(worldPt1Y), float UNUSED(worldPt2X), float UNUSED(worldPt2Y),
-	                       float UNUSED(mapPt1X), float UNUSED(mapPt1Y), float UNUSED(mapPt2X), float UNUSED(mapPt2Y)) {
-}
-
-void IngameGUI::setPosition(float UNUSED(x), float UNUSED(y)) {
-}
-
-void IngameGUI::setRotation(float UNUSED(angle)) {
-}
-
-void IngameGUI::setReturnStrref(uint32 UNUSED(id)) {
-}
-
-void IngameGUI::setReturnQueryStrref(uint32 UNUSED(id)) {
-}
-
-void IngameGUI::setReturnEnabled(bool UNUSED(enabled)) {
-}
-
-void IngameGUI::showContainer(KotORBase::Inventory &UNUSED(inv)) {
-}
-
-void IngameGUI::setPartyLeader(KotORBase::Creature *UNUSED(creature)) {
-}
-
-void IngameGUI::setPartyMember1(KotORBase::Creature *UNUSED(creature)) {
-}
-
-void IngameGUI::setPartyMember2(KotORBase::Creature *UNUSED(creature)) {
-}
-
-KotORBase::Object *IngameGUI::getHoveredObject() const {
-	return 0;
-}
-
-KotORBase::Object *IngameGUI::getTargetObject() const {
-	return 0;
-}
-
-void IngameGUI::setHoveredObject(KotORBase::Object *UNUSED(object)) {
-}
-
-void IngameGUI::setTargetObject(KotORBase::Object *UNUSED(object)) {
-}
-
-void IngameGUI::updateSelection() {
-}
-
-void IngameGUI::hideSelection() {
-}
-
-void IngameGUI::resetSelection() {
-}
-
-void IngameGUI::addEvent(const Events::Event &event) {
-	_hud->addEvent(event);
-}
-
-void IngameGUI::processEventQueue() {
-	_hud->processEventQueue();
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor2/gui/ingame/ingame.h
+++ b/src/engines/kotor2/gui/ingame/ingame.h
@@ -19,19 +19,13 @@
  */
 
 /** @file
- *  The ingame GUI.
+ *  In-game GUI for Star Wars: Knights of the Old Republic II - The Sith Lords.
  */
 
 #ifndef ENGINES_KOTOR2_GUI_INGAME_INGAME_H
 #define ENGINES_KOTOR2_GUI_INGAME_INGAME_H
 
-#include "src/engines/aurora/console.h"
-
-#include "src/engines/kotorbase/module.h"
-
 #include "src/engines/kotorbase/gui/ingame.h"
-
-#include "src/engines/kotor2/gui/ingame/hud.h"
 
 namespace Engines {
 
@@ -40,50 +34,6 @@ namespace KotOR2 {
 class IngameGUI : public KotORBase::IngameGUI {
 public:
 	IngameGUI(KotORBase::Module &module, ::Engines::Console *console = 0);
-
-	void show(); ///< Show all ingame elements.
-	void hide(); ///< Hide all ingame elements.
-
-	/** Set the minimap with the specified id and both scaling points. */
-	void setMinimap(const Common::UString &map, int northAxis,
-	                float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
-	                float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y);
-
-	/** Set the position for the minimap. */
-	void setPosition(float x, float y);
-	/** Set the rotation for the minimap arrow. */
-	void setRotation(float angle);
-
-	void setReturnStrref(uint32 id);
-	void setReturnQueryStrref(uint32 id);
-	void setReturnEnabled(bool enabled);
-
-	// Container inventory handling
-	void showContainer(KotORBase::Inventory &inv);
-
-	// Party handling.
-	void setPartyLeader(KotORBase::Creature *creature);
-	void setPartyMember1(KotORBase::Creature *creature);
-	void setPartyMember2(KotORBase::Creature *creature);
-
-	// Selection handling
-
-	KotORBase::Object *getHoveredObject() const;
-	KotORBase::Object *getTargetObject() const;
-
-	void setHoveredObject(KotORBase::Object *object);
-	void setTargetObject(KotORBase::Object *object);
-
-	void updateSelection();
-	void hideSelection();
-	void resetSelection();
-
-
-	void addEvent(const Events::Event &event);
-	void processEventQueue();
-
-private:
-	Common::ScopedPtr<HUD> _hud;
 };
 
 } // End of namespace KotOR

--- a/src/engines/kotor2/gui/main/main.cpp
+++ b/src/engines/kotor2/gui/main/main.cpp
@@ -34,6 +34,8 @@
 
 #include "src/engines/kotorbase/module.h"
 
+#include "src/engines/kotor2/gui/gui.h"
+
 #include "src/engines/kotor2/gui/main/main.h"
 #include "src/engines/kotor2/gui/chargen/classselection.h"
 
@@ -42,7 +44,7 @@ namespace Engines {
 namespace KotOR2 {
 
 MainMenu::MainMenu(KotORBase::Module &module, ::Engines::Console *console) :
-		GUI(console),
+		KotORBase::GUI(console),
 		_module(&module) {
 
 	load("mainmenu8x6_p");
@@ -54,7 +56,7 @@ MainMenu::~MainMenu() {
 }
 
 void MainMenu::initWidget(Widget &widget) {
-	GUI::initWidget(widget);
+	KotOR2::initWidget(widget);
 
 	// ...BioWare...
 	if (widget.getTag() == "LBL_GAMELOGO") {

--- a/src/engines/kotor2/gui/main/main.h
+++ b/src/engines/kotor2/gui/main/main.h
@@ -27,13 +27,13 @@
 
 #include "src/engines/kotorbase/module.h"
 
-#include "src/engines/kotor2/gui/gui.h"
+#include "src/engines/kotorbase/gui/gui.h"
 
 namespace Engines {
 
 namespace KotOR2 {
 
-class MainMenu : public GUI {
+class MainMenu : public KotORBase::GUI {
 public:
 	MainMenu(KotORBase::Module &module, ::Engines::Console *console = 0);
 	~MainMenu();

--- a/src/engines/kotorbase/actionexecutor.cpp
+++ b/src/engines/kotorbase/actionexecutor.cpp
@@ -50,6 +50,9 @@ void ActionExecutor::executeActions(Creature &creature, Area &area, float dt) {
 		case kActionFollowLeader:
 			executeFollowLeader(creature, area, *action, dt);
 			break;
+		case kActionOpenLock:
+			executeOpenLock(creature, area, *action, dt);
+			break;
 		default:
 			warning("TODO: Handle action %u", (uint)action->type);
 			break;
@@ -68,6 +71,14 @@ void ActionExecutor::executeFollowLeader(Creature &creature, Area &area, const A
 	float x, y, z;
 	area._module->getPartyLeader()->getPosition(x, y, z);
 	moveTo(creature, area, x, y, 1.0f, dt);
+}
+
+void ActionExecutor::executeOpenLock(Creature &creature, Area &area, const Action &action, float dt) {
+	float x, y, _;
+	action.object->getPosition(x, y, _);
+
+	if (moveTo(creature, area, x, y, 1.0f, dt))
+		creature.dequeueAction();
 }
 
 bool ActionExecutor::moveTo(Creature &creature, Area &area, float x, float y, float range, float dt) {
@@ -99,6 +110,12 @@ bool ActionExecutor::moveTo(Creature &creature, Area &area, float x, float y, fl
 	if (haveMovement) {
 		creature.playAnimation(run ? "run" : "walk", false, -1.0f);
 		creature.setPosition(newX, newY, z);
+
+		if (&creature == area._module->getPartyLeader())
+			area._module->movedPartyLeader();
+		else
+			area.notifyObjectMoved(creature);
+
 	} else {
 		creature.playDefaultAnimation();
 	}

--- a/src/engines/kotorbase/actionexecutor.h
+++ b/src/engines/kotorbase/actionexecutor.h
@@ -38,6 +38,7 @@ public:
 	static void executeActions(Creature &creature, Area &area, float dt);
 	static void executeMoveToPoint(Creature &creature, Area &area, const Action &action, float dt);
 	static void executeFollowLeader(Creature &creature, Area &area, const Action &action, float dt);
+	static void executeOpenLock(Creature &creature, Area &area, const Action &action, float dt);
 
 private:
 	/**

--- a/src/engines/kotorbase/gui/dialog.h
+++ b/src/engines/kotorbase/gui/dialog.h
@@ -48,24 +48,33 @@ class Module;
 
 class DialogGUI : public GUI, Events::Notifyable {
 public:
-	DialogGUI(bool k2);
+	DialogGUI(Module &module);
 
-	void startConversation(const Common::UString &name, Aurora::NWScript::Object *owner = 0);
-	bool isConversationActive() const;
+	// Basic visuals
 
 	void show();
 	void hide();
+
+	// Conversation
+
+	bool isConversationActive() const;
+
+	void startConversation(const Common::UString &name, Aurora::NWScript::Object *owner = 0);
+
 
 	void callbackActive(Widget &widget);
 	void callbackKeyInput(const Events::Key &key, const Events::EventType &type);
 
 protected:
-	virtual void makeLookAtPC(const Common::UString &tag) = 0;
-	virtual void playDefaultAnimations(const Common::UString &tag) = 0;
-	virtual void playTalkAnimations(const Common::UString &tag) = 0;
+	virtual void getTextColor(float &r, float &g, float &b) const = 0;
+
+	virtual void preprocessEntry(Common::UString &text);
+
+	/** Updates the gui when a resize occurs or it is created. */
+	void update(int width, int height);
 
 private:
-	bool _kotor2;
+	Module &_module;
 	bool _isActive;
 	Common::ScopedPtr<Graphics::Aurora::KotORDialogFrame> _frame;
 	Common::ScopedPtr<Aurora::DLGFile> _dlg;
@@ -75,18 +84,14 @@ private:
 	Common::UString _owner;
 	Common::UString _curSpeaker;
 
-	/** Updates the gui when a resize occurs or it is created. */
-	void update(int width, int height);
-
 	void refresh();
 	void playSounds();
 	void stopSounds();
 	void pickReply(int index);
 
-	/** Some dialog entries in KotOR 2 contain developer notes in
-	 *  curly braces. Erase those.
-	 */
-	void eraseDeveloperNotes(Common::UString &str);
+	void makeLookAtPC(const Common::UString &tag);
+	void playDefaultAnimations(const Common::UString &tag);
+	void playTalkAnimations(const Common::UString &tag);
 
 	void notifyResized(int oldWidth, int oldHeight, int newWidth, int newHeight);
 };

--- a/src/engines/kotorbase/gui/gui.cpp
+++ b/src/engines/kotorbase/gui/gui.cpp
@@ -60,7 +60,11 @@ GUI::WidgetContext::WidgetContext(const Aurora::GFF3Struct &s, Widget *p) {
 }
 
 
-GUI::GUI(::Engines::Console *console) : ::Engines::GUI(console), _widgetZ(0), _guiHeight(0.0f), _guiWidth(0.0f) {
+GUI::GUI(::Engines::Console *console) :
+		::Engines::GUI(console),
+		_widgetZ(0),
+		_guiHeight(0.0f),
+		_guiWidth(0.0f) {
 }
 
 GUI::~GUI() {

--- a/src/engines/kotorbase/gui/hud.cpp
+++ b/src/engines/kotorbase/gui/hud.cpp
@@ -1,0 +1,332 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Base in-game HUD for KotOR games.
+ */
+
+#include "src/engines/odyssey/button.h"
+#include "src/engines/odyssey/label.h"
+#include "src/engines/odyssey/progressbar.h"
+
+#include "src/engines/kotorbase/objectcontainer.h"
+#include "src/engines/kotorbase/object.h"
+#include "src/engines/kotorbase/module.h"
+#include "src/engines/kotorbase/creature.h"
+
+#include "src/engines/kotorbase/gui/hud.h"
+
+namespace Engines {
+
+namespace KotORBase {
+
+HUD::HUD(Module &module, Console *console) :
+		GUI(console),
+		_module(module),
+		_hoveredCircle(new SelectionCircle()),
+		_targetCircle(new SelectionCircle()) {
+
+	_hoveredCircle->setHovered(true);
+	_targetCircle->setTarget(true);
+
+	_targetActionMap[0] = _targetActionMap[1] = _targetActionMap[2] = kActionInvalid;
+}
+
+void HUD::setMinimap(const Common::UString &UNUSED(map), int UNUSED(northAxis),
+                     float UNUSED(worldPt1X), float UNUSED(worldPt1Y), float UNUSED(worldPt2X), float UNUSED(worldPt2Y),
+                     float UNUSED(mapPt1X), float UNUSED(mapPt1Y), float UNUSED(mapPt2X), float UNUSED(mapPt2Y)) {
+}
+
+void HUD::setPosition(float UNUSED(x), float UNUSED(y)) {
+}
+
+void HUD::setRotation(float UNUSED(angle)) {
+}
+
+void HUD::setReturnStrref(uint32 UNUSED(id)) {
+}
+
+void HUD::setReturnQueryStrref(uint32 UNUSED(id)) {
+}
+
+void HUD::setReturnEnabled(bool UNUSED(enabled)) {
+}
+
+void HUD::showContainer(Inventory &UNUSED(inv)) {
+}
+
+void HUD::setPartyLeader(Creature *UNUSED(creature)) {
+}
+
+void HUD::setPartyMember1(Creature *UNUSED(creature)) {
+}
+
+void HUD::setPartyMember2(Creature *UNUSED(creature)) {
+}
+
+Object *HUD::getHoveredObject() const {
+	return _hoveredObject;
+}
+
+Object *HUD::getTargetObject() const {
+	return _targetObject;
+}
+
+void HUD::setHoveredObject(Object *object) {
+	_hoveredObject = object;
+}
+
+void HUD::setTargetObject(Object *object) {
+	_targetObject = object;
+}
+
+void HUD::resetSelection() {
+	_hoveredObject = nullptr;
+	_targetObject = nullptr;
+}
+
+void HUD::updateSelection() {
+	if (_targetObject) {
+		_targetCircle->setHovered(_hoveredObject == _targetObject);
+
+		Situated *situated = ObjectContainer::toSituated(_targetObject);
+		if (situated) {
+			float sX, sY;
+			_targetCircle->moveTo(situated, sX, sY);
+			_targetCircle->show();
+			updateTargetInformation(_targetObject, sX, sY);
+			showTargetInformation(_targetObject);
+		} else {
+			_targetCircle->hide();
+			hideTargetInformation();
+		}
+	} else {
+		_targetCircle->hide();
+		hideTargetInformation();
+	}
+
+	if (_hoveredObject && (_hoveredObject != _targetObject)) {
+		Situated *situated = ObjectContainer::toSituated(_hoveredObject);
+		if (situated) {
+			float _, __;
+			_hoveredCircle->moveTo(situated, _, __);
+			_hoveredCircle->show();
+		} else {
+			_hoveredCircle->hide();
+		}
+	} else {
+		_hoveredCircle->hide();
+	}
+}
+
+void HUD::hideSelection() {
+	_hoveredCircle->hide();
+	_targetCircle->hide();
+	hideTargetInformation();
+}
+
+void HUD::init() {
+	_targetName = getLabel("LBL_NAME");
+	_targetNameBackground = getLabel("LBL_NAMEBG");
+	_targetHealth = getProgressbar("PB_HEALTH");
+	_targetHealthBackground = getLabel("LBL_HEALTHBG");
+	_firstTargetButton = getButton("BTN_TARGET0");
+	_secondTargetButton = getButton("BTN_TARGET1");
+	_thirdTargetButton = getButton("BTN_TARGET2");
+}
+
+void HUD::callbackActive(Widget &widget) {
+	if (widget.getTag() == "BTN_TARGET0") {
+		return;
+	}
+	if (widget.getTag() == "BTN_TARGET1") {
+		if (_targetActionMap[1] == kActionOpenLock) {
+			Action action(kActionOpenLock);
+			action.object = _targetObject;
+			_module.getPartyLeader()->enqueueAction(action);
+		}
+		return;
+	}
+	if (widget.getTag() == "BTN_TARGET2") {
+		return;
+	}
+}
+
+void HUD::getTargetButtonSize(float &width, float &height) const {
+	if (!_firstTargetButton)
+		return;
+
+	width = _firstTargetButton->getWidth();
+	height = _firstTargetButton->getHeight();
+}
+
+float HUD::getTargetButtonsDistance() const {
+	if (!_firstTargetButton || !_secondTargetButton)
+		throw Common::Exception("HUD::getTargetButtonsDistance(): Buttons not initialized");
+
+	float x1, x2, _, __;
+	_firstTargetButton->getPosition(x1, _, __);
+	_secondTargetButton->getPosition(x2, _, __);
+
+	return x2 - x1;
+}
+
+void HUD::positionTargetButtons(float originX, float originY) {
+	if (!_firstTargetButton || !_secondTargetButton || !_thirdTargetButton)
+		return;
+
+	float dist = getTargetButtonsDistance();
+
+	float width = 0.0f, _;
+	getTargetButtonSize(width, _);
+	float halfWidth = width / 2.0f;
+
+	float halfSelectionSize = kSelectionCircleSize / 2.0f;
+	float y = originY + halfSelectionSize + 1.0f;
+
+	_firstTargetButton->setPosition(originX - dist - halfWidth, y, -100.0f);
+	_secondTargetButton->setPosition(originX - halfWidth, y, -100.0f);
+	_thirdTargetButton->setPosition(originX + dist - halfWidth, y, -100.0f);
+}
+
+void HUD::updateTargetActions() {
+	_targetActionMap[0] = _targetActionMap[1] = _targetActionMap[2] = kActionInvalid;
+
+	for (int action : _targetObject->getPossibleActions()) {
+		switch (action) {
+			case kActionOpenLock:
+				_targetActionMap[1] = kActionOpenLock;
+				break;
+			default:
+				break;
+		}
+	}
+
+	if (_targetActionMap[1] == kActionOpenLock)
+		_secondTargetButton->setIcon("isk_security");
+	else
+		_secondTargetButton->setIcon("");
+}
+
+void HUD::showTargetInformation(Object *object) {
+	if (_targetNameBackground) {
+		_targetNameBackground->setInvisible(false);
+		_targetNameBackground->show();
+	}
+	if (_targetName) {
+		_targetName->setInvisible(false);
+		_targetName->show();
+		_targetName->setText(object->getName());
+	}
+
+	if (_targetHealthBackground) {
+		_targetHealthBackground->setInvisible(false);
+		_targetHealthBackground->show();
+	}
+	if (_targetHealth) {
+		_targetHealth->setInvisible(false);
+		_targetHealth->show();
+	}
+
+	if (object->getPossibleActions().empty())
+		return;
+
+	if (_firstTargetButton) {
+		_firstTargetButton->setInvisible(false);
+		_firstTargetButton->show();
+	}
+	if (_secondTargetButton) {
+		_secondTargetButton->setInvisible(false);
+		_secondTargetButton->show();
+	}
+	if (_thirdTargetButton) {
+		_thirdTargetButton->setInvisible(false);
+		_thirdTargetButton->show();
+	}
+}
+
+void HUD::updateTargetInformation(KotORBase::Object *object, float x, float y) {
+	float halfSelectionSize = kSelectionCircleSize / 2.0f;
+	float elementY = y + halfSelectionSize + 1.0f;
+
+	if (!object->getPossibleActions().empty()) {
+		float _, targetBtnHeight = 0.0f;
+		getTargetButtonSize(_, targetBtnHeight);
+		elementY += targetBtnHeight + 1.0f;
+	}
+
+	if (_targetHealthBackground)
+		_targetHealthBackground->setPosition(x - 100, elementY, -FLT_MAX);
+
+	if (_targetHealth) {
+		_targetHealth->setPosition(x - 100, elementY, -FLT_MAX);
+
+		_targetHealth->setMaxValue(object->getMaxHitPoints());
+		_targetHealth->setCurrentValue(object->getCurrentHitPoints());
+	}
+
+	elementY += _targetHealth->getHeight() + 1.0f;
+
+	if (_targetNameBackground)
+		_targetNameBackground->setPosition(x - 100, elementY, -100);
+
+	if (_targetName)
+		_targetName->setPosition(x - 100, elementY, -FLT_MAX);
+
+	positionTargetButtons(x, y);
+	updateTargetActions();
+}
+
+void HUD::hideTargetInformation() {
+	if (_targetNameBackground) {
+		_targetNameBackground->setInvisible(true);
+		_targetNameBackground->hide();
+	}
+	if (_targetName) {
+		_targetName->setInvisible(true);
+		_targetName->hide();
+	}
+
+	if (_targetHealthBackground) {
+		_targetHealthBackground->setInvisible(true);
+		_targetHealthBackground->hide();
+	}
+	if (_targetHealth) {
+		_targetHealth->setInvisible(true);
+		_targetHealth->hide();
+	}
+
+	if (_firstTargetButton) {
+		_firstTargetButton->setInvisible(true);
+		_firstTargetButton->hide();
+	}
+	if (_secondTargetButton) {
+		_secondTargetButton->setInvisible(true);
+		_secondTargetButton->hide();
+	}
+	if (_thirdTargetButton) {
+		_thirdTargetButton->setInvisible(true);
+		_thirdTargetButton->hide();
+	}
+}
+
+} // End of namespace KotORBase
+
+} // End of namespace Engines

--- a/src/engines/kotorbase/gui/hud.h
+++ b/src/engines/kotorbase/gui/hud.h
@@ -1,0 +1,132 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Base in-game HUD for KotOR games.
+ */
+
+#ifndef ENGINES_KOTORBASE_GUI_HUD_H
+#define ENGINES_KOTORBASE_GUI_HUD_H
+
+#include "src/engines/kotorbase/types.h"
+
+#include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/selectioncircle.h"
+
+namespace Engines {
+
+namespace KotORBase {
+
+class Module;
+class Inventory;
+class Creature;
+class Object;
+
+class HUD : public GUI {
+public:
+	HUD(Module &module, Console *console = 0);
+
+	// Minimap
+
+	virtual void setMinimap(const Common::UString &map, int northAxis,
+	                        float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
+	                        float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y);
+
+	virtual void setPosition(float x, float y);
+	virtual void setRotation(float angle);
+
+	// Return to hideout
+
+	virtual void setReturnStrref(uint32 id);
+	virtual void setReturnQueryStrref(uint32 id);
+	virtual void setReturnEnabled(bool);
+
+	// Container
+
+	virtual void showContainer(Inventory &inv);
+
+	// Party management
+
+	virtual void setPartyLeader(Creature *creature);
+	virtual void setPartyMember1(Creature *creature);
+	virtual void setPartyMember2(Creature *creature);
+
+	// Selection handling
+
+	Object *getHoveredObject() const;
+	Object *getTargetObject() const;
+
+	void setHoveredObject(Object *object);
+	void setTargetObject(Object *object);
+
+	void resetSelection();
+	void updateSelection();
+	void hideSelection();
+
+protected:
+	Module &_module;
+
+	void init();
+	virtual void callbackActive(Widget &widget);
+
+private:
+	// Hovered object
+
+	Object *_hoveredObject { nullptr };
+	Common::ScopedPtr<SelectionCircle> _hoveredCircle;
+
+	// Target object
+	
+	Object *_targetObject { nullptr };
+	Common::ScopedPtr<SelectionCircle> _targetCircle;
+
+	// Widgets for showing target information
+
+	Odyssey::WidgetLabel       *_targetName { nullptr };
+	Odyssey::WidgetLabel       *_targetNameBackground { nullptr };
+	Odyssey::WidgetProgressbar *_targetHealth { nullptr };
+	Odyssey::WidgetLabel       *_targetHealthBackground { nullptr };
+	Odyssey::WidgetButton      *_firstTargetButton { nullptr };
+	Odyssey::WidgetButton      *_secondTargetButton { nullptr };
+	Odyssey::WidgetButton      *_thirdTargetButton { nullptr };
+
+
+	ActionType _targetActionMap[3];
+
+	// Target buttons
+
+	void getTargetButtonSize(float &width, float &height) const;
+	float getTargetButtonsDistance() const;
+
+	void positionTargetButtons(float originX, float originY);
+	void updateTargetActions();
+
+	// Target information
+
+	void showTargetInformation(Object *object);
+	void updateTargetInformation(Object *object, float x, float y);
+	void hideTargetInformation();
+};
+
+} // End of namespace KotORBase
+
+} // End of namespace Engines
+
+#endif // ENGINES_KOTORBASE_GUI_HUD_H

--- a/src/engines/kotorbase/gui/ingame.cpp
+++ b/src/engines/kotorbase/gui/ingame.cpp
@@ -19,7 +19,7 @@
  */
 
 /** @file
- *  Abstract in-game GUI for KotOR games.
+ *  Base in-game GUI for KotOR games.
  */
 
 #include "src/engines/kotorbase/gui/ingame.h"
@@ -28,7 +28,91 @@ namespace Engines {
 
 namespace KotORBase {
 
-IngameGUI::~IngameGUI() {
+void IngameGUI::show() {
+	_hud->show();
+}
+
+void IngameGUI::hide() {
+	_hud->hide();
+}
+
+void IngameGUI::setMinimap(const Common::UString &map, int northAxis,
+                           float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
+                           float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y) {
+
+	_hud->setMinimap(map, northAxis, worldPt1X, worldPt1Y, worldPt2X, worldPt2Y, mapPt1X, mapPt1Y, mapPt2X, mapPt2Y);
+}
+
+void IngameGUI::setPosition(float x, float y) {
+	_hud->setPosition(x, y);
+}
+
+void IngameGUI::setRotation(float angle) {
+	_hud->setRotation(angle);
+}
+
+void IngameGUI::setReturnStrref(uint32 id) {
+	_hud->setReturnStrref(id);
+}
+
+void IngameGUI::setReturnQueryStrref(uint32 id) {
+	_hud->setReturnQueryStrref(id);
+}
+
+void IngameGUI::setReturnEnabled(bool enabled) {
+	_hud->setReturnEnabled(enabled);
+}
+
+void IngameGUI::showContainer(KotORBase::Inventory &inv) {
+	_hud->showContainer(inv);
+}
+
+void IngameGUI::setPartyLeader(KotORBase::Creature *creature) {
+	_hud->setPartyLeader(creature);
+}
+
+void IngameGUI::setPartyMember1(KotORBase::Creature *creature) {
+	_hud->setPartyMember1(creature);
+}
+
+void IngameGUI::setPartyMember2(KotORBase::Creature *creature) {
+	_hud->setPartyMember2(creature);
+}
+
+Object *IngameGUI::getHoveredObject() const {
+	return _hud->getHoveredObject();
+}
+
+Object *IngameGUI::getTargetObject() const {
+	return _hud->getTargetObject();
+}
+
+void IngameGUI::setHoveredObject(Object *object) {
+	_hud->setHoveredObject(object);
+}
+
+void IngameGUI::setTargetObject(Object *object) {
+	_hud->setTargetObject(object);
+}
+
+void IngameGUI::resetSelection() {
+	_hud->resetSelection();
+}
+
+void IngameGUI::updateSelection() {
+	_hud->updateSelection();
+}
+
+void IngameGUI::hideSelection() {
+	_hud->hideSelection();
+}
+
+void IngameGUI::addEvent(const Events::Event &event) {
+	_hud->addEvent(event);
+}
+
+void IngameGUI::processEventQueue() {
+	_hud->processEventQueue();
 }
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/gui/ingame.h
+++ b/src/engines/kotorbase/gui/ingame.h
@@ -19,13 +19,14 @@
  */
 
 /** @file
- *  Abstract in-game GUI for KotOR games.
+ *  Base in-game GUI for KotOR games.
  */
 
 #ifndef ENGINES_KOTORBASE_GUI_INGAME_H
 #define ENGINES_KOTORBASE_GUI_INGAME_H
 
 #include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/hud.h"
 
 namespace Engines {
 
@@ -37,45 +38,57 @@ class Object;
 
 class IngameGUI : public KotORBase::GUI {
 public:
-	virtual ~IngameGUI();
+	// Basic visuals
+
+	void show();
+	void hide();
+
+	// Minimap
 
 	/** Set the minimap with the specified id and both scaling points. */
-	virtual void setMinimap(const Common::UString &map, int northAxis,
-	                        float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
-	                        float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y) = 0;
+	void setMinimap(const Common::UString &map, int northAxis,
+	                float worldPt1X, float worldPt1Y, float worldPt2X, float worldPt2Y,
+	                float mapPt1X, float mapPt1Y, float mapPt2X, float mapPt2Y);
 
 	/** Set the position for the minimap. */
-	virtual void setPosition(float x, float y) = 0;
+	void setPosition(float x, float y);
 	/** Set the rotation for the minimap arrow. */
-	virtual void setRotation(float angle) = 0;
+	void setRotation(float angle);
 
-	virtual void setReturnStrref(uint32 id) = 0;
-	virtual void setReturnQueryStrref(uint32 id) = 0;
-	virtual void setReturnEnabled(bool enabled) = 0;
+	// Return to hideout
 
-	// Container inventory handling
-	virtual void showContainer(Inventory &inv) = 0;
+	void setReturnStrref(uint32 id);
+	void setReturnQueryStrref(uint32 id);
+	void setReturnEnabled(bool enabled);
 
-	// Party handling.
-	virtual void setPartyLeader(Creature *creature) = 0;
-	virtual void setPartyMember1(Creature *creature) = 0;
-	virtual void setPartyMember2(Creature *creature) = 0;
+	// Container
+
+	void showContainer(Inventory &inv);
+
+	// Party management
+
+	void setPartyLeader(Creature *creature);
+	void setPartyMember1(Creature *creature);
+	void setPartyMember2(Creature *creature);
 
 	// Selection handling
 
-	virtual Object *getHoveredObject() const = 0;
-	virtual Object *getTargetObject() const = 0;
+	Object *getHoveredObject() const;
+	Object *getTargetObject() const;
 
-	virtual void setHoveredObject(Object *object) = 0;
-	virtual void setTargetObject(Object *object) = 0;
+	void setHoveredObject(Object *object);
+	void setTargetObject(Object *object);
+	
+	void resetSelection();
+	void updateSelection();
+	void hideSelection();
 
-	virtual void updateSelection() = 0;
-	virtual void hideSelection() = 0;
-	virtual void resetSelection() = 0;
 
+	void addEvent(const Events::Event &event);
+	void processEventQueue();
 
-	virtual void addEvent(const Events::Event &event) = 0;
-	virtual void processEventQueue() = 0;
+protected:
+	Common::ScopedPtr<HUD> _hud;
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/gui/rules.mk
+++ b/src/engines/kotorbase/gui/rules.mk
@@ -28,6 +28,8 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/gui/gui.h \
     src/engines/kotorbase/gui/guibackground.h \
     src/engines/kotorbase/gui/loadscreen.h \
+    src/engines/kotorbase/gui/selectioncircle.h \
+    src/engines/kotorbase/gui/hud.h \
     $(EMPTY)
 
 src_engines_kotorbase_libkotorbase_la_SOURCES += \
@@ -39,4 +41,6 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/gui/gui.cpp \
     src/engines/kotorbase/gui/guibackground.cpp \
     src/engines/kotorbase/gui/loadscreen.cpp \
+    src/engines/kotorbase/gui/selectioncircle.cpp \
+    src/engines/kotorbase/gui/hud.cpp \
     $(EMPTY)

--- a/src/engines/kotorbase/gui/selectioncircle.cpp
+++ b/src/engines/kotorbase/gui/selectioncircle.cpp
@@ -19,17 +19,17 @@
  */
 
 /** @file
- *  The circle visible when selecting objects
+ *  Selection circle for KotOR games.
  */
 
 #include "src/engines/kotorbase/objectcontainer.h"
 #include "src/engines/kotorbase/situated.h"
 
-#include "src/engines/kotor/gui/ingame/selectioncircle.h"
+#include "src/engines/kotorbase/gui/selectioncircle.h"
 
 namespace Engines {
 
-namespace KotOR {
+namespace KotORBase {
 
 SelectionCircle::SelectionCircle() :
 		_hoveredQuad(new Graphics::Aurora::GUIQuad("friendlyreticle", 0.0f, 0.0f, kSelectionCircleSize, kSelectionCircleSize)),
@@ -86,7 +86,7 @@ void SelectionCircle::setTarget(bool target) {
 	}
 }
 
-void SelectionCircle::moveTo(KotORBase::Situated *situated, float &sX, float &sY) {
+void SelectionCircle::moveTo(Situated *situated, float &sX, float &sY) {
 	float x, y, z;
 	situated->getTooltipAnchor(x, y, z);
 
@@ -96,6 +96,6 @@ void SelectionCircle::moveTo(KotORBase::Situated *situated, float &sX, float &sY
 	setPosition(sX, sY);
 }
 
-} // End of namespace KotOR
+} // End of namespace KotORBase
 
 } // End of namespace Engines

--- a/src/engines/kotorbase/gui/selectioncircle.h
+++ b/src/engines/kotorbase/gui/selectioncircle.h
@@ -19,17 +19,17 @@
  */
 
 /** @file
- *  The circle visible when selecting objects
+ *  Selection circle for KotOR games.
  */
 
-#ifndef ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H
-#define ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H
+#ifndef ENGINES_KOTORBASE_GUI_SELECTIONCIRCLE_H
+#define ENGINES_KOTORBASE_GUI_SELECTIONCIRCLE_H
 
 #include "src/graphics/aurora/guiquad.h"
 
 namespace Engines {
 
-namespace KotOR {
+namespace KotORBase {
 
 const float kSelectionCircleSize = 64.0f;
 
@@ -49,7 +49,7 @@ public:
 	void setHovered(bool hovered);
 	void setTarget(bool target);
 
-	void moveTo(KotORBase::Situated *situated, float &sX, float &sY);
+	void moveTo(Situated *situated, float &sX, float &sY);
 
 private:
 	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _hoveredQuad;
@@ -60,8 +60,8 @@ private:
 	bool _visible { false };
 };
 
-} // End of namespace KotOR
+} // End of namespace KotORBase
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTOR_GUI_INGAME_SELECTIONCIRCLE_H
+#endif // ENGINES_KOTORBASE_GUI_SELECTIONCIRCLE_H

--- a/src/engines/kotorbase/module.cpp
+++ b/src/engines/kotorbase/module.cpp
@@ -303,7 +303,7 @@ void Module::loadParty() {
 				continue;
 
 			Creature *creature = createCreature(templ);
-			addPartyMember(npc, creature);
+			_partyController.addPartyMember(npc, creature);
 		}
 	}
 
@@ -840,12 +840,12 @@ void Module::showPartySelectionGUI(int forceNPC1, int forceNPC2) {
 
 	if (npc1 != -1) {
 		Creature *creature = createCreature(config.slotTemplate[npc1]);
-		addPartyMember(npc1, creature);
+		_partyController.addPartyMember(npc1, creature);
 	}
 
 	if (npc2 != -1) {
 		Creature *creature = createCreature(config.slotTemplate[npc2]);
-		addPartyMember(npc2, creature);
+		_partyController.addPartyMember(npc2, creature);
 	}
 
 	updateCurrentPartyGUI();
@@ -1080,19 +1080,6 @@ void Module::setupSatelliteCamera() {
 
 void Module::stopCameraMovement() {
 	SatelliteCam.clearInput();
-}
-
-void Module::addPartyMember(int npc, Creature *creature) {
-	Creature *partyLeader = _partyController.getPartyLeader();
-
-	float x, y, z;
-	partyLeader->getPosition(x, y, z);
-	creature->setPosition(x, y, z);
-
-	_area->addCreature(creature);
-	_partyController.addPartyMember(npc, creature);
-
-	creature->show();
 }
 
 void Module::onPartyLeaderChanged() {

--- a/src/engines/kotorbase/module.cpp
+++ b/src/engines/kotorbase/module.cpp
@@ -150,24 +150,7 @@ void Module::loadModule(const Common::UString &module, const Common::UString &en
 		throw e;
 	}
 
-	int northAxis;
-	float mapPt1X, mapPt1Y, mapPt2X, mapPt2Y;
-	float worldPt1X, worldPt1Y, worldPt2X, worldPt2Y;
-
-	northAxis = _area->getNorthAxis();
-	_area->getMapPoint1(mapPt1X, mapPt1Y);
-	_area->getMapPoint2(mapPt2X, mapPt2Y);
-	_area->getWorldPoint1(worldPt1X, worldPt1Y);
-	_area->getWorldPoint2(worldPt2X, worldPt2Y);
-
-	Common::UString mapId;
-	if (_module.contains('_'))
-		mapId = _module.substr(++_module.findFirst("_"), _module.end());
-	else
-		mapId = _module.substr(_module.getPosition(3), _module.end());
-	_ingame->setMinimap(mapId, northAxis,
-	                    worldPt1X, worldPt1Y, worldPt2X, worldPt2Y,
-	                    mapPt1X, mapPt1Y, mapPt2X, mapPt2Y);
+	initMinimap();
 
 	_newModule.clear();
 
@@ -668,6 +651,29 @@ void Module::handleEvents() {
 		_area->processEventQueue();
 		_ingame->processEventQueue();
 	}
+}
+
+void Module::initMinimap() {
+	int northAxis = _area->getNorthAxis();
+
+	float mapPt1X, mapPt1Y, mapPt2X, mapPt2Y;
+	_area->getMapPoint1(mapPt1X, mapPt1Y);
+	_area->getMapPoint2(mapPt2X, mapPt2Y);
+
+	float worldPt1X, worldPt1Y, worldPt2X, worldPt2Y;
+	_area->getWorldPoint1(worldPt1X, worldPt1Y);
+	_area->getWorldPoint2(worldPt2X, worldPt2Y);
+
+	Common::UString mapId;
+
+	if (_module.contains('_'))
+		mapId = _module.substr(++_module.findFirst("_"), _module.end());
+	else
+		mapId = _module.substr(_module.getPosition(3), _module.end());
+
+	_ingame->setMinimap(mapId, northAxis,
+	                    worldPt1X, worldPt1Y, worldPt2X, worldPt2Y,
+	                    mapPt1X, mapPt1Y, mapPt2X, mapPt2Y);
 }
 
 void Module::updateMinimap() {

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -362,7 +362,6 @@ private:
 
 	// Party
 
-	void addPartyMember(int npc, Creature *creature);
 	void onPartyLeaderChanged();
 	void updateCurrentPartyGUI();
 

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -376,10 +376,10 @@ private:
 	void leaveArea();
 
 	void handleEvents();
-
 	void handleActions();
 	void handleHeartbeat();
 
+	void initMinimap();
 	void updateMinimap();
 	void updateSoundListener();
 };

--- a/src/engines/kotorbase/partycontroller.cpp
+++ b/src/engines/kotorbase/partycontroller.cpp
@@ -73,7 +73,19 @@ void PartyController::clearCurrentParty() {
 }
 
 void PartyController::addPartyMember(int npc, Creature *creature) {
+	if (!_party.empty()) {
+		Creature *partyLeader = getPartyLeader();
+		float x, y, z;
+		partyLeader->getPosition(x, y, z);
+		creature->setPosition(x, y, z);
+	}
+
 	_party.push_back(std::make_pair(npc, creature));
+
+	if (npc != -1) {
+		_module->getCurrentArea()->addCreature(creature);
+		creature->show();
+	}
 }
 
 void PartyController::setPartyLeader(int npc) {

--- a/src/engines/odyssey/button.cpp
+++ b/src/engines/odyssey/button.cpp
@@ -22,6 +22,8 @@
  *  Button widget for the Odyssey engine.
  */
 
+#include "src/graphics/aurora/textureman.h"
+
 #include "src/sound/sound.h"
 
 #include "src/engines/aurora/util.h"
@@ -50,6 +52,42 @@ void WidgetButton::load(const Aurora::GFF3Struct &gff) {
 	highlightable = getQuadHighlightableComponent();
 	if (highlightable)
 		setDefaultHighlighting(highlightable);
+}
+
+void WidgetButton::show() {
+	if (isVisible())
+		return;
+
+	Widget::show();
+
+	if (_iconQuad)
+		_iconQuad->show();
+}
+
+void WidgetButton::hide() {
+	if (!isVisible())
+		return;
+
+	Widget::hide();
+	
+	if (_iconQuad)
+		_iconQuad->hide();
+}
+
+void WidgetButton::setPosition(float x, float y, float z) {
+	float oX, oY, oZ;
+	getPosition(oX, oY, oZ);
+
+	float dx = x - oX;
+	float dy = y - oY;
+	float dz = z - oZ;
+
+	Widget::setPosition(x, y, z);
+
+	if (_iconQuad) {
+		_iconQuad->getPosition(x, y, z);
+		_iconQuad->setPosition(x + dx, y + dy, z + dz);
+	}
 }
 
 void WidgetButton::setPermanentHighlight(bool permanentHighlight) {
@@ -109,6 +147,40 @@ void WidgetButton::mouseUp(uint8 UNUSED(state), float UNUSED(x), float UNUSED(y)
 
 	playSound("gui_actuse", Sound::kSoundTypeSFX);
 	setActive(true);
+}
+
+const Common::UString &WidgetButton::getIcon() const {
+	return _icon;
+}
+
+void WidgetButton::setIcon(const Common::UString &icon) {
+	if (_icon == icon)
+		return;
+
+	_icon = icon;
+
+	if (icon.empty()) {
+		if (_iconQuad) {
+			_iconQuad->hide();
+			_iconQuad.reset();
+		}
+		return;
+	}
+
+	Graphics::Aurora::TextureHandle textureHandle = TextureMan.get(icon);
+	Graphics::Aurora::Texture &texture = textureHandle.getTexture();
+
+	_iconQuad.reset(new Graphics::Aurora::GUIQuad(
+			textureHandle,
+			0.0f, 0.0f, texture.getWidth(), texture.getHeight()));
+
+	float x, y, z;
+	getPosition(x, y, z);
+
+	_iconQuad->setPosition(x, y + texture.getHeight() / 2.0f, z - 1.0f);
+
+	if (isVisible())
+		_iconQuad->show();
 }
 
 void WidgetButton::setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable) {

--- a/src/engines/odyssey/button.h
+++ b/src/engines/odyssey/button.h
@@ -45,6 +45,15 @@ public:
 
 	virtual void load(const Aurora::GFF3Struct &gff);
 
+	// Basic visuals
+
+	void show();
+	void hide();
+
+	// Positioning
+
+	void setPosition(float x, float y, float z);
+
 	// Highlighting
 
 	/** Set if the button should be pulsing continuously. */
@@ -62,6 +71,12 @@ public:
 	void leave();
 	void mouseUp(uint8 state, float x, float y);
 
+	// Icon
+
+	const Common::UString &getIcon() const;
+
+	void setIcon(const Common::UString &icon);
+
 	// Sound
 
 	/** Set if the button should not play sound on hover. */
@@ -75,6 +90,9 @@ private:
 	Sound::ChannelHandle _sound;
 
 	bool _hovered;
+
+	Common::UString _icon;
+	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _iconQuad;
 
 	void setDefaultHighlighting(Graphics::Aurora::Highlightable *highlightable);
 };


### PR DESCRIPTION
- GUI class from KotOR 2 is replaced with an utility function (it was limiting reuse possibilities)
- Duplicate dialog logic was moved into the base dialog GUI while the game-specific logic was extracted from it
- In-game GUI and HUD were merged between the two games, which effectively enabled selection mechanics in KotOR 2