### PR TITLE
COMMON: Fix calling convention for SetThreadDescription

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -210,7 +210,7 @@ void Thread::setCurrentThreadName(const Common::UString &name) {
 		FreeLibrary(kernel32);
 	} BOOST_SCOPE_EXIT_END;
 
-	typedef HRESULT (*SetThreadDescriptionFunc)(HANDLE hThread, PCWSTR lpThreadDescription);
+	typedef HRESULT (WINAPI *SetThreadDescriptionFunc)(HANDLE hThread, PCWSTR lpThreadDescription);
 	SetThreadDescriptionFunc func = (SetThreadDescriptionFunc)GetProcAddress(kernel32, "SetThreadDescription");
 	if (!func)
 		return;


### PR DESCRIPTION
This fixes the following crash when building with MSVC:

> Run-Time Check Failure #0 - The value of ESP was not properly saved across a function call.  This is usually a result of calling a function declared with one calling convention with a function pointer declared with a different calling convention.