### PR TITLE
BUILD: Add SDL2 path suffix for windows compilation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,7 +83,7 @@ build_script:
   - cmake -Bbuild -H. -G"%CMAKE_GENERATOR%"
           -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
           -DBOOST_LIBRARYDIR=%BOOST_LIBRARYDIR%
-          -DSDL2_LIBRARY=%VCPKG_LIB_DIR%/SDL2.lib -DSDL2_INCLUDE_DIR=%VCPKG_INC_DIR%/SDL2
+          -DSDL2_LIBRARY=%VCPKG_LIB_DIR%/SDL2.lib
   - cmake --build build
   - copy /y %BOOST_ROOT%\lib32-msvc-14.0\*.dll build\bin\Debug
   - copy /y %VCPKG_BIN_DIR%\*.dll build\bin\Debug

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -25,7 +25,7 @@
 # SDL2_FOUND - True if SDL2 found.
 
 if(WIN32)
-  find_path(SDL2_INCLUDE_DIR SDL.h $ENV{PROGRAMFILES}/SDL2/include DOC "The directory where SDL.h resides")
+  find_path(SDL2_INCLUDE_DIR SDL.h $ENV{PROGRAMFILES}/SDL2/include PATH_SUFFIXES SDL2 DOC "The directory where SDL.h resides")
   find_library(SDL2_LIBRARY NAMES SDL2 PATHS $ENV{PROGRAMFILES}/SDL2/lib DOC "The SDL2 library")
 
 else(WIN32)


### PR DESCRIPTION
This PR adds a path suffix for SDL2 in windows builds and therefore fix #520. I also removed a cirumvention of this issue from the appveyor file to verify the correct behaviour.