### PR TITLE
GRAPHICS: Fix head animations in K2, refactor skeletal animation

### DIFF
--- a/src/engines/nwn2/area.cpp
+++ b/src/engines/nwn2/area.cpp
@@ -495,8 +495,8 @@ void Area::loadTileModels() {
 		t->model->setOrientation(0.0f, 0.0f, 1.0f, rotation);
 
 		// Rotate static floors back
-		const std::list<Graphics::Aurora::ModelNode *> &nodes = t->model->getNodes();
-		for (std::list<Graphics::Aurora::ModelNode *>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
+		const std::vector<Graphics::Aurora::ModelNode *> &nodes = t->model->getNodes();
+		for (std::vector<Graphics::Aurora::ModelNode *>::const_iterator n = nodes.begin(); n != nodes.end(); ++n) {
 			if (t->metaTile || !(*n)->getName().endsWith("_F"))
 				continue;
 

--- a/src/graphics/aurora/animation.h
+++ b/src/graphics/aurora/animation.h
@@ -50,7 +50,7 @@ class AnimNode;
 class Animation {
 public:
 	Animation();
-	~Animation();
+	virtual ~Animation();
 
 	/** Get the animation's name. */
 	const Common::UString &getName() const;
@@ -63,7 +63,7 @@ public:
 	void setTransTime(float transtime);
 
 	/** Update the model position and orientation */
-	void update(Model *model, float lastFrame, float nextFrame, const std::vector<ModelNode *> &modelNodeMap);
+	virtual void update(Model *model, float lastFrame, float nextFrame, const std::vector<ModelNode *> &modelNodeMap);
 
 	// Nodes
 
@@ -92,19 +92,8 @@ protected:
 	float _length;
 	float _transtime;
 
-private:
-	void interpolatePosition(ModelNode *animNode, ModelNode *target, float time, float scale,
-	                         bool relative) const;
-	void interpolateOrientation(ModelNode *animNode, ModelNode *target, float time) const;
-
-	void updateSkinnedModel(Model *model);
-	void fillBoneTransformsOfModelNode(const ModelNode *node);
-
-	inline void applyBoneTransformsToVertex(
-			const ModelNode *node,
-			const float *initialVertexData,
-			int vertexIndex,
-			float *vertexData);
+	glm::vec3 interpolatePosition(ModelNode *animNode, float time) const;
+	glm::quat interpolateOrientation(ModelNode *animNode, float time) const;
 };
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/model.h
+++ b/src/graphics/aurora/model.h
@@ -65,28 +65,26 @@ public:
 	Model(ModelType type = kModelTypeObject);
 	~Model();
 
+	// Basic visuals
+
 	void show();
 	void hide();
 
-	ModelType getType() const; ///< Return the model's type.
+	// Basic properties
 
+	/** Return the model's type. */
+	ModelType getType() const;
 	/** Get the model's name. */
 	const Common::UString &getName() const;
 
-	float getWidth () const; ///< Get the width of the model's bounding box.
-	float getHeight() const; ///< Get the height of the model's bounding box.
-	float getDepth () const; ///< Get the depth of the model's bounding box.
+	// Bounding box
 
-	/** Should a bounding box be drawn around this model? */
-	void drawBound(bool enabled);
-	/** Should a skeleton showing the nodes and their relation be drawn inside the model? */
-	void drawSkeleton(bool enabled, bool showInvisible);
-
-	/** Change the environment map on this model. */
-	void setEnvironmentMap(const Common::UString &environmentMap = "");
-
-	/** Set the flag if the model has skinned animations. */
-	void setSkinned(bool skinned);
+	/** Get the width of the model's bounding box. */
+	float getWidth () const;
+	/** Get the height of the model's bounding box. */
+	float getHeight() const;
+	/** Get the depth of the model's bounding box. */
+	float getDepth () const;
 
 	/** Is that point within the model's bounding box? */
 	bool isIn(float x, float y) const;
@@ -94,7 +92,6 @@ public:
 	bool isIn(float x, float y, float z) const;
 	/** Does the line from x1.y1.z1 to x2.y2.z2 intersect with model's bounding box? */
 	bool isIn(float x1, float y1, float z1, float x2, float y2, float z2) const;
-
 
 	// Positioning
 
@@ -104,7 +101,6 @@ public:
 	void getOrientation(float &x, float &y, float &z, float &angle) const;
 	/** Get the current position of the model. */
 	void getPosition(float &x, float &y, float &z) const;
-
 	/** Get the position of the node after translate/rotate. */
 	void getAbsolutePosition(float &x, float &y, float &z) const;
 
@@ -134,7 +130,6 @@ public:
 	/** Return the name of the current state. */
 	const Common::UString &getState() const;
 
-
 	// Nodes
 
 	/** Does the specified node exist in the current state? */
@@ -154,22 +149,26 @@ public:
 	const ModelNode *getNode(uint16 nodeNumber) const;
 
 	/** Get all nodes in the current state. */
-	const std::list<ModelNode *> &getNodes();
-
-	/** Add another model as a child to the named node. */
-	void attachModel(const Common::UString &nodeName, Model *model);
+	const std::vector<ModelNode *> &getNodes();
 
 	// Animation
+	
+	/** Determine what animation scaling applies. */
+	float getAnimationScale(const Common::UString &anim);
+	/** Get a specified animation channel by name. */
+	AnimationChannel *getAnimationChannel(AnimationChannelName name);
 
 	/** Does this model have this named animation? */
 	bool hasAnimation(const Common::UString &anim) const;
+	/** Are position frames in animations relative to the node's base position? */
+	bool arePositionFramesRelative() const;
+	/** Does the model have skin nodes? */
+	bool hasSkinNodes() const;
 
-	/** Determine what animation scaling applies. */
-	float getAnimationScale(const Common::UString &anim);
+	/** Notify the model that it has skin nodes. */
+	void notifyHasSkinNodes();
 
 	void addAnimationChannel(AnimationChannelName name);
-	AnimationChannel *getAnimationChannel(AnimationChannelName name);
-
 	void clearDefaultAnimations();
 	void addDefaultAnimation(const Common::UString &anim, uint8 probability);
 	void playDefaultAnimation();
@@ -179,22 +178,38 @@ public:
 	                   float length = 0.0f,
 	                   float speed = 1.0f);
 
+	/** Compute transformation matrices of model nodes. */
+	void computeNodeTransforms();
 
 	// Renderable
+
 	void calculateDistance();
 	void render(RenderPass pass);
 	void renderImmediate(const glm::mat4 &parentTransform);
 	void queueRender(const glm::mat4 &parentTransform);
 	void advanceTime(float dt);
 
-	/** Apply buffered changes to model nodes position and geometry. */
-	void flushNodeBuffers();
+	// Attached models
 
+	std::map<Common::UString, Model *> &getAttachedModels();
 	Model *getAttachedModel(const Common::UString &node);
 
+	/** Add another model as a child to the named node. */
+	void attachModel(const Common::UString &nodeName, Model *model);
+
+
+	/** Change the environment map on this model. */
+	void setEnvironmentMap(const Common::UString &environmentMap = "");
+
+	/** Should a bounding box be drawn around this model? */
+	void drawBound(bool enabled);
+	/** Should a skeleton showing the nodes and their relation be drawn inside the model? */
+	void drawSkeleton(bool enabled, bool showInvisible);
+	/** Apply buffered changes to position and geometry of the model nodes. */
+	void flushNodeBuffers();
 
 protected:
-	typedef std::list<ModelNode *> NodeList;
+	typedef std::vector<ModelNode *> NodeList;
 	typedef std::map<Common::UString, ModelNode *, Common::UString::iless> NodeMap;
 	typedef std::map<Common::UString, Animation *, Common::UString::iless> AnimationMap;
 	typedef std::map<AnimationChannelName, AnimationChannel *> AnimationChannelMap;
@@ -247,7 +262,7 @@ protected:
 	/** The model's box after translate/rotate. */
 	Common::BoundingBox _absoluteBoundBox;
 
-	bool _skinned;
+	bool _hasSkinNodes;
 	bool _positionRelative;
 
 

--- a/src/graphics/aurora/model_kotor.h
+++ b/src/graphics/aurora/model_kotor.h
@@ -90,8 +90,10 @@ private:
 			const std::vector<uint32> &offsets, uint32 offset,
 			std::vector<Common::UString> &strings);
 
-	/** Map bone indices to model node references for better peformance. */
-	void makeBoneNodeMap();
+	/** Map bone indices to model nodes for optimization. */
+	void fillBoneNodeMap();
+	/** Certain head models in KotOR 2 contain nodes that are children to a bone rather than a root node. */
+	void reparentHeadNodes();
 
 	friend class ModelNode_KotOR;
 };

--- a/src/graphics/aurora/modelnode.cpp
+++ b/src/graphics/aurora/modelnode.cpp
@@ -27,6 +27,7 @@
 
 #include "external/glm/gtc/type_ptr.hpp"
 #include "external/glm/gtc/matrix_transform.hpp"
+#include "external/glm/gtx/matrix_decompose.hpp"
 
 #include "src/common/util.h"
 #include "src/common/maths.h"
@@ -158,6 +159,41 @@ void ModelNode::setParent(ModelNode *parent) {
 	}
 }
 
+void ModelNode::reparentTo(ModelNode *parent) {
+	if (_parent == parent)
+		return;
+
+	if (_parent)
+		_parent->_children.remove(this);
+
+	if (!parent)
+		return;
+
+	glm::mat4 transform;
+
+	std::vector<const ModelNode *> oldToNew(getPath(_parent, parent));
+	for (std::vector<const ModelNode *>::reverse_iterator n = oldToNew.rbegin(); n != oldToNew.rend(); ++n) {
+		transform *= (*n)->_localTransform;
+	}
+
+	transform *= _parent->_localTransform * _localTransform;
+
+	glm::vec3 scale;
+	glm::quat rotation;
+	glm::vec3 translation;
+	glm::vec3 skew;
+	glm::vec4 perspective;
+	glm::decompose(transform, scale, rotation, translation, skew, perspective);
+
+	setBasePosition(translation);
+	setBaseOrientation(rotation);
+
+	parent->_children.push_back(this);
+
+	_level = parent->_level + 1;
+	_parent = parent;
+}
+
 std::list<ModelNode *> &ModelNode::getChildren() {
 	return _children;
 }
@@ -266,6 +302,72 @@ void ModelNode::move(float x, float y, float z) {
 
 void ModelNode::rotate(float x, float y, float z) {
 	setRotation(_rotation[0] + x, _rotation[1] + y, _rotation[2] + z);
+}
+
+glm::vec3 ModelNode::getBasePosition() const {
+	if (_positionFrames.empty())
+		return glm::vec3();
+
+	const PositionKeyFrame &pos = _positionFrames[0];
+
+	return glm::vec3(pos.x, pos.y, pos.z);
+}
+
+glm::quat ModelNode::getBaseOrientation() const {
+	if (_orientationFrames.empty())
+		return glm::quat();
+
+	const QuaternionKeyFrame &ori = _orientationFrames[0];
+
+	return glm::quat(ori.q, ori.x, ori.y, ori.z);
+}
+
+bool ModelNode::hasPositionFrames() const {
+	return !_positionFrames.empty();
+}
+
+bool ModelNode::hasOrientationFrames() const {
+	return !_orientationFrames.empty();
+}
+
+void ModelNode::setBasePosition(const glm::vec3 &pos) {
+	_position[0] = pos.x;
+	_position[1] = pos.y;
+	_position[2] = pos.z;
+
+	_positionBuffer[0] = pos.x;
+	_positionBuffer[1] = pos.y;
+	_positionBuffer[2] = pos.z;
+
+	if (_positionFrames.empty()) {
+		_positionFrames.push_back(PositionKeyFrame { 0.0f, pos.x, pos.y, pos.z });
+		return;
+	}
+
+	PositionKeyFrame &frame = _positionFrames[0];
+	frame.x = pos.x;
+	frame.y = pos.y;
+	frame.z = pos.z;
+}
+
+void ModelNode::setBaseOrientation(const glm::quat &ori) {
+	_orientation[0] = ori.x;
+	_orientation[1] = ori.y;
+	_orientation[2] = ori.z;
+	_orientation[3] = Common::rad2deg(acosf(ori.w) * 2.0f);
+
+	std::memcpy(_orientationBuffer, _orientation, 4 * sizeof(float));
+
+	if (_orientationFrames.empty()) {
+		_orientationFrames.push_back(QuaternionKeyFrame { 0.0f, ori.x, ori.y, ori.z, ori.w });
+		return;
+	}
+
+	QuaternionKeyFrame &frame = _orientationFrames[0];
+	frame.x = ori.x;
+	frame.y = ori.y;
+	frame.z = ori.z;
+	frame.q = ori.w;
 }
 
 void ModelNode::inheritPosition(ModelNode &node) const {
@@ -913,67 +1015,113 @@ void ModelNode::flushBuffers() {
 	}
 }
 
-void ModelNode::computeBindPose() {
-	std::vector<ModelNode *> nodeChain;
-	for (ModelNode *node = this; node; node = node->_parent) {
-		nodeChain.push_back(node);
-	}
-
-	_bindPose = glm::mat4();
-
-	for (std::vector<ModelNode *>::reverse_iterator n = nodeChain.rbegin();
-			n != nodeChain.rend();
-			++n) {
-		const ModelNode *node = *n;
-
-		if (node->_positionFrames.size() > 0) {
-			const PositionKeyFrame &pos = node->_positionFrames[0];
-			_bindPose = glm::translate(_bindPose, glm::vec3(pos.x, pos.y, pos.z));
-		}
-
-		if (node->_orientationFrames.size() > 0) {
-			const QuaternionKeyFrame &ori = node->_orientationFrames[0];
-			if (ori.x != 0 || ori.y != 0 || ori.z != 0)
-				_bindPose = glm::rotate(_bindPose,
-						acosf(ori.q) * 2.0f,
-						glm::vec3(ori.x, ori.y, ori.z));
-		}
-	}
-
-	_invBindPose = glm::inverse(_bindPose);
+int ModelNode::getBoneCount() const {
+	return _mesh->skin->boneMappingCount;
 }
 
-void ModelNode::computeAbsoluteTransform() {
-	std::vector<ModelNode *> nodeChain;
-	for (ModelNode *node = this; node; node = node->_parent) {
-		nodeChain.push_back(node);
+int ModelNode::getBoneIndexByNodeNumber(int nodeNumber) const {
+	return static_cast<int>(_mesh->skin->boneMapping[nodeNumber]);
+}
+
+ModelNode *ModelNode::getBoneNode(int index) {
+	return _mesh->skin->boneNodeMap[index];
+}
+
+const std::vector<float> &ModelNode::getInitialVertexCoords() const {
+	return _mesh->data->initialVertexCoords;
+}
+
+const std::vector<float> &ModelNode::getBoneIndices() const {
+	return _mesh->skin->boneMappingId;
+}
+
+const std::vector<float> &ModelNode::getBoneWeights() const {
+	return _mesh->skin->boneWeights;
+}
+
+std::vector<float> &ModelNode::getVertexCoordsBuffer() {
+	return _vertexCoordsBuffer;
+}
+
+bool ModelNode::hasSkinNode() const {
+	return _mesh && _mesh->skin;
+}
+
+void ModelNode::computeTransforms() {
+	computeLocalBaseTransform();
+	computeLocalTransform();
+
+	if (_parent) {
+		_absoluteBaseTransform = _parent->_absoluteBaseTransform * _localBaseTransform;
+		_absoluteTransform = _parent->_absoluteTransform * _localTransform;
+	} else {
+		_absoluteBaseTransform = _localBaseTransform;
+		_absoluteTransform = _localTransform;
 	}
 
-	_absoluteTransform = glm::mat4();
+	_boneTransform = _absoluteTransform * _absoluteBaseTransformInv;
+	_absoluteBaseTransformInv = glm::inverse(_absoluteBaseTransform);
+	_absoluteTransformInv = glm::inverse(_absoluteTransform);
 
-	for (std::vector<ModelNode *>::reverse_iterator n = nodeChain.rbegin();
-			n != nodeChain.rend();
-			++n) {
-		const ModelNode *node = *n;
-
-		_absoluteTransform = glm::translate(_absoluteTransform,
-				glm::vec3(node->_positionBuffer[0],
-				          node->_positionBuffer[1],
-				          node->_positionBuffer[2]));
-
-		if (node->_orientationBuffer[0] != 0 ||
-				node->_orientationBuffer[1] != 0 ||
-				node->_orientationBuffer[2] != 0)
-			_absoluteTransform = glm::rotate(_absoluteTransform,
-					Common::deg2rad(node->_orientationBuffer[3]),
-					glm::vec3(node->_orientationBuffer[0],
-					          node->_orientationBuffer[1],
-					          node->_orientationBuffer[2]));
+	for (const auto &n : _children) {
+		n->computeTransforms();
 	}
 }
 
-void ModelNode::computeBoneTransform() {
-	_boneTransform = _absoluteTransform * _invBindPose;
+void ModelNode::computeLocalBaseTransform() {
+	_localBaseTransform = glm::mat4();
+
+	if (_positionFrames.size() > 0) {
+		const PositionKeyFrame &pos = _positionFrames[0];
+		_localBaseTransform = glm::translate(_localBaseTransform, glm::vec3(pos.x, pos.y, pos.z));
+	}
+
+	if (_orientationFrames.size() > 0) {
+		const QuaternionKeyFrame &ori = _orientationFrames[0];
+		if ((ori.x != 0.0f) || (ori.y != 0.0f) || (ori.z != 0.0f)) {
+			_localBaseTransform = glm::rotate(
+					_localBaseTransform,
+					acosf(ori.q) * 2.0f,
+					glm::vec3(ori.x, ori.y, ori.z));
+		}
+	}
+
+	_localBaseTransformInv = glm::inverse(_localBaseTransform);
+}
+
+void ModelNode::computeLocalTransform() {
+	_localTransform = glm::mat4();
+
+	_localTransform = glm::translate(
+			_localTransform,
+			glm::vec3(_positionBuffer[0], _positionBuffer[1], _positionBuffer[2]));
+
+	if     ((_orientationBuffer[0] != 0.0f) ||
+			(_orientationBuffer[1] != 0.0f) ||
+			(_orientationBuffer[2] != 0.0f)) {
+		
+		_localTransform = glm::rotate(
+				_localTransform,
+				Common::deg2rad(_orientationBuffer[3]),
+				glm::vec3(_orientationBuffer[0], _orientationBuffer[1], _orientationBuffer[2]));
+	}
+
+	_localTransformInv = glm::inverse(_localTransform);
+}
+
+std::vector<const ModelNode *> ModelNode::getPath(const ModelNode *from, const ModelNode *to) const {
+	std::vector<const ModelNode *> path;
+	for (const ModelNode *node = from->_parent; node && (node != to); node = node->_parent) {
+		if (node->_level == 0)
+			return std::vector<const ModelNode *>();
+
+		path.push_back(node);
+	}
+	return path;
+}
+
+void ModelNode::notifyVertexCoordsBuffered() {
+	_vertexCoordsBuffered = true;
 }
 
 ModelNode::Mesh *ModelNode::getMesh() const {

--- a/src/graphics/aurora/rules.mk
+++ b/src/graphics/aurora/rules.mk
@@ -60,6 +60,7 @@ src_graphics_libgraphics_la_SOURCES += \
     src/graphics/aurora/walkmesh.h \
     src/graphics/aurora/animationchannel.h \
     src/graphics/aurora/line.h \
+    src/graphics/aurora/skeletalanimation.h \
     $(EMPTY)
 
 src_graphics_libgraphics_la_SOURCES += \
@@ -102,4 +103,5 @@ src_graphics_libgraphics_la_SOURCES += \
     src/graphics/aurora/walkmesh.cpp \
     src/graphics/aurora/animationchannel.cpp \
     src/graphics/aurora/line.cpp \
+    src/graphics/aurora/skeletalanimation.cpp \
     $(EMPTY)

--- a/src/graphics/aurora/skeletalanimation.cpp
+++ b/src/graphics/aurora/skeletalanimation.cpp
@@ -1,0 +1,145 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Skeletal animation helper class.
+ */
+
+#include "external/glm/gtc/type_ptr.hpp"
+#include "external/glm/gtc/matrix_transform.hpp"
+
+#include "src/graphics/aurora/skeletalanimation.h"
+#include "src/graphics/aurora/model.h"
+#include "src/graphics/aurora/animnode.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+SkeletalAnimation::SkeletalAnimation(int bonesPerVertex) :
+		Animation(),
+		_bonesPerVertex(bonesPerVertex) {
+}
+
+void SkeletalAnimation::update(Model *model,
+                               float lastFrame,
+                               float nextFrame,
+                               const std::vector<ModelNode *> &modelNodeMap) {
+
+	Animation::update(model, lastFrame, nextFrame, modelNodeMap);
+	updateModel(model, lastFrame);
+}
+
+void SkeletalAnimation::updateModel(Model *model, float time) {
+	if (!model->hasSkinNodes())
+		return;
+
+	for (const auto &n : model->getNodes()) {
+		if (!n->hasSkinNode())
+			continue;
+
+		model->computeNodeTransforms();
+
+		if (GfxMan.isRendererExperimental()) {
+			fillBoneTransforms(n);
+			continue;
+		}
+
+		const std::vector<float> &vertsIn = n->getInitialVertexCoords();
+		const std::vector<float> &boneIndices = n->getBoneIndices();
+		const std::vector<float> &boneWeights = n->getBoneWeights();
+		std::vector<float> &vertsOut = n->getVertexCoordsBuffer();
+
+		transform(n, vertsIn, boneIndices, boneWeights, vertsOut);
+
+		n->notifyVertexCoordsBuffered();
+	}
+
+	for (const auto &m : model->getAttachedModels()) {
+		updateModel(m.second, time);
+	}
+}
+
+void SkeletalAnimation::fillBoneTransforms(ModelNode *node) {
+	ModelNode::Mesh *mesh = node->getMesh();
+	std::vector<float> &boneTransforms = mesh->data->rawMesh->getBoneTransforms();
+	ModelNode::Skin *skin = mesh->skin;
+
+	for (int i = 0; i < static_cast<int>(skin->boneMappingCount); ++i) {
+		int boneIndex = static_cast<int>(mesh->skin->boneMapping[i]);
+		if (boneIndex == -1)
+			continue;
+
+		float *boneTransformsData = boneTransforms.data() + 16 * boneIndex;
+		ModelNode *boneNode = skin->boneNodeMap[boneIndex];
+		std::memcpy(boneTransformsData, glm::value_ptr(boneNode->getBoneTransform()), 16 * sizeof(float));
+	}
+}
+
+void SkeletalAnimation::transform(ModelNode *node,
+                                  const std::vector<float> &vertsIn,
+                                  const std::vector<float> &boneIndices,
+                                  const std::vector<float> &boneWeights,
+                                  std::vector<float> &vertsOut) {
+
+	const int vertexCount = static_cast<int>(vertsIn.size()) / 3;
+	vertsOut.resize(3 * vertexCount);
+	std::fill(vertsOut.begin(), vertsOut.end(), 0.0f);
+
+	for (int i = 0; i < vertexCount; ++i) {
+		const int vertexOffset = i * 3;
+		const int boneOffset = i * _bonesPerVertex;
+		const float *vertsInData = vertsIn.data() + vertexOffset;
+		float *vertsOutData = vertsOut.data() + vertexOffset;
+
+		for (int j = 0; j < _bonesPerVertex; ++j) {
+			const int boneIndex = static_cast<int>(boneIndices[boneOffset + j]);
+			if (boneIndex == -1)
+				continue;
+
+			const glm::mat4 &boneTransform = node->getBoneNode(boneIndex)->getBoneTransform();
+			const float boneWeight = boneWeights[boneOffset + j];
+			float v0[3], v1[3];
+
+			multiply(vertsInData, node->getAbsoluteBaseTransform(), v0);
+			multiply(v0, boneTransform, v1);
+			multiply(v1, node->getAbsoluteBaseTransformInverse(), v0);
+
+			vertsOutData[0] += v0[0] * boneWeight;
+			vertsOutData[1] += v0[1] * boneWeight;
+			vertsOutData[2] += v0[2] * boneWeight;
+		}
+	}
+}
+
+void SkeletalAnimation::multiply(const float *v, const glm::mat4 &m, float *vOut) {
+	float x = v[0] * m[0][0] + v[1] * m[1][0] + v[2] * m[2][0] + m[3][0];
+	float y = v[0] * m[0][1] + v[1] * m[1][1] + v[2] * m[2][1] + m[3][1];
+	float z = v[0] * m[0][2] + v[1] * m[1][2] + v[2] * m[2][2] + m[3][2];
+	float w = v[0] * m[0][3] + v[1] * m[1][3] + v[2] * m[2][3] + m[3][3];
+
+	vOut[0] = x / w;
+	vOut[1] = y / w;
+	vOut[2] = z / w;
+}
+
+} // End of namespace Aurora
+
+} // End of namespace Graphics

--- a/src/graphics/aurora/skeletalanimation.h
+++ b/src/graphics/aurora/skeletalanimation.h
@@ -1,0 +1,78 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Skeletal animation helper class.
+ */
+
+#ifndef GRAPHICS_AURORA_SKELETALANIMATION_H
+#define GRAPHICS_AURORA_SKELETALANIMATION_H
+
+#include <vector>
+
+#include "external/glm/vec3.hpp"
+#include "external/glm/mat4x4.hpp"
+
+#include "src/common/types.h"
+
+#include "src/graphics/aurora/animation.h"
+
+namespace Graphics {
+
+namespace Aurora {
+
+class SkeletalAnimation : public Animation {
+public:
+	SkeletalAnimation(int bonesPerVertex);
+
+	void update(Model *model,
+	            float lastFrame,
+	            float nextFrame,
+	            const std::vector<ModelNode *> &modelNodeMap);
+
+private:
+	int _bonesPerVertex;
+
+	void updateModel(Model *model, float time);
+	void fillBoneTransforms(ModelNode *node);
+
+	/** Transform vertex coordinates.
+	 *
+	 *  @param node        Model node whose vertices are being transformed.
+	 *  @param vertsIn     Input array of vertex coordinates.
+	 *  @param boneIndices Array of bone indices.
+	 *  @param boneWeights Array of bone weights.
+	 *  @param vertsOut    Output array of vertex coordinates.
+	 */
+	void transform(ModelNode *node,
+	               const std::vector<float> &vertsIn,
+	               const std::vector<float> &boneIndices,
+	               const std::vector<float> &boneWeights,
+	               std::vector<float> &vertsOut);
+
+	/** Multiply a specified vector by a specified matrix. */
+	static void multiply(const float *v, const glm::mat4 &m, float *vOut);
+};
+
+} // End of namespace Aurora
+
+} // End of namespace Graphics
+
+#endif // GRAPHICS_AURORA_SKELETALANIMATION_H


### PR DESCRIPTION
This PR fixes a long-standing issue with certain head models in KotOR 2 (particularly, p_handmaidenh and pmhc06).

The issue was caused by two things. Firstly, we interpreted the bone map as a map from node numbers to bone indices, while it was a map from node indices (in array of root node's children) to bone indices. Secondly, in our current implementation, if a model node is both skinned and is a child to a bone node, then it will be transformed twice, both by the renderer and by the skeletal animation routine. Now, in a majority of models, head and tongue nodes are children to a root node, while in these particular heads they were children to bone nodes.

I have also refactored animations by extracting the skeletal animation code to a separate class and using recursion to compute node transformation matrices.