### PR TITLE
KOTORBASE: Fix ODR violation

### DIFF
--- a/src/engines/kotorbase/game.h
+++ b/src/engines/kotorbase/game.h
@@ -66,7 +66,7 @@ public:
 	virtual void run() = 0;
 
 protected:
-	Console *_console;
+	Engines::Console *_console;
 	std::unique_ptr<KotORBase::Module> _module;
 	std::vector<Common::UString> _modules;
 	Sound::ChannelHandle _menuMusic;


### PR DESCRIPTION
GCC 10.2 reports an ODR warning due to a mismatch in type Engines::KotORBase::Game. Specifically, the type ambiguity of the `_console` member means in some source files it gets resolved as Engines::Console and sometimes as Engines::KotORBase::Console.

This fixes the ambiguity.