### PR TITLE
GRAPHICS: Use std::numeric_limits over literals

### DIFF
--- a/src/graphics/shader/shadermaterial.cpp
+++ b/src/graphics/shader/shadermaterial.cpp
@@ -22,6 +22,8 @@
  *  Shader material, responsible for tracking data relating to a fragment shader.
  */
 
+#include <limits>
+
 #include "src/graphics/shader/shadermaterial.h"
 
 namespace Graphics {
@@ -33,7 +35,7 @@ namespace Shader {
 ShaderMaterial::ShaderMaterial(Shader::ShaderObject *fragShader, const Common::UString &name) :
 		_variableData(), _fragShader(fragShader), _flags(0), _blendEquationRGB(GL_FUNC_ADD), _blendEquationAlpha(GL_FUNC_ADD),
 		_blendSrcRGB(GL_SRC_ALPHA), _blendSrcAlpha(GL_SRC_ALPHA), _blendDstRGB(GL_ONE_MINUS_SRC_ALPHA), _blendDstAlpha(GL_ONE_MINUS_SRC_ALPHA),
-		_name(name), _usageCount(0), _alphaIndex(0xFFFFFFFF) {
+		_name(name), _usageCount(0), _alphaIndex(std::numeric_limits<uint32_t>::max()) {
 	fragShader->usageCount++;
 
 	uint32_t varCount = fragShader->variablesCombined.size();
@@ -255,7 +257,7 @@ void ShaderMaterial::bindProgram(Shader::ShaderProgram *program, float alpha) {
 }
 
 void ShaderMaterial::bindFade(Shader::ShaderProgram *program, float alpha) {
-	if (_alphaIndex != 0xFFFFFFFF) {
+	if (_alphaIndex != std::numeric_limits<uint32_t>::max()) {
 		ShaderMan.bindShaderVariable(program->fragmentObject->variablesCombined[_alphaIndex], program->fragmentVariableLocations[_alphaIndex], &alpha);
 	}
 }

--- a/src/graphics/shader/shadersurface.cpp
+++ b/src/graphics/shader/shadersurface.cpp
@@ -21,6 +21,7 @@
 /** @file
  *  Shader surface, responsible for tracking data relating to a vertex shader.
  */
+#include <limits>
 
 #include "external/glm/gtc/type_ptr.hpp"
 
@@ -40,10 +41,10 @@ ShaderSurface::ShaderSurface(Shader::ShaderObject *vertShader, const Common::USt
 		_flags(0),
 		_name(name),
 		_usageCount(0),
-		_objectModelviewIndex(0xFFFFFFFF),
-		_textureViewIndex(0xFFFFFFFF),
-		_bindPoseIndex(0xFFFFFFFF),
-		_boneTransformsIndex(0xFFFFFFFF) {
+		_objectModelviewIndex(std::numeric_limits<uint32_t>::max()),
+		_textureViewIndex(std::numeric_limits<uint32_t>::max()),
+		_bindPoseIndex(std::numeric_limits<uint32_t>::max()),
+		_boneTransformsIndex(std::numeric_limits<uint32_t>::max()) {
 
 	vertShader->usageCount++;
 
@@ -191,25 +192,25 @@ void ShaderSurface::bindProgram(Shader::ShaderProgram *program, const glm::mat4 
 }
 
 void ShaderSurface::bindObjectModelview(Shader::ShaderProgram *program, const glm::mat4 *t) {
-	if (_objectModelviewIndex != 0xFFFFFFFF) {
+	if (_objectModelviewIndex != std::numeric_limits<uint32_t>::max()) {
 		ShaderMan.bindShaderVariable(program->vertexObject->variablesCombined[_objectModelviewIndex], program->vertexVariableLocations[_objectModelviewIndex], t);
 	}
 }
 
 void ShaderSurface::bindTextureView(Shader::ShaderProgram *program, const glm::mat4 *t) {
-	if (_textureViewIndex != 0xFFFFFFFF) {
+	if (_textureViewIndex != std::numeric_limits<uint32_t>::max()) {
 		ShaderMan.bindShaderVariable(program->vertexObject->variablesCombined[_textureViewIndex], program->vertexVariableLocations[_objectModelviewIndex], t);
 	}
 }
 
 void ShaderSurface::bindBindPose(Shader::ShaderProgram *program, const glm::mat4 *t) {
-	if (_bindPoseIndex != 0xFFFFFFFF) {
+	if (_bindPoseIndex != std::numeric_limits<uint32_t>::max()) {
 		ShaderMan.bindShaderVariable(program->vertexObject->variablesCombined[_bindPoseIndex], program->vertexVariableLocations[_bindPoseIndex], glm::value_ptr(*t));
 	}
 }
 
 void ShaderSurface::bindBoneTransforms(Shader::ShaderProgram *program, const float *t) {
-	if (_boneTransformsIndex != 0xFFFFFFFF) {
+	if (_boneTransformsIndex != std::numeric_limits<uint32_t>::max()) {
 		ShaderMan.bindShaderVariable(program->vertexObject->variablesCombined[_boneTransformsIndex], program->vertexVariableLocations[_boneTransformsIndex], t);
 	}
 }


### PR DESCRIPTION
Use std::numerics_limits<type>::max() to indicate invalid index
values rather than the more error prone literals of 0xFFFFFFFF.