### PR TITLE
BUILD: Fix build using MinGW and CMake

### DIFF
--- a/src/engines/rules.mk
+++ b/src/engines/rules.mk
@@ -36,9 +36,9 @@ src_engines_libengines_la_SOURCES += \
     $(EMPTY)
 
 src_engines_libengines_la_LIBADD = \
-    src/engines/aurora/libaurora.la \
-    src/engines/odyssey/libodyssey.la \
     src/engines/kotorbase/libkotorbase.la \
+    src/engines/odyssey/libodyssey.la \
+    src/engines/aurora/libaurora.la \
     $(EMPTY)
 
 # Subdirectories

--- a/src/graphics/aurora/rules.mk
+++ b/src/graphics/aurora/rules.mk
@@ -19,10 +19,7 @@
 
 # Aurora-specific graphics-related loaders.
 
-noinst_LTLIBRARIES += src/graphics/aurora/libaurora.la
-src_graphics_aurora_libaurora_la_SOURCES =
-
-src_graphics_aurora_libaurora_la_SOURCES += \
+src_graphics_libgraphics_la_SOURCES += \
     src/graphics/aurora/types.h \
     src/graphics/aurora/texture.h \
     src/graphics/aurora/texturehandle.h \
@@ -65,7 +62,7 @@ src_graphics_aurora_libaurora_la_SOURCES += \
     src/graphics/aurora/line.h \
     $(EMPTY)
 
-src_graphics_aurora_libaurora_la_SOURCES += \
+src_graphics_libgraphics_la_SOURCES += \
     src/graphics/aurora/texture.cpp \
     src/graphics/aurora/texturehandle.cpp \
     src/graphics/aurora/textureman.cpp \

--- a/src/graphics/rules.mk
+++ b/src/graphics/rules.mk
@@ -66,7 +66,6 @@ src_graphics_libgraphics_la_SOURCES += \
 
 src_graphics_libgraphics_la_LIBADD = \
     src/graphics/images/libimages.la \
-    src/graphics/aurora/libaurora.la \
     src/graphics/shader/libshader.la \
     src/graphics/mesh/libmesh.la \
     src/graphics/render/librender.la \

--- a/src/video/aurora/rules.mk
+++ b/src/video/aurora/rules.mk
@@ -19,13 +19,10 @@
 
 # Aurora-specific video-related support classes.
 
-noinst_LTLIBRARIES += src/video/aurora/libaurora.la
-src_video_aurora_libaurora_la_SOURCES =
-
-src_video_aurora_libaurora_la_SOURCES += \
+src_video_libvideo_la_SOURCES += \
     src/video/aurora/videoplayer.h \
     $(EMPTY)
 
-src_video_aurora_libaurora_la_SOURCES += \
+src_video_libvideo_la_SOURCES += \
     src/video/aurora/videoplayer.cpp \
     $(EMPTY)

--- a/src/video/rules.mk
+++ b/src/video/rules.mk
@@ -42,7 +42,6 @@ src_video_libvideo_la_SOURCES += \
     $(EMPTY)
 
 src_video_libvideo_la_LIBADD = \
-    src/video/aurora/libaurora.la \
     src/video/codecs/libcodecs.la \
     $(EMPTY)
 


### PR DESCRIPTION
This PR, when paired with #474, fixes the #473. The issue was caused by circular dependencies in the video and graphics subsystems, as well as, an invalid order of components in the engines subsystem.