### PR TITLE
BUILD: Remove boost regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 list(APPEND XOREOS_LIBRARIES ${ZLIB_LIBRARIES})
 
-find_package(Boost COMPONENTS system filesystem regex date_time locale REQUIRED)
+find_package(Boost COMPONENTS system filesystem date_time locale REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})

--- a/src/common/filelist.cpp
+++ b/src/common/filelist.cpp
@@ -22,8 +22,9 @@
  *  A list of files.
  */
 
+#include <regex>
+
 #include <boost/filesystem.hpp>
-#include <boost/regex.hpp>
 
 #include "src/common/filelist.h"
 #include "src/common/filepath.h"
@@ -165,16 +166,16 @@ bool FileList::getSubList(const UString &str, bool caseInsensitive, FileList &su
 }
 
 bool FileList::getSubListGlob(const UString &glob, bool caseInsensitive, FileList &subList) const {
-	boost::regex::flag_type type = boost::regex::perl;
+	std::regex::flag_type type = std::regex_constants::ECMAScript;
 	if (caseInsensitive)
-		type |= boost::regex::icase;
-	boost::regex expression(glob.c_str(), type);
+		type |= std::regex::icase;
+	std::regex expression(glob.c_str(), type);
 
 	bool foundMatch = false;
 
 	// Iterate through the whole list, adding the matches to the sub list
 	for (Files::const_iterator it = _files.begin(); it != _files.end(); ++it)
-		if (boost::regex_match(it->c_str(), expression)) {
+		if (std::regex_match(it->c_str(), expression)) {
 			subList._files.push_back(*it);
 			foundMatch = true;
 		}
@@ -205,14 +206,14 @@ UString FileList::findFirst(const UString &str, bool caseInsensitive) const {
 }
 
 UString FileList::findFirstGlob(const UString &glob, bool caseInsensitive) const {
-	boost::regex::flag_type type = boost::regex::perl;
+	std::regex::flag_type type = std::regex_constants::ECMAScript;
 	if (caseInsensitive)
-		type |= boost::regex::icase;
-	boost::regex expression(glob.c_str(), type);
+		type |= std::regex::icase;
+	std::regex expression(glob.c_str(), type);
 
 	// Iterate through the whole list, adding the matches to the sub list
 	for (Files::const_iterator it = _files.begin(); it != _files.end(); ++it)
-		if (boost::regex_match(it->c_str(), expression))
+		if (std::regex_match(it->c_str(), expression))
 			return *it;
 
 	return "";

--- a/src/common/filepath.cpp
+++ b/src/common/filepath.cpp
@@ -23,10 +23,10 @@
  */
 
 #include <list>
+#include <regex>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/regex.hpp>
 
 #include "src/common/filepath.h"
 #include "src/common/util.h"
@@ -119,11 +119,12 @@ bool FilePath::isPOSIXAbsolute(const UString &p) {
 }
 
 static path convertToSlash(const path &p) {
-	const boost::regex bSlash("\\\\");
+	const std::regex bSlash("\\\\");
 	const std::string fSlash("/");
-	const boost::match_flag_type flags(boost::match_default | boost::format_sed);
+	const std::regex_constants::match_flag_type flags(
+			std::regex_constants::match_default | std::regex_constants::format_sed);
 
-	return path(boost::regex_replace(p.string(), bSlash, fSlash, flags));
+	return path(std::regex_replace(p.string(), bSlash, fSlash, flags));
 }
 
 UString FilePath::absolutize(const UString &p) {
@@ -352,10 +353,15 @@ bool FilePath::createDirectories(const UString &path) {
 }
 
 UString FilePath::escapeStringLiteral(const UString &str) {
-	const boost::regex esc("[\\^\\.\\$\\|\\(\\)\\[\\]\\*\\+\\?\\/\\\\]");
+	const std::regex esc("[\\^\\.\\$\\|\\(\\)\\[\\]\\*\\+\\?\\/\\\\]");
 	const std::string  rep("\\\\\\1&");
 
-	return boost::regex_replace(std::string(str.c_str()), esc, rep, boost::match_default | boost::format_sed);
+	return std::regex_replace(
+			std::string(str.c_str()),
+			esc,
+			rep,
+			std::regex_constants::match_default | std::regex_constants::format_sed
+	);
 }
 
 UString FilePath::getHumanReadableSize(size_t size) {

--- a/src/common/filepath.cpp
+++ b/src/common/filepath.cpp
@@ -354,14 +354,9 @@ bool FilePath::createDirectories(const UString &path) {
 
 UString FilePath::escapeStringLiteral(const UString &str) {
 	const std::regex esc("[\\^\\.\\$\\|\\(\\)\\[\\]\\*\\+\\?\\/\\\\]");
-	const std::string  rep("\\\\\\1&");
+	const std::string  rep("\\$&");
 
-	return std::regex_replace(
-			std::string(str.c_str()),
-			esc,
-			rep,
-			std::regex_constants::match_default | std::regex_constants::format_sed
-	);
+	return std::regex_replace(std::string(str.c_str()),	esc, rep);
 }
 
 UString FilePath::getHumanReadableSize(size_t size) {


### PR DESCRIPTION
This PR removes boost regex from the depndencies and replaces it through c++11 regex