### PR TITLE
ODYSSEY: Adjust icon to be in the middle of the widget

### DIFF
--- a/src/engines/odyssey/button.cpp
+++ b/src/engines/odyssey/button.cpp
@@ -177,7 +177,11 @@ void WidgetButton::setIcon(const Common::UString &icon) {
 	float x, y, z;
 	getPosition(x, y, z);
 
-	_iconQuad->setPosition(x, y + texture.getHeight() / 2.0f, z - 1.0f);
+	_iconQuad->setPosition(
+		x + getWidth() / 2.0f - texture.getWidth() / 2.0f,
+		y + getHeight() / 2.0f - texture.getHeight() / 2.0f,
+		z - 1.0f
+	);
 
 	if (isVisible())
 		_iconQuad->show();


### PR DESCRIPTION
A small fix to adjust the lock icon in both kotor games like it is in the original