### PR TITLE
KOTOR: Fix selection, use object action, actions refactoring

### DIFF
--- a/src/engines/kotorbase/actionexecutor.h
+++ b/src/engines/kotorbase/actionexecutor.h
@@ -35,20 +35,28 @@ class Creature;
 
 class ActionExecutor {
 public:
-	static void executeActions(Creature &creature, Area &area, float dt);
-	static void executeMoveToPoint(Creature &creature, Area &area, const Action &action, float dt);
-	static void executeFollowLeader(Creature &creature, Area &area, const Action &action, float dt);
-	static void executeOpenLock(Creature &creature, Area &area, const Action &action, float dt);
+	struct ExecutionContext {
+		Creature *creature { nullptr };
+		Area *area { nullptr };
+		float frameTime { 0.0f };
+	};
+
+	static void executeActions(const ExecutionContext &ctx);
 
 private:
-	/** Get if a specified creature has reached a specified location. */
-	static bool isLocationReached(Creature &creature, float x, float y, float range);
+	/** Get if the current creature has reached a specified location. */
+	static bool isLocationReached(const glm::vec2 &location, float range, const ExecutionContext &ctx);
+
+	static void executeMoveToPoint(const Action &action, const ExecutionContext &ctx);
+	static void executeFollowLeader(const Action &action, const ExecutionContext &ctx);
+	static void executeOpenLock(const Action &action, const ExecutionContext &ctx);
+	static void executeUseObject(const Action &action, const ExecutionContext &ctx);
 
 	/**
-	 * Move the creature towards a point. Returns true if the point is
-	 * within the specified range, false otherwise.
+	 * Move the current creature towards a specified location. Returns
+	 * true if location is within a specified range.
 	 */
-	static bool moveTo(Creature &creature, Area &area, float x, float y, float range, float dt);
+	static bool moveTo(const glm::vec2 &location, float range, const ExecutionContext &ctx);
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/area.cpp
+++ b/src/engines/kotorbase/area.cpp
@@ -781,9 +781,13 @@ Creature *Area::getNearestCreature(const Object *target, int UNUSED(nth), const 
 }
 
 void Area::processCreaturesActions(float dt) {
-	for (std::vector<Creature *>::iterator c = _creatures.begin();
-			c != _creatures.end(); ++c) {
-		ActionExecutor::executeActions(**c, *this, dt);
+	ActionExecutor::ExecutionContext ctx;
+	ctx.area = this;
+	ctx.frameTime = dt;
+
+	for (auto &c : _creatures) {
+		ctx.creature = c;
+		ActionExecutor::executeActions(ctx);
 	}
 }
 

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -708,14 +708,11 @@ void Creature::playDrawWeaponAnimation() {
 		case kWeaponWieldPistol:
 			_model->playAnimation("g5w1");
 			break;
-		case kWeaponWieldHeavy:
-			_model->playAnimation("g6w1");
-			break;
 		case kWeaponWieldRifle:
 			_model->playAnimation("g7w1");
 			break;
 		default:
-			// TODO: two swords (g4w1)
+			// TODO: two swords (g4w1) and two pistols (g6w1)
 			break;
 	}
 }

--- a/src/engines/kotorbase/gui/hud.cpp
+++ b/src/engines/kotorbase/gui/hud.cpp
@@ -160,12 +160,15 @@ void HUD::updateTargetObject() {
 	_targetCircle->setHovered(_hoveredObject == _targetObject);
 
 	float sX, sY;
-
-	_targetCircle->moveTo(_targetObject, sX, sY);
-	_targetCircle->show();
-
-	updateTargetInformation(_targetObject, sX, sY);
-	showTargetInformation(_targetObject);
+	bool onScreen = _targetCircle->moveTo(_targetObject, sX, sY);
+	if (onScreen) {
+		_targetCircle->show();
+		updateTargetInformation(_targetObject, sX, sY);
+		showTargetInformation(_targetObject);
+	} else {
+		_targetCircle->hide();
+		hideTargetInformation();
+	}
 }
 
 void HUD::updateHoveredObject() {
@@ -181,8 +184,12 @@ void HUD::updateHoveredObject() {
 	}
 
 	float _, __;
-	_hoveredCircle->moveTo(_hoveredObject, _, __);
-	_hoveredCircle->show();
+	bool onScreen = _hoveredCircle->moveTo(_hoveredObject, _, __);
+
+	if (onScreen)
+		_hoveredCircle->show();
+	else
+		_hoveredCircle->hide();
 }
 
 void HUD::getTargetButtonSize(float &width, float &height) const {

--- a/src/engines/kotorbase/gui/hud.cpp
+++ b/src/engines/kotorbase/gui/hud.cpp
@@ -135,6 +135,7 @@ void HUD::callbackActive(Widget &widget) {
 		if (_targetButtonActions[1] == kActionOpenLock) {
 			Action action(kActionOpenLock);
 			action.object = _targetObject;
+			action.range = 1.0f;
 			_module.getPartyLeader()->enqueueAction(action);
 		}
 		return;

--- a/src/engines/kotorbase/gui/selectioncircle.cpp
+++ b/src/engines/kotorbase/gui/selectioncircle.cpp
@@ -86,14 +86,15 @@ void SelectionCircle::setTarget(bool target) {
 	}
 }
 
-void SelectionCircle::moveTo(Object *object, float &sX, float &sY) {
+bool SelectionCircle::moveTo(Object *object, float &sX, float &sY) {
 	float x, y, z;
 	object->getTooltipAnchor(x, y, z);
 
-	float _;
-	GfxMan.project(x, y, z, sX, sY, _);
-
+	float sZ;
+	GfxMan.project(x, y, z, sX, sY, sZ);
 	setPosition(sX, sY);
+
+	return (sZ >= 0.0f) && (sZ <= 1.0f);
 }
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/gui/selectioncircle.h
+++ b/src/engines/kotorbase/gui/selectioncircle.h
@@ -49,7 +49,8 @@ public:
 	void setHovered(bool hovered);
 	void setTarget(bool target);
 
-	void moveTo(Object *object, float &sX, float &sY);
+	/** Move this selection circle to a specified object. Returns true if it is on screen. */
+	bool moveTo(Object *object, float &sX, float &sY);
 
 private:
 	Common::ScopedPtr<Graphics::Aurora::GUIQuad> _hoveredQuad;

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -235,6 +235,11 @@ public:
 
 	void setCameraYaw(float yaw);
 
+	// Delayed object interactions
+
+	void delayConversation(const Common::UString &name, Aurora::NWScript::Object *owner = nullptr);
+	void delayContainer(Placeable *placeable);
+
 
 	void addItemToActiveObject(const Common::UString &item, int count);
 	void toggleFlyCamera();
@@ -306,6 +311,18 @@ private:
 
 	std::map<Common::UString, bool> _globalBooleans;
 	std::map<Common::UString, int> _globalNumbers;
+
+	// Delayed object interactions
+
+	struct DelayedConversation {
+		Common::UString name;
+		Aurora::NWScript::Object *owner;
+
+		DelayedConversation(const Common::UString &name, Aurora::NWScript::Object *owner = nullptr);
+	};
+
+	Common::ScopedPtr<DelayedConversation> _delayedConversation;
+	Placeable *_delayedContainer { nullptr };
 
 
 	EventQueue  _eventQueue;
@@ -390,6 +407,9 @@ private:
 
 	void updateSoundListener();
 	void updateSelection();
+
+	void handleDelayedInteractions();
+	void openContainer(Placeable *placeable);
 };
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/partyleader.cpp
+++ b/src/engines/kotorbase/partyleader.cpp
@@ -92,6 +92,8 @@ bool PartyLeaderController::processMovement(float frameTime) {
 		return false;
 	}
 
+	partyLeader->clearAllActions();
+
 	float x, y, _;
 	partyLeader->getPosition(x, y, _);
 	float yaw = _module->getCameraYaw();

--- a/src/engines/kotorbase/script/functions_action.cpp
+++ b/src/engines/kotorbase/script/functions_action.cpp
@@ -125,6 +125,7 @@ void Functions::actionFollowLeader(Aurora::NWScript::FunctionContext &ctx) {
 		throw Common::Exception("Functions::actionFollowLeader(): Invalid caller");
 
 	Action action(kActionFollowLeader);
+	action.range = 1.0f;
 	caller->enqueueAction(action);
 }
 


### PR DESCRIPTION
- Fix #480 as suggested
- Issue a "use object" action on click, like in original games (partially solves #479, but still)
- Use ExecutionContext structure in ActionExecutor