### PR TITLE
KOTORBASE: Add that non-creature object dialogs are properly started

### DIFF
--- a/src/engines/kotorbase/module.cpp
+++ b/src/engines/kotorbase/module.cpp
@@ -1030,6 +1030,10 @@ void Module::startConversation(const Common::UString &name, Aurora::NWScript::Ob
 		Creature *creature = ObjectContainer::toCreature(owner);
 		if (creature)
 			finalName = creature->getConversation();
+
+		Situated *situated = ObjectContainer::toSituated(owner);
+		if (situated)
+			finalName = situated->getConversation();
 	}
 
 	if (finalName.empty())


### PR DESCRIPTION
This PR fixes the start of non-creature dialogs. It enables the playing of the dialog in the third room and properly assigns the Sith troopers as enemys.