### PR TITLE
GRAPHICS: Fix head animation glitches in KotOR 2 (WIP)

### DIFF
--- a/src/graphics/aurora/animation.cpp
+++ b/src/graphics/aurora/animation.cpp
@@ -255,15 +255,6 @@ void Animation::updateSkinnedModel(Model *model) {
 		if (!node->_mesh || !node->_mesh->skin)
 			continue;
 
-		/**
-		 * TODO: Handmaiden model in KotOR 2 has a node that is different from
-		 * all the others in that it's parent is a bone. Because of this it has
-		 * transformations applied twice to it: by the renderer and by the skeletal
-		 * animation routine. This should probably be handled the other way.
-		 */
-		if (node->_parent && node->_parent->_name.stricmp("f_jaw_g") == 0)
-			continue;
-
 		fillBoneTransformsOfModelNode(node);
 
 		if (!GfxMan.isRendererExperimental()) {

--- a/src/graphics/aurora/model.cpp
+++ b/src/graphics/aurora/model.cpp
@@ -656,6 +656,12 @@ void Model::render(RenderPass pass) {
 		glPushMatrix();
 		(*n)->render(pass);
 		glPopMatrix();
+
+		if (!_staticParentsNodes.empty()) {
+			glPushMatrix();
+			(*n)->renderStaticParents(pass);
+			glPopMatrix();
+		}
 	}
 
 	// Reset the first texture units
@@ -823,6 +829,19 @@ void Model::finalize() {
 	c->second->playDefaultAnimation();
 
 	createAbsolutePosition();
+}
+
+bool Model::isStaticParentsNode(const Common::UString &name) const {
+	return _staticParentsNodes.find(name) != _staticParentsNodes.end();
+}
+
+void Model::registerStaticParentsNode(ModelNode *node) {
+	if (isStaticParentsNode(node->_name)) {
+		warning("Node \"%s\" is already registered as a node with static parents", node->_name.c_str());
+		return;
+	}
+
+	_staticParentsNodes.insert(std::make_pair(node->_name, node));
 }
 
 void Model::createStateNamesList(std::list<Common::UString> *stateNames) {

--- a/src/graphics/aurora/model.h
+++ b/src/graphics/aurora/model.h
@@ -250,6 +250,8 @@ protected:
 	bool _skinned;
 	bool _positionRelative;
 
+	std::map<Common::UString, ModelNode *> _staticParentsNodes;
+
 
 	// Rendering
 	void queueDrawBound();
@@ -261,9 +263,15 @@ protected:
 	/** Get the animation from its name. */
 	Animation *getAnimation(const Common::UString &anim);
 
+	// Nodes with static parents
+
+	bool isStaticParentsNode(const Common::UString &name) const;
+
+	void registerStaticParentsNode(ModelNode *node);
+
 
 	/** Finalize the loading procedure. */
-	void finalize();
+	virtual void finalize();
 
 
 	// GLContainer

--- a/src/graphics/aurora/model_kotor.cpp
+++ b/src/graphics/aurora/model_kotor.cpp
@@ -430,6 +430,28 @@ void Model_KotOR::makeBoneNodeMap() {
 	}
 }
 
+void Model_KotOR::finalize() {
+	Model::finalize();
+	handleDefectiveNodes();
+}
+
+void Model_KotOR::handleDefectiveNodes() {
+	handleNodeIfDefective("head");
+	handleNodeIfDefective("tongue");
+	handleNodeIfDefective("tongie");
+}
+
+void Model_KotOR::handleNodeIfDefective(const Common::UString &name) {
+	if (!hasNode(name))
+		return;
+
+	ModelNode *node = getNode(name);
+	ModelNode *rootNode = _currentState->rootNodes.front();
+
+	if (node->getParent() != rootNode)
+		registerStaticParentsNode(node);
+}
+
 
 ModelNode_KotOR::ModelNode_KotOR(Model &model) :
 	ModelNode(model) {

--- a/src/graphics/aurora/model_kotor.h
+++ b/src/graphics/aurora/model_kotor.h
@@ -93,6 +93,10 @@ private:
 	/** Map bone indices to model node references for better peformance. */
 	void makeBoneNodeMap();
 
+	void finalize();
+	void handleDefectiveNodes();
+	void handleNodeIfDefective(const Common::UString &node);
+
 	friend class ModelNode_KotOR;
 };
 

--- a/src/graphics/aurora/modelnode.h
+++ b/src/graphics/aurora/modelnode.h
@@ -88,14 +88,10 @@ public:
 	void getRotation(float &x, float &y, float &z) const;
 	/** Get the orientation of the node. */
 	void getOrientation(float &x, float &y, float &z, float &a) const;
-
 	/** Get the position of the node after translate/rotate. */
 	void getAbsolutePosition(float &x, float &y, float &z) const;
-
 	/** Get the position of the node after translate/rotate. */
 	glm::mat4 getAbsolutePosition() const;
-
-	uint16 getNodeNumber() const;
 
 	/** Set the position of the node. */
 	void setPosition(float x, float y, float z);
@@ -108,6 +104,9 @@ public:
 	void move  (float x, float y, float z);
 	/** Rotate the node, relative to its current rotation. */
 	void rotate(float x, float y, float z);
+
+
+	uint16 getNodeNumber() const;
 
 	/** Set textures to the node. */
 	void setTextures(const std::vector<Common::UString> &textures);
@@ -289,6 +288,7 @@ protected:
 	void createAbsoluteBound(Common::BoundingBox parentPosition);
 
 	void render(RenderPass pass);
+	void renderStaticParents(RenderPass pass);
 	void drawSkeleton(const glm::mat4 &parent, bool showInvisible);
 
 	/** Calculate the transform used for rendering. */
@@ -309,6 +309,9 @@ protected:
 	TextureHandle *getTextures(uint32 &count);
 	TextureHandle *getEnvironmentMap(EnvironmentMapMode &mode);
 
+	glm::vec3 getBasePosition() const;
+	glm::quat getBaseOrientation() const;
+
 	void setMaterial(Shader::ShaderMaterial *material);
 	virtual void buildMaterial();
 
@@ -324,6 +327,7 @@ private:
 
 	void orderChildren();
 
+	void renderInternal(RenderPass pass);
 	void renderGeometry(Mesh &mesh);
 	void renderGeometryNormal(Mesh &mesh);
 	void renderGeometryEnvMappedUnder(Mesh &mesh);


### PR DESCRIPTION
This PR attempts to fix head animation glitches with some models in KotOR 2 (particularly, pmhc06 and p_handmaidenh). The issue seems to be caused by head, tongue (and tongie) nodes being children to a bone, rather than a root node.