### PR TITLE
KOTOR: NPC equipment, in-game menus, cursor mechanics, lightsabers, fixes

### DIFF
--- a/src/engines/aurora/gui.cpp
+++ b/src/engines/aurora/gui.cpp
@@ -74,6 +74,8 @@ void GUI::show() {
 		(*iter)->show();
 	}
 
+	_visible = true;
+
 	GfxMan.unlockFrame();
 }
 
@@ -87,6 +89,8 @@ void GUI::hide() {
 	for (std::list<GUI *>::iterator iter = _childGUIs.begin(); iter != _childGUIs.end(); ++iter) {
 		(*iter)->hide();
 	}
+
+	_visible = false;
 
 	GfxMan.unlockFrame();
 }

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -50,6 +50,8 @@ public:
 	GUI(Console *console = 0);
 	virtual ~GUI();
 
+	bool isVisible() const { return _visible; }
+
 	virtual void show(); ///< Show the GUI.
 	virtual void hide(); ///< Hide the GUI.
 
@@ -75,6 +77,8 @@ protected:
 	uint32 _returnCode; ///< The GUI's return code.
 
 	GUI *_sub; ///< The currently running sub GUI.
+
+	bool _visible { false };
 
 
 	/** Add a widget. */

--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -196,24 +196,6 @@ void Creature::getPartModelsPC(PartModels &parts, uint32 state, uint8 textureVar
 	parts.bodyTexture = getBodyTextureString(_gender, _skin, charClass, state);
 	parts.head = getHeadMeshString(_gender, _skin, _face);
 
-	switch (state) {
-		case 'a':
-		case 'b':
-			break;
-		default:
-			switch (_gender) {
-				case KotORBase::kGenderMale:
-					parts.body += "l";
-					break;
-				case KotORBase::kGenderFemale:
-					parts.body += "s";
-					break;
-				default:
-					return;
-			}
-			break;
-	}
-
 	parts.portrait = "po_" + parts.head;
 	parts.portrait.replaceAll("0", "");
 	parts.bodyTexture += Common::UString::format("%02u", textureVariation);

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -427,6 +427,7 @@ void HUD::callbackActive(Widget &widget) {
 	hideSelection();
 	_menu.showMenu(widget.getTag());
 	sub(_menu);
+	_module.updateFrameTimestamp();
 }
 
 void HUD::notifyResized(int UNUSED(oldWidth), int UNUSED(oldHeight), int newWidth, int newHeight) {

--- a/src/engines/kotor/gui/ingame/hud.cpp
+++ b/src/engines/kotor/gui/ingame/hud.cpp
@@ -280,7 +280,7 @@ void HUD::setPortrait(uint8 n, bool visible, const Common::UString &portrait) {
 	if (vitals)
 		vitals->setInvisible(!visible);
 
-	if (visible) {
+	if (visible && _visible) {
 		if (labelBack)
 			labelBack->show();
 		if (labelChar)

--- a/src/engines/kotor/gui/ingame/menu.cpp
+++ b/src/engines/kotor/gui/ingame/menu.cpp
@@ -71,9 +71,9 @@ Menu::Menu(KotORBase::Module &module, Console *console) :
 	}
 
 	_menu[kMenuTypeEquipment].menu.reset(new MenuEquipment(_module, console));
-	_menu[kMenuTypeInventory].menu.reset(new MenuInventory(console));
-	_menu[kMenuTypeCharacter].menu.reset(new MenuCharacter(console));
-	_menu[kMenuTypeAbilities].menu.reset(new MenuAbilities(console));
+	_menu[kMenuTypeInventory].menu.reset(new MenuInventory(_module, console));
+	_menu[kMenuTypeCharacter].menu.reset(new MenuCharacter(_module, console));
+	_menu[kMenuTypeAbilities].menu.reset(new MenuAbilities(_module, console));
 	_menu[kMenuTypeMessages].menu.reset(new MenuMessages(console));
 	_menu[kMenuTypeJournal].menu.reset(new MenuJournal(console));
 	_menu[kMenuTypeMap].menu.reset(new MenuMap(console));
@@ -98,11 +98,9 @@ void Menu::setReturnEnabled(bool enabled) {
 void Menu::showMenu(MenuType type) {
 	assert((type >= 0) && (type < kMenuTypeMAX));
 
-	if (type == kMenuTypeEquipment) {
-		MenuEquipment *equipment = dynamic_cast<MenuEquipment *>(_menu[type].menu.get());
-		if (equipment)
-			equipment->refresh();
-	}
+	KotORBase::MenuBase *menuBase = dynamic_cast<KotORBase::MenuBase *>(_menu[type].menu.get());
+	if (menuBase)
+		menuBase->update();
 
 	if (_currentMenu == &_menu[type])
 		return;

--- a/src/engines/kotor/gui/ingame/menu_abi.cpp
+++ b/src/engines/kotor/gui/ingame/menu_abi.cpp
@@ -30,8 +30,15 @@ namespace Engines {
 
 namespace KotOR {
 
-MenuAbilities::MenuAbilities(Console *console) : KotORBase::GUI(console) {
+MenuAbilities::MenuAbilities(KotORBase::Module &module, Console *console) :
+		KotORBase::MenuBase(module, console) {
+
 	load("abilities");
+}
+
+void MenuAbilities::update() {
+	MenuBase::update();
+	updatePartyLeader("LBL_PORTRAIT");
 }
 
 void MenuAbilities::callbackActive(Widget &widget) {
@@ -39,6 +46,8 @@ void MenuAbilities::callbackActive(Widget &widget) {
 		_returnCode = 1;
 		return;
 	}
+
+	MenuBase::callbackActive(widget);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/menu_char.cpp
+++ b/src/engines/kotor/gui/ingame/menu_char.cpp
@@ -30,8 +30,14 @@ namespace Engines {
 
 namespace KotOR {
 
-MenuCharacter::MenuCharacter(Console *console) : KotORBase::GUI(console) {
+MenuCharacter::MenuCharacter(KotORBase::Module &module, ::Engines::Console *console) :
+		KotORBase::MenuBase(module, console) {
+
 	load("character");
+}
+
+void MenuCharacter::update() {
+	MenuBase::update();
 }
 
 void MenuCharacter::callbackActive(Widget &widget) {
@@ -39,6 +45,8 @@ void MenuCharacter::callbackActive(Widget &widget) {
 		_returnCode = 1;
 		return;
 	}
+
+	MenuBase::callbackActive(widget);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/menu_char.h
+++ b/src/engines/kotor/gui/ingame/menu_char.h
@@ -25,15 +25,21 @@
 #ifndef ENGINES_KOTOR_GUI_INGAME_MENU_CHAR_H
 #define ENGINES_KOTOR_GUI_INGAME_MENU_CHAR_H
 
-#include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/menubase.h"
 
 namespace Engines {
 
+namespace KotORBase {
+	class Module;
+}
+
 namespace KotOR {
 
-class MenuCharacter : public KotORBase::GUI {
+class MenuCharacter : public KotORBase::MenuBase {
 public:
-	MenuCharacter(::Engines::Console *console = 0);
+	MenuCharacter(KotORBase::Module &module, ::Engines::Console *console = 0);
+
+	void update();
 
 protected:
 	void callbackActive(Widget &widget);

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -140,8 +140,9 @@ void MenuEquipment::callbackActive(Widget &widget) {
 			Common::UString itemTag = selectedIndex > 0 ? _visibleItems[selectedIndex - 1] : "";
 
 			KotORBase::Creature *pc = _module->getPC();
-			pc->equipItem(itemTag, _selectedSlot);
-			_module->getCurrentArea()->addToObjectMap(pc);
+			KotORBase::Creature *partyLeader = _module->getPartyLeader();
+			partyLeader->equipItem(itemTag, _selectedSlot, pc->getCreatureInfo());
+			_module->getCurrentArea()->addToObjectMap(partyLeader);
 
 			fillEquipedItems();
 			fillEquipableItemsList();
@@ -205,7 +206,7 @@ void MenuEquipment::fillEquipedItems() {
 }
 
 Common::UString MenuEquipment::getEquipedItemIcon(KotORBase::InventorySlot slot) const {
-	KotORBase::Item *item = _module->getPC()->getEquipedItem(slot);
+	KotORBase::Item *item = _module->getPartyLeader()->getEquipedItem(slot);
 	return item ? item->getIcon() : "";
 }
 

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -219,22 +219,27 @@ void MenuEquipment::fillEquipableItemsList() {
 
 	_visibleItems.clear();
 
-	const std::map<Common::UString, KotORBase::Inventory::ItemGroup> &invItems = inv.getItems();
-	for (std::map<Common::UString, KotORBase::Inventory::ItemGroup>::const_iterator i = invItems.begin();
-			i != invItems.end(); ++i) {
+	for (const auto &i : inv.getItems()) {
 		try {
-			KotORBase::Item item(i->second.tag);
+			KotORBase::Item item(i.second.tag);
 			if (!item.isSlotEquipable(_selectedSlot))
 				continue;
+
+			if (_selectedSlot == KotORBase::kInventorySlotLeftWeapon) {
+				KotORBase::Creature *partyLeader = _module->getPartyLeader();
+				KotORBase::Item *rightWeapon = partyLeader->getEquipedItem(KotORBase::kInventorySlotRightWeapon);
+				if (!rightWeapon || (item.getWeaponWield() != rightWeapon->getWeaponWield()))
+					continue;
+			}
 
 			lbItems->addItem(Common::UString::format("%s|%s|%u",
 			                                         item.getName().c_str(),
 			                                         item.getIcon().c_str(),
-			                                         i->second.count));
+			                                         i.second.count));
 
-			_visibleItems.push_back(i->second.tag);
+			_visibleItems.push_back(i.second.tag);
 		} catch (Common::Exception &e) {
-			e.add("Failed to load item %s", i->second.tag.c_str());
+			e.add("Failed to load item \"%s\"", i.second.tag.c_str());
 			Common::printException(e, "WARNING: ");
 		}
 	}

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -44,8 +44,7 @@ namespace Engines {
 namespace KotOR {
 
 MenuEquipment::MenuEquipment(KotORBase::Module &module, Console *console) :
-		KotORBase::GUI(console),
-		_module(&module),
+		KotORBase::MenuBase(module, console),
 		_selectedSlot(KotORBase::kInventorySlotBody),
 		_slotFixated(false) {
 
@@ -76,7 +75,10 @@ MenuEquipment::MenuEquipment(KotORBase::Module &module, Console *console) :
 	}
 }
 
-void MenuEquipment::refresh() {
+void MenuEquipment::update() {
+	MenuBase::update();
+	updatePartyLeader("LBL_PORTRAIT");
+
 	fillEquipedItems();
 	fillEquipableItemsList();
 }
@@ -161,6 +163,8 @@ void MenuEquipment::callbackActive(Widget &widget) {
 			return;
 		}
 	}
+
+	MenuBase::callbackActive(widget);
 }
 
 void MenuEquipment::callbackKeyInput(const Events::Key &key, const Events::EventType &type) {

--- a/src/engines/kotor/gui/ingame/menu_equ.h
+++ b/src/engines/kotor/gui/ingame/menu_equ.h
@@ -25,7 +25,7 @@
 #ifndef ENGINES_KOTOR_GUI_INGAME_MENU_EQU_H
 #define ENGINES_KOTOR_GUI_INGAME_MENU_EQU_H
 
-#include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/menubase.h"
 
 namespace Engines {
 
@@ -41,11 +41,11 @@ namespace KotORBase {
 
 namespace KotOR {
 
-class MenuEquipment : public KotORBase::GUI {
+class MenuEquipment : public KotORBase::MenuBase {
 public:
 	MenuEquipment(KotORBase::Module &module, ::Engines::Console *console = 0);
 
-	void refresh();
+	void update();
 
 	void show();
 	void hide();
@@ -56,7 +56,6 @@ protected:
 	void callbackKeyInput(const Events::Key &key, const Events::EventType &type);
 
 private:
-	KotORBase::Module *_module;
 	KotORBase::InventorySlot _selectedSlot;
 	bool _slotFixated;
 	std::vector<Common::UString> _visibleItems;

--- a/src/engines/kotor/gui/ingame/menu_inv.cpp
+++ b/src/engines/kotor/gui/ingame/menu_inv.cpp
@@ -24,14 +24,26 @@
 
 #include "src/engines/aurora/widget.h"
 
+#include "src/engines/odyssey/label.h"
+
+#include "src/engines/kotorbase/module.h"
+#include "src/engines/kotorbase/creature.h"
+
 #include "src/engines/kotor/gui/ingame/menu_inv.h"
 
 namespace Engines {
 
 namespace KotOR {
 
-MenuInventory::MenuInventory(Console *console) : KotORBase::GUI(console) {
+MenuInventory::MenuInventory(KotORBase::Module &module, Console *console) :
+		KotORBase::MenuBase(module, console) {
+
 	load("inventory");
+}
+
+void MenuInventory::update() {
+	MenuBase::update();
+	updatePartyLeader("LBL_PORT");
 }
 
 void MenuInventory::callbackActive(Widget &widget) {
@@ -39,6 +51,8 @@ void MenuInventory::callbackActive(Widget &widget) {
 		_returnCode = 1;
 		return;
 	}
+
+	MenuBase::callbackActive(widget);
 }
 
 } // End of namespace KotOR

--- a/src/engines/kotor/gui/ingame/menu_inv.h
+++ b/src/engines/kotor/gui/ingame/menu_inv.h
@@ -25,15 +25,21 @@
 #ifndef ENGINES_KOTOR_GUI_INGAME_MENU_INV_H
 #define ENGINES_KOTOR_GUI_INGAME_MENU_INV_H
 
-#include "src/engines/kotorbase/gui/gui.h"
+#include "src/engines/kotorbase/gui/menubase.h"
 
 namespace Engines {
 
+namespace KotORBase {
+	class Module;
+}
+
 namespace KotOR {
 
-class MenuInventory : public KotORBase::GUI {
+class MenuInventory : public KotORBase::MenuBase {
 public:
-	MenuInventory(::Engines::Console *console = 0);
+	MenuInventory(KotORBase::Module &module, ::Engines::Console *console = 0);
+
+	void update();
 
 protected:
 	void callbackActive(Widget &widget);

--- a/src/engines/kotorbase/cameracontroller.cpp
+++ b/src/engines/kotorbase/cameracontroller.cpp
@@ -38,7 +38,7 @@ namespace Engines {
 namespace KotORBase {
 
 static const float kRotationSpeed = M_PI / 2.0f;
-static const float kMovementSpeed = M_PI / 2.0f;
+static const float kMovementSpeed = 2.0f * M_PI;
 
 CameraController::CameraController(Module *module) : _module(module) {
 }

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -36,7 +36,6 @@
 #include "src/graphics/aurora/modelnode.h"
 #include "src/graphics/aurora/model.h"
 #include "src/graphics/aurora/animationchannel.h"
-#include "src/graphics/aurora/cursorman.h"
 
 #include "src/engines/aurora/util.h"
 #include "src/engines/aurora/model.h"
@@ -522,14 +521,9 @@ void Creature::initAsPC(const CharacterGenerationInfo &chargenInfo, const Creatu
 	loadEquippedModel();
 }
 
-void Creature::enter() {
-	CursorMan.setGroup("talk");
-	highlight(true);
-}
-
-void Creature::leave() {
-	CursorMan.set();
-	highlight(false);
+const Common::UString &Creature::getCursor() const {
+	static Common::UString cursor("talk");
+	return cursor;
 }
 
 void Creature::highlight(bool enabled) {

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -384,7 +384,10 @@ void Creature::loadBody(PartModels &parts) {
 	if (parts.body.stricmp("P_BastilaBB") == 0)
 		parts.body = "P_BastilaBB02";
 
+	GfxMan.lockFrame();
 	_model.reset(loadModelObject(parts.body, parts.bodyTexture));
+	GfxMan.unlockFrame();
+
 	if (!_model)
 		return;
 
@@ -406,7 +409,9 @@ void Creature::loadHead(PartModels &parts) {
 	if (!_headModel)
 		return;
 
+	GfxMan.lockFrame();
 	_model->attachModel("headhook", _headModel);
+	GfxMan.unlockFrame();
 }
 
 void Creature::loadMovementRate(const Common::UString &name) {

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -635,11 +635,11 @@ void Creature::playDefaultHeadAnimation() {
 }
 
 void Creature::playDrawWeaponAnimation() {
-	if (!_model || !_info.isInventorySlotEquipped(kInventorySlotRightWeapon))
+	if (!_model)
 		return;
 
-	Item *rightWeapon = _equipment[kInventorySlotRightWeapon];
-	Item *leftWeapon = _equipment[kInventorySlotLeftWeapon];
+	Item *rightWeapon = _info.isInventorySlotEquipped(kInventorySlotRightWeapon) ? _equipment[kInventorySlotRightWeapon] : nullptr;
+	Item *leftWeapon = _info.isInventorySlotEquipped(kInventorySlotLeftWeapon) ? _equipment[kInventorySlotLeftWeapon] : nullptr;
 
 	if (rightWeapon && !leftWeapon) {
 		switch (rightWeapon->getWeaponWield()) {

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -639,26 +639,43 @@ void Creature::playDrawWeaponAnimation() {
 	if (!_model || !_info.isInventorySlotEquipped(kInventorySlotRightWeapon))
 		return;
 
-	Item *item = _equipment[kInventorySlotRightWeapon];
-	switch (item->getWeaponWield()) {
-		case kWeaponWieldBaton:
-			_model->playAnimation("g1w1");
-			break;
-		case kWeaponWieldSword:
-			_model->playAnimation("g2w1");
-			break;
-		case kWeaponWieldStaff:
-			_model->playAnimation("g3w1");
-			break;
-		case kWeaponWieldPistol:
-			_model->playAnimation("g5w1");
-			break;
-		case kWeaponWieldRifle:
-			_model->playAnimation("g7w1");
-			break;
-		default:
-			// TODO: two swords (g4w1) and two pistols (g6w1)
-			break;
+	Item *rightWeapon = _equipment[kInventorySlotRightWeapon];
+	Item *leftWeapon = _equipment[kInventorySlotLeftWeapon];
+
+	if (rightWeapon && !leftWeapon) {
+		switch (rightWeapon->getWeaponWield()) {
+			case kWeaponWieldBaton:
+				_model->playAnimation("g1w1");
+				break;
+			case kWeaponWieldSword:
+				_model->playAnimation("g2w1");
+				break;
+			case kWeaponWieldStaff:
+				_model->playAnimation("g3w1");
+				break;
+			case kWeaponWieldPistol:
+				_model->playAnimation("g5w1");
+				break;
+			case kWeaponWieldRifle:
+				_model->playAnimation("g7w1");
+				break;
+			default:
+				break;
+		}
+		return;
+	}
+
+	if (rightWeapon && leftWeapon) {
+		switch (rightWeapon->getWeaponWield()) {
+			case kWeaponWieldSword:
+				_model->playAnimation("g4w1");
+				break;
+			case kWeaponWieldPistol:
+				_model->playAnimation("g6w1");
+				break;
+			default:
+				break;
+		}
 	}
 }
 

--- a/src/engines/kotorbase/creature.h
+++ b/src/engines/kotorbase/creature.h
@@ -135,10 +135,8 @@ public:
 
 	// Object/Cursor interactions
 
-	/** The cursor entered the creature. */
-	void enter();
-	/** The cursor left the creature. */
-	void leave();
+	const Common::UString &getCursor() const;
+
 	/** (Un)Highlight the creature. */
 	void highlight(bool enabled);
 	/** The creature was clicked. */

--- a/src/engines/kotorbase/creature.h
+++ b/src/engines/kotorbase/creature.h
@@ -97,7 +97,7 @@ public:
 	/** Get id of the conversation with this creature. */
 	const Common::UString &getConversation() const;
 	/** Get abstract information of this creature. */
-	const CreatureInfo &getCreatureInfo() const;
+	CreatureInfo &getCreatureInfo();
 
 	/** Is the creature a player character? */
 	bool isPC() const;
@@ -149,7 +149,8 @@ public:
 	Inventory &getInventory();
 	Item *getEquipedItem(InventorySlot slot) const;
 
-	void equipItem(Common::UString tag, InventorySlot slot);
+	void equipItem(Common::UString tag, InventorySlot slot, bool updateModel = true);
+	void equipItem(Common::UString tag, InventorySlot slot, CreatureInfo &invOwner, bool updateModel = true);
 
 	// Animation
 
@@ -235,9 +236,10 @@ private:
 
 	void loadProperties(const Aurora::GFF3Struct &gff);
 	void loadPortrait(const Aurora::GFF3Struct &gff);
-	void loadAppearance();
-
-	void getPartModels(PartModels &parts, uint32 state = 'a');
+	void loadEquipment(const Aurora::GFF3Struct &gff);
+	
+	void getModelState(uint32 &state, uint8 &textureVariation);
+	void getPartModels(PartModels &parts, uint32 state, uint8 textureVariation);
 	void loadBody(PartModels &parts);
 	void loadHead(PartModels &parts);
 

--- a/src/engines/kotorbase/door.cpp
+++ b/src/engines/kotorbase/door.cpp
@@ -35,7 +35,6 @@
 #include "src/aurora/2dareg.h"
 
 #include "src/graphics/aurora/model.h"
-#include "src/graphics/aurora/cursorman.h"
 
 #include "src/engines/aurora/util.h"
 
@@ -120,14 +119,9 @@ void Door::hide() {
 void Door::notifyNotSeen() {
 }
 
-void Door::enter() {
-	CursorMan.setGroup("door");
-	highlight(true);
-}
-
-void Door::leave() {
-	CursorMan.set();
-	highlight(false);
+const Common::UString &Door::getCursor() const {
+	static Common::UString cursor("door");
+	return cursor;
 }
 
 void Door::highlight(bool enabled) {

--- a/src/engines/kotorbase/door.h
+++ b/src/engines/kotorbase/door.h
@@ -69,10 +69,8 @@ public:
 
 	// Object/cursor interactions
 
-	/** The cursor entered the door. */
-	void enter();
-	/** The cursor left the door. */
-	void leave();
+	const Common::UString &getCursor() const;
+
 	/** (Un)Highlight the door. */
 	void highlight(bool enabled);
 	/** The door was clicked. */

--- a/src/engines/kotorbase/gui/hud.cpp
+++ b/src/engines/kotorbase/gui/hud.cpp
@@ -22,6 +22,8 @@
  *  Base in-game HUD for KotOR games.
  */
 
+#include "src/graphics/aurora/cursorman.h"
+
 #include "src/engines/odyssey/button.h"
 #include "src/engines/odyssey/label.h"
 #include "src/engines/odyssey/progressbar.h"
@@ -91,6 +93,13 @@ Object *HUD::getTargetObject() const {
 
 void HUD::setHoveredObject(Object *object) {
 	_hoveredObject = object;
+
+	if (!object || (object != _targetObject)) {
+		CursorMan.set();
+		return;
+	}
+
+	setCursorToTarget();
 }
 
 void HUD::setTargetObject(Object *object) {
@@ -99,6 +108,8 @@ void HUD::setTargetObject(Object *object) {
 
 	_targetObject = object;
 	_targetDirty = true;
+
+	setCursorToTarget();
 }
 
 void HUD::resetSelection() {
@@ -191,6 +202,19 @@ void HUD::updateHoveredObject() {
 		_hoveredCircle->show();
 	else
 		_hoveredCircle->hide();
+}
+
+void HUD::setCursorToTarget() {
+	if (!_targetObject) {
+		CursorMan.set();
+		return;
+	}
+
+	const Common::UString &cursor = _targetObject->getCursor();
+	if (!cursor.empty())
+		CursorMan.setGroup(cursor);
+	else
+		CursorMan.set();
 }
 
 void HUD::getTargetButtonSize(float &width, float &height) const {

--- a/src/engines/kotorbase/gui/hud.h
+++ b/src/engines/kotorbase/gui/hud.h
@@ -113,6 +113,7 @@ private:
 
 	void updateTargetObject();
 	void updateHoveredObject();
+	void setCursorToTarget();
 
 	// Target buttons
 

--- a/src/engines/kotorbase/gui/menubase.cpp
+++ b/src/engines/kotorbase/gui/menubase.cpp
@@ -1,0 +1,83 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Common base for in-game menus in KotOR games.
+ */
+
+#include "src/common/strutil.h"
+
+#include "src/engines/odyssey/label.h"
+#include "src/engines/odyssey/button.h"
+
+#include "src/engines/kotorbase/module.h"
+#include "src/engines/kotorbase/creature.h"
+
+#include "src/engines/kotorbase/gui/menubase.h"
+
+namespace Engines {
+
+namespace KotORBase {
+
+MenuBase::MenuBase(Module &module, Console *console) :
+		GUI(console),
+		_module(&module) {
+}
+
+MenuBase::~MenuBase() {
+}
+
+void MenuBase::update() {
+	updatePartyMember(1);
+	updatePartyMember(2);
+}
+
+void MenuBase::callbackActive(Widget &widget) {
+	const Common::UString &tag = widget.getTag();
+
+	if (tag.beginsWith("BTN_CHANGE")) {
+		int memberIndex = (tag == "BTN_CHANGE1") ? 1 : 2;
+		_module->setPartyLeaderByIndex(memberIndex);
+		update();
+		return;
+	}
+}
+
+void MenuBase::updatePartyLeader(const Common::UString &widgetTag) {
+	const Common::UString &portrait = _module->getPartyLeader()->getPortrait();
+	getLabel(widgetTag)->setFill(portrait);
+}
+
+void MenuBase::updatePartyMember(int index) {
+	Odyssey::WidgetButton *btnChange = getButton("BTN_CHANGE" + Common::composeString(index));
+	KotORBase::Creature *partyMember = _module->getPartyMemberByIndex(index);
+	if (partyMember) {
+		Common::UString texture = partyMember ? partyMember->getPortrait() : "";
+		btnChange->setInvisible(false);
+		btnChange->setFill(texture);
+		btnChange->setHighlight(texture);
+	} else {
+		btnChange->setInvisible(true);
+	}
+}
+
+} // End of namespace KotORBase
+
+} // End of namespace Engines

--- a/src/engines/kotorbase/gui/menubase.h
+++ b/src/engines/kotorbase/gui/menubase.h
@@ -19,34 +19,40 @@
  */
 
 /** @file
- *  The ingame abilities menu.
+ *  Common base for in-game menus in KotOR games.
  */
 
-#ifndef ENGINES_KOTOR_GUI_INGAME_MENU_ABI_H
-#define ENGINES_KOTOR_GUI_INGAME_MENU_ABI_H
+#ifndef ENGINES_KOTORBASE_GUI_MENUBASE_H
+#define ENGINES_KOTORBASE_GUI_MENUBASE_H
 
-#include "src/engines/kotorbase/gui/menubase.h"
+#include "src/engines/kotorbase/gui/gui.h"
 
 namespace Engines {
 
 namespace KotORBase {
-	class Module;
-}
 
-namespace KotOR {
+class Module;
 
-class MenuAbilities : public KotORBase::MenuBase {
+class MenuBase : public GUI {
 public:
-	MenuAbilities(KotORBase::Module &module, ::Engines::Console *console = 0);
+	MenuBase(Module &module, Console *console = nullptr);
+	virtual ~MenuBase();
 
-	void update();
+	virtual void update();
 
 protected:
-	void callbackActive(Widget &widget);
+	Module *_module;
+	
+	virtual void callbackActive(Widget &widget);
+
+	void updatePartyLeader(const Common::UString &widgetTag);
+
+private:
+	void updatePartyMember(int index);
 };
 
-} // End of namespace KotOR
+} // End of namespace KotORBase
 
 } // End of namespace Engines
 
-#endif // ENGINES_KOTOR_GUI_INGAME_MENU_ABI_H
+#endif // ENGINES_KOTORBASE_GUI_MENUBASE_H

--- a/src/engines/kotorbase/gui/rules.mk
+++ b/src/engines/kotorbase/gui/rules.mk
@@ -30,6 +30,7 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/gui/loadscreen.h \
     src/engines/kotorbase/gui/selectioncircle.h \
     src/engines/kotorbase/gui/hud.h \
+    src/engines/kotorbase/gui/menubase.h \
     $(EMPTY)
 
 src_engines_kotorbase_libkotorbase_la_SOURCES += \
@@ -43,4 +44,5 @@ src_engines_kotorbase_libkotorbase_la_SOURCES += \
     src/engines/kotorbase/gui/loadscreen.cpp \
     src/engines/kotorbase/gui/selectioncircle.cpp \
     src/engines/kotorbase/gui/hud.cpp \
+    src/engines/kotorbase/gui/menubase.cpp \
     $(EMPTY)

--- a/src/engines/kotorbase/module.cpp
+++ b/src/engines/kotorbase/module.cpp
@@ -582,6 +582,10 @@ void Module::processEventQueue() {
 	handleDelayedInteractions();
 }
 
+void Module::updateFrameTimestamp() {
+	_prevTimestamp = EventMan.getTimestamp();
+}
+
 void Module::handleEvents() {
 	for (EventQueue::const_iterator event = _eventQueue.begin(); event != _eventQueue.end(); ++event) {
 		// Handle console
@@ -704,7 +708,7 @@ void Module::openContainer(Placeable *placeable) {
 	placeable->close(_pc);
 	placeable->runScript(kScriptDisturbed, placeable, _pc);
 
-	_prevTimestamp = EventMan.getTimestamp();
+	updateFrameTimestamp();
 }
 
 void Module::handleActions() {
@@ -1038,7 +1042,7 @@ void Module::startConversation(const Common::UString &name, Aurora::NWScript::Ob
 		_dialog->show();
 		_inDialog = true;
 
-		_prevTimestamp = EventMan.getTimestamp();
+		updateFrameTimestamp();
 	}
 }
 

--- a/src/engines/kotorbase/module.h
+++ b/src/engines/kotorbase/module.h
@@ -202,6 +202,8 @@ public:
 	void addEvent(const Events::Event &event);
 	/** Process the current event queue. */
 	void processEventQueue();
+	/** Update timestamp of the previous rendered frame. */
+	void updateFrameTimestamp();
 
 	// Saved games
 

--- a/src/engines/kotorbase/object.cpp
+++ b/src/engines/kotorbase/object.cpp
@@ -202,6 +202,11 @@ void Object::setMinOneHitPoints(bool enabled) {
 	_minOneHitPoint = enabled;
 }
 
+const Common::UString &Object::getCursor() const {
+	static Common::UString cursor("");
+	return cursor;
+}
+
 void Object::enter() {
 }
 

--- a/src/engines/kotorbase/object.h
+++ b/src/engines/kotorbase/object.h
@@ -131,6 +131,8 @@ public:
 
 	// Object/Cursor interactions
 
+	virtual const Common::UString &getCursor() const;
+
 	/** The cursor entered the object. */
 	virtual void enter();
 	/** The cursor left the object. */

--- a/src/engines/kotorbase/placeable.cpp
+++ b/src/engines/kotorbase/placeable.cpp
@@ -108,14 +108,9 @@ void Placeable::loadAppearance() {
 	_soundAppType = twoda.getRow(_appearanceID).getInt("SoundAppType");
 }
 
-void Placeable::enter() {
-	CursorMan.setGroup("use");
-	highlight(true);
-}
-
-void Placeable::leave() {
-	CursorMan.set();
-	highlight(false);
+const Common::UString &Placeable::getCursor() const {
+	static Common::UString cursor("use");
+	return cursor;
 }
 
 void Placeable::highlight(bool enabled) {

--- a/src/engines/kotorbase/placeable.h
+++ b/src/engines/kotorbase/placeable.h
@@ -78,10 +78,8 @@ public:
 
 	// Object/cursor interactions
 
-	/** The cursor entered the placeable. */
-	void enter();
-	/** The cursor left the placeable. */
-	void leave();
+	const Common::UString &getCursor() const;
+
 	/** (Un)Highlight the placeable. */
 	void highlight(bool enabled);
 	/** The placeable was clicked. */

--- a/src/graphics/aurora/model_kotor.h
+++ b/src/graphics/aurora/model_kotor.h
@@ -57,6 +57,7 @@ private:
 		std::list<ModelNode_KotOR *> nodes;
 
 		Common::UString texture;
+		std::vector<Common::UString> textures;
 
 		bool kotor2;
 		bool xbox;
@@ -68,7 +69,9 @@ private:
 
 		uint32 mdxStructSize;
 		uint16 vertexCount;
+		uint16 textureCount;
 		uint32 offNodeData;
+		uint32 offVertsCoords;
 		uint16 flags;
 
 		ParserContext(const Common::UString &name, const Common::UString &t, bool k2, bool x);
@@ -117,6 +120,7 @@ private:
 	                               uint16 dataIndex, std::vector<float> &dataFloat, std::vector<uint32> &dataInt);
 	void readMesh(Model_KotOR::ParserContext &ctx);
 	void readSkin(Model_KotOR::ParserContext &ctx);
+	void readSaber(Model_KotOR::ParserContext &ctx);
 };
 
 } // End of namespace Aurora

--- a/src/graphics/aurora/modelnode.cpp
+++ b/src/graphics/aurora/modelnode.cpp
@@ -563,13 +563,24 @@ void ModelNode::renderGeometry(ModelNode::Mesh &mesh) {
 }
 
 void ModelNode::renderGeometryNormal(Mesh &mesh) {
+	bool specialBlending = false;
+
 	for (size_t t = 0; t < mesh.data->textures.size(); t++) {
 		TextureMan.activeTexture(t);
 		TextureMan.set(mesh.data->textures[t]);
+
+		if (!mesh.data->textures[t].empty()) {
+			const Graphics::Aurora::Texture &texture = mesh.data->textures[t].getTexture();
+			if (!texture.hasAlpha() && (texture.getTXI().getFeatures().blending == TXI::kBlendingAdditive))
+				specialBlending = true;
+		}
 	}
 
 	if (mesh.data->textures.empty())
 		glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
+	if (specialBlending)
+		glBlendFunc(GL_SRC_COLOR, GL_ONE);
 
 	mesh.data->rawMesh->renderImmediate();
 
@@ -580,6 +591,8 @@ void ModelNode::renderGeometryNormal(Mesh &mesh) {
 
 	if (mesh.data->textures.empty())
 		glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
 
 void ModelNode::renderGeometryEnvMappedUnder(Mesh &mesh) {


### PR DESCRIPTION
This PR:
- Implements loading and changing of NPC equipment.
- Implements changing the party leader from in-game menus.
- Implements weapon wield animation for two swords and two pistols.
- Implements cursor mechanics from the original games.
- Fixes frame time miscalculations when closing in-game menus (teleporting characters).
- Fixes loading equipped body models for PC.
- Fixes loading and displaying of lightsaber models. Also, windows on the Endar Spire.