### PR TITLE
BUILD: Add build folder to the include path for win32/xoreos.rc

### DIFF
--- a/src/rules.mk
+++ b/src/rules.mk
@@ -21,7 +21,7 @@
 
 # Windows resources
 .rc.o:
-	$(AM_V_GEN)$(RC) -DHAVE_CONFIG_H -I$(srcdir) -o $@ $<
+	$(AM_V_GEN)$(RC) -DHAVE_CONFIG_H -I$(srcdir) -I. -o $@ $<
 
 bin_PROGRAMS += src/xoreos
 src_xoreos_SOURCES =


### PR DESCRIPTION
Otherwise, the MinGW build fails because of the `config.h` file not being
found.