### PR TITLE
KOTORBASE: Prevent infinite distance from camera

### DIFF
--- a/src/engines/kotorbase/cameracontroller.cpp
+++ b/src/engines/kotorbase/cameracontroller.cpp
@@ -167,6 +167,9 @@ void CameraController::processMovement(float frameTime) {
 		_actualDistance += delta;
 	}
 
+	// TODO: 3.5 is only an assumption for the max distance
+	_actualDistance = MIN(_actualDistance, 3.5f);
+
 	glm::vec3 actualPosition = getCameraPosition(_actualDistance);
 	CameraMan.setPosition(actualPosition.x, actualPosition.y, actualPosition.z);
 	CameraMan.update();


### PR DESCRIPTION
I discovered, that especially in the first kotor2 level on peragus, the camera got stuck and applied really long distances between the character. This PR should prevent this by applying an upper bound to the distance.