### PR TITLE
COMMON: Add some prep work for working up to removing UString

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,9 @@ AC_CHECK_FUNCS([strtoll])
 AC_CHECK_FUNCS([strtoull])
 AC_CHECK_FUNCS([strtof])
 
+dnl Check for strcasecmp
+AC_CHECK_FUNCS([strcasecmp])
+
 dnl Check for -ggdb support
 AX_CHECK_COMPILER_FLAGS_VAR([C++], [GGDB], [-ggdb])
 

--- a/src/aurora/2dafile.cpp
+++ b/src/aurora/2dafile.cpp
@@ -32,6 +32,7 @@
 
 #include "src/common/util.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/encoding.h"
 #include "src/common/readstream.h"
@@ -349,7 +350,7 @@ void TwoDAFile::load(const GDAFile &gda) {
 		for (size_t i = 0; i < gda.getColumnCount(); i++) {
 			const char *headerString = findGDAHeader(headers[i].hash);
 
-			_headers[i] = headerString ? headerString : Common::UString::format("[%u]", headers[i].hash);
+			_headers[i] = headerString ? headerString : Common::String::format("[%u]", headers[i].hash);
 		}
 
 		_rows.resize(gda.getRowCount());
@@ -368,15 +369,15 @@ void TwoDAFile::load(const GDAFile &gda) {
 							break;
 
 						case GDAFile::kTypeInt:
-							_rows[i]->_data[j] = Common::UString::format("%d", (int) row->getSint(headers[j].field));
+							_rows[i]->_data[j] = Common::String::format("%d", (int) row->getSint(headers[j].field));
 							break;
 
 						case GDAFile::kTypeFloat:
-							_rows[i]->_data[j] = Common::UString::format("%f", row->getDouble(headers[j].field));
+							_rows[i]->_data[j] = Common::String::format("%f", row->getDouble(headers[j].field));
 							break;
 
 						case GDAFile::kTypeBool:
-							_rows[i]->_data[j] = Common::UString::format("%u", (uint) row->getUint(headers[j].field));
+							_rows[i]->_data[j] = Common::String::format("%u", (uint) row->getUint(headers[j].field));
 							break;
 
 						default:
@@ -446,7 +447,7 @@ void TwoDAFile::writeASCII(Common::WriteStream &out) const {
 
 	out.writeString("2DA V2.0\n");
 	if (!_defaultString.empty())
-		out.writeString(Common::UString::format("DEFAULT: %s", _defaultString.c_str()));
+		out.writeString(Common::String::format("DEFAULT: %s", _defaultString.c_str()));
 	out.writeByte('\n');
 
 	// Calculate column lengths
@@ -454,7 +455,7 @@ void TwoDAFile::writeASCII(Common::WriteStream &out) const {
 	std::vector<size_t> colLength;
 	colLength.resize(_headers.size() + 1, 0);
 
-	const Common::UString maxRow = Common::UString::format("%d", (int)_rows.size() - 1);
+	const Common::UString maxRow = Common::String::format("%d", (int)_rows.size() - 1);
 	colLength[0] = maxRow.size();
 
 	for (size_t i = 0; i < _headers.size(); i++)
@@ -471,28 +472,28 @@ void TwoDAFile::writeASCII(Common::WriteStream &out) const {
 
 	// Write column headers
 
-	out.writeString(Common::UString::format("%-*s", (int)colLength[0], ""));
+	out.writeString(Common::String::format("%-*s", (int)colLength[0], ""));
 
 	for (size_t i = 0; i < _headers.size(); i++)
-		out.writeString(Common::UString::format(" %-*s", (int)colLength[i + 1], _headers[i].c_str()));
+		out.writeString(Common::String::format(" %-*s", (int)colLength[i + 1], _headers[i].c_str()));
 
 	out.writeByte('\n');
 
 	// Write array
 
 	for (size_t i = 0; i < _rows.size(); i++) {
-		out.writeString(Common::UString::format("%*u", (int)colLength[0], (uint)i));
+		out.writeString(Common::String::format("%*u", (int)colLength[0], (uint)i));
 
 		for (size_t j = 0; j < _rows[i]->_data.size(); j++) {
 			const bool needQuote = _rows[i]->_data[j].contains(' ');
 
 			Common::UString cellString;
 			if (needQuote)
-				cellString = Common::UString::format("\"%s\"", _rows[i]->_data[j].c_str());
+				cellString = Common::String::format("\"%s\"", _rows[i]->_data[j].c_str());
 			else
 				cellString = _rows[i]->_data[j];
 
-			out.writeString(Common::UString::format(" %-*s", (int)colLength[j + 1], cellString.c_str()));
+			out.writeString(Common::String::format(" %-*s", (int)colLength[j + 1], cellString.c_str()));
 
 		}
 

--- a/src/aurora/erfwriter.cpp
+++ b/src/aurora/erfwriter.cpp
@@ -163,8 +163,14 @@ void ERFWriter::addV10(const Common::UString &resRef, FileType resType, Common::
 	// Write the key table entry
 	_stream.seek(_keyTableOffset + _currentFileCount * 24);
 
-	_stream.write(resRef.c_str(), MIN<size_t>(resRef.size(), 16));
-	_stream.writeZeros(16 - MIN<size_t>(resRef.size(), 16));
+	// Write the name
+	{
+		std::unique_ptr<Common::SeekableReadStream> encoded = convertString(resRef, Common::kEncodingASCII, false);
+		const size_t encodedSize = MIN<size_t>(encoded->size(), 16);
+		_stream.writeStream(*encoded, encodedSize);
+		_stream.writeZeros(16 - encodedSize);
+	}
+
 	_stream.writeUint32LE(_currentFileCount);
 	_stream.writeUint16LE(resType);
 	_stream.writeUint16LE(0); // Unused

--- a/src/aurora/gff4file.cpp
+++ b/src/aurora/gff4file.cpp
@@ -843,7 +843,7 @@ Common::UString GFF4Struct::getString(Common::SeekableSubReadStreamEndian &data,
 	} catch (...) {
 	}
 
-	return Common::UString::format("GFF4: Invalid string encoding (0x%08X)", (uint) offset);
+	return Common::String::format("GFF4: Invalid string encoding (0x%08X)", (uint) offset);
 }
 
 Common::UString GFF4Struct::getString(Common::SeekableSubReadStreamEndian &data, Common::Encoding encoding,

--- a/src/aurora/language.cpp
+++ b/src/aurora/language.cpp
@@ -27,6 +27,7 @@
 #include "src/common/ustring.h"
 #include "src/common/memreadstream.h"
 #include "src/common/memwritestream.h"
+#include "src/common/string.h"
 
 #include "src/aurora/language.h"
 #include "src/aurora/language_strings.h"
@@ -328,7 +329,7 @@ Common::MemoryReadStream *LanguageManager::preParseColorCodes(Common::SeekableRe
 
 		if (state == 5) {
 			if (b == '>') {
-				Common::UString c = Common::UString::format("<c%02X%02X%02X%02X>",
+				Common::UString c = Common::String::format("<c%02X%02X%02X%02X>",
 				                    (uint8_t) color[0], (uint8_t) color[1], (uint8_t) color[2], (uint8_t) 0xFF);
 
 				output.writeString(c);

--- a/src/aurora/locstring.cpp
+++ b/src/aurora/locstring.cpp
@@ -175,7 +175,7 @@ void LocString::readLocString(Common::SeekableReadStream &stream) {
 	readLocString(stream, id, count);
 }
 
-static Common::SeekableReadStream *convertString(const Common::UString &str, uint32_t languageID, bool terminateString) {
+static std::unique_ptr<Common::SeekableReadStream> convertString(const Common::UString &str, uint32_t languageID, bool terminateString) {
 	Common::Encoding encoding = LangMan.getEncodingLocString(LangMan.getLanguageGendered(languageID));
 	if (encoding == Common::kEncodingInvalid)
 		encoding = Common::kEncodingASCII;

--- a/src/aurora/ltrfile.cpp
+++ b/src/aurora/ltrfile.cpp
@@ -66,7 +66,7 @@ Common::UString LTRFile::generateRandomName(size_t maxLetters) const {
 	for (size_t i = 0; i < _letterCount; ++i) {
 		if (_singleLetters.start[i] > probability) {
 			// Make the first letter upper case.
-			name += Common::UString::toUpper(static_cast<unsigned char>(_alphabet[i]));
+			name += Common::String::toUpper(_alphabet[i]);
 			firstLetterIndex = i;
 			break;
 		}

--- a/src/aurora/pefile.cpp
+++ b/src/aurora/pefile.cpp
@@ -142,7 +142,7 @@ void PEFile::load(const std::vector<Common::UString> &remap) {
 
 		uint32_t id = it->getID();
 		if (id >= remap.size() || id <= 0)
-			res.name = Common::UString::format("cursor%d", id);
+			res.name = Common::String::format("cursor%d", id);
 		else
 			res.name = remap[id - 1];
 
@@ -160,7 +160,7 @@ void PEFile::load(const std::vector<Common::UString> &remap) {
 
 		uint32_t id = it->getID();
 		if (id >= remap.size())
-			res.name = Common::UString::format("bitmap%d", id);
+			res.name = Common::String::format("bitmap%d", id);
 		else
 			res.name = remap[id];
 

--- a/src/aurora/resman.cpp
+++ b/src/aurora/resman.cpp
@@ -1072,7 +1072,7 @@ void ResourceManager::dumpResourcesList(const Common::UString &fileName) const {
 		const uint32_t         size = getResourceSize(res);
 
 		const Common::UString line =
-			Common::UString::format("%32s%4s | %s | %12d\n", name.c_str(), ext.c_str(),
+			Common::String::format("%32s%4s | %s | %12d\n", name.c_str(), ext.c_str(),
                                Common::formatHash(hash).c_str(), size);
 
 		file.writeString(line);

--- a/src/aurora/ssffile.cpp
+++ b/src/aurora/ssffile.cpp
@@ -243,7 +243,7 @@ size_t SSFFile::getMaxSoundFileLen() const {
 bool SSFFile::existNonASCIISoundFile() const {
 	for (SoundSet::const_iterator s = _sounds.begin(); s != _sounds.end(); ++s)
 		for (Common::UString::iterator c = s->soundFile.begin(); c != s->soundFile.end(); ++c)
-			if (!Common::UString::isASCII(*c))
+			if (!Common::String::isASCII(*c))
 				return true;
 
 	return false;

--- a/src/aurora/xmlfixer.cpp
+++ b/src/aurora/xmlfixer.cpp
@@ -102,7 +102,7 @@ Common::UString XMLFixer::fixXMLElement(const Common::UString &element) {
 		Common::UString name, value = segment;
 		if (!segment.empty()) {
 			for (Common::UString::iterator it2 = --segment.end(); it2 != segment.begin(); --it2) {
-				if (Common::UString::isSpace(*it2)) {
+				if (Common::String::isSpace(*it2)) {
 					segment.split(it2, value, name, true);
 					break;
 				}
@@ -272,7 +272,7 @@ void XMLFixer::splitNewElement(Common::UString &value, Common::UString &tail) {
 				return;
 			}
 
-			if (!Common::UString::isSpace(*it2)) {
+			if (!Common::String::isSpace(*it2)) {
 				// Not a new element
 				it1 = it2;
 

--- a/src/common/configfile.cpp
+++ b/src/common/configfile.cpp
@@ -265,7 +265,7 @@ bool ConfigFile::isValidName(const UString &name) {
 	for (UString::iterator it = name.begin(); it != name.end(); ++it) {
 		uint32_t c = *it;
 
-		if (UString::isASCII(c) &&
+		if (Common::String::isASCII(c) &&
 				(!isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != ' ')))
 			return false;
 	}

--- a/src/common/configman.cpp
+++ b/src/common/configman.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 
 #include "src/common/configman.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/readfile.h"
 #include "src/common/writefile.h"
@@ -205,7 +206,7 @@ UString ConfigManager::createGameID(const UString &path) {
 		return target;
 
 	for (uint32_t i = 0; i < 65536; i++) {
-		UString targetNumbered = UString::format("%s_%d", target.c_str(), i);
+		UString targetNumbered = String::format("%s_%d", target.c_str(), i);
 
 		if (!_config->hasDomain(targetNumbered))
 			return targetNumbered;

--- a/src/common/configman.cpp
+++ b/src/common/configman.cpp
@@ -195,7 +195,7 @@ UString ConfigManager::createGameID(const UString &path) {
 	for (UString::iterator s = canonicalStem.begin(); s != canonicalStem.end(); ++s) {
 		uint32_t c = *s;
 
-		if (UString::isAlNum(c))
+		if (Common::String::isAlNum(c))
 			target += c;
 	}
 

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -24,6 +24,7 @@
 
 #include "src/common/datetime.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 
 using boost::posix_time::ptime;
 using boost::posix_time::second_clock;
@@ -61,7 +62,7 @@ DateTime::DateTime(const UString &value) : ptime(not_a_date_time) {
 UString DateTime::formatDateISO(uint32_t sep) const {
 	const UString sepStr(sep, sep ? 1 : 0);
 
-	return UString::format("%04d%s%02d%s%02d",
+	return String::format("%04d%s%02d%s%02d",
 	                       (int) date().year() , sepStr.c_str(),
 	                       (int) date().month(), sepStr.c_str(),
 	                       (int) date().day());
@@ -70,7 +71,7 @@ UString DateTime::formatDateISO(uint32_t sep) const {
 UString DateTime::formatTimeISO(uint32_t sep) const {
 	const UString sepStr(sep, sep ? 1 : 0);
 
-	return UString::format("%02d%s%02d%s%02d",
+	return String::format("%02d%s%02d%s%02d",
 	                       (int) time_of_day().hours()  , sepStr.c_str(),
 	                       (int) time_of_day().minutes(), sepStr.c_str(),
 	                       (int) time_of_day().seconds());
@@ -79,7 +80,7 @@ UString DateTime::formatTimeISO(uint32_t sep) const {
 UString DateTime::formatDateTimeISO(uint32_t sep, uint32_t sepDate, uint32_t sepTime) const {
 	const UString sepStr(sep, sep ? 1 : 0);
 
-	return UString::format("%s%s%s", formatDateISO(sepDate).c_str(), sepStr.c_str(),
+	return String::format("%s%s%s", formatDateISO(sepDate).c_str(), sepStr.c_str(),
 	                                 formatTimeISO(sepTime).c_str());
 }
 

--- a/src/common/disposableptr.h
+++ b/src/common/disposableptr.h
@@ -51,6 +51,8 @@
 #ifndef COMMON_DISPOSABLEPTR_H
 #define COMMON_DISPOSABLEPTR_H
 
+#include <memory>
+
 #include <boost/noncopyable.hpp>
 
 #include "src/common/system.h"
@@ -135,6 +137,9 @@ class DisposableArray : public DisposablePtrBase<T, Deallocator> {
 public:
 	explicit DisposableArray(typename DisposablePtrBase<T, Deallocator>::PointerType o, bool d) :
 		DisposablePtrBase<T, Deallocator>(o, d) {
+	}
+
+	explicit DisposableArray(std::unique_ptr<T[]> ptr) : DisposablePtrBase<T, Deallocator>(ptr.release(), true) {
 	}
 
 	typename DisposablePtrBase<T, Deallocator>::ReferenceType operator[](size_t i) const {

--- a/src/common/encoding.cpp
+++ b/src/common/encoding.cpp
@@ -182,7 +182,7 @@ private:
 
 		size_t size = 0;
 		for (UString::iterator c = str.begin(); c != str.end(); ++c)
-			if (UString::isASCII(*c))
+			if (String::isASCII(*c))
 				dataOut[size++] = *c;
 
 		if (terminate)

--- a/src/common/encoding.h
+++ b/src/common/encoding.h
@@ -26,6 +26,7 @@
 #define COMMON_ENCODING_H
 
 #include <cstddef>
+#include <memory>
 
 #include "src/common/types.h"
 
@@ -33,7 +34,6 @@ namespace Common {
 
 class UString;
 class SeekableReadStream;
-class MemoryReadStream;
 class WriteStream;
 
 enum Encoding {
@@ -133,9 +133,9 @@ void writeStringFixed(WriteStream &stream, const Common::UString &str, Encoding 
  *  @param  encoding The encoding to convert the string into.
  *  @param  terminateString Should the result contain a terminating end-of-
  *                          string sequence?
- *  @return A newly created MemoryReadStream of the converted string.
+ *  @return A newly created SeekableReadStream of the converted string.
  */
-MemoryReadStream *convertString(const UString &str, Encoding encoding, bool terminateString = true);
+std::unique_ptr<SeekableReadStream> convertString(const UString &str, Encoding encoding, bool terminateString = true);
 
 /** Return the number of bytes per codepoint in this encoding.
  *

--- a/src/common/filepath.cpp
+++ b/src/common/filepath.cpp
@@ -33,6 +33,7 @@
 #include "src/common/error.h"
 #include "src/common/encoding.h"
 #include "src/common/platform.h"
+#include "src/common/string.h"
 
 // boost-filesystem stuff
 using boost::filesystem::path;
@@ -370,7 +371,7 @@ UString FilePath::getHumanReadableSize(size_t size) {
 		s /= 1024;
 	}
 
-	return UString::format("%.2lf%s", s, sizes[n]);
+	return String::format("%.2lf%s", s, sizes[n]);
 }
 
 UString FilePath::getHomeDirectory() {

--- a/src/common/foxpro.cpp
+++ b/src/common/foxpro.cpp
@@ -520,7 +520,7 @@ void FoxPro::deleteRecord(size_t record) {
 
 void FoxPro::checkName(const UString &name) {
 	for (UString::iterator c = name.begin(); c != name.end(); ++c)
-		if (!UString::isASCII(*c))
+		if (!Common::String::isASCII(*c))
 			throw Common::Exception("FoxPro field names need to be in unextended ASCII");
 }
 

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -31,6 +31,7 @@
 #include "src/common/ustring.h"
 #include "src/common/encoding.h"
 #include "src/common/memreadstream.h"
+#include "src/common/string.h"
 
 namespace Common {
 
@@ -260,7 +261,7 @@ static inline uint64_t hashString(const UString &string, HashAlgo algo, Encoding
 }
 
 static inline UString formatHash(uint64_t hash) {
-	return UString::format("0x%04X%04X%04X%04X",
+	return String::format("0x%04X%04X%04X%04X",
 			(uint) ((hash >> 48) & 0xFFFF),
 			(uint) ((hash >> 32) & 0xFFFF),
 			(uint) ((hash >> 16) & 0xFFFF),

--- a/src/common/memreadstream.h
+++ b/src/common/memreadstream.h
@@ -52,6 +52,7 @@
 
 #include <cstring>
 #include <cstddef>
+#include <memory>
 
 #include <boost/noncopyable.hpp>
 
@@ -88,6 +89,11 @@ public:
 	MemoryReadStream(const byte (&array)[N]) :
 		_ptrOrig(array, false), _ptr(array), _size(N), _pos(0), _eos(false) {
 
+	}
+
+	/** Create a MemoryReadStream from a unique_ptr<byte[]>. */
+	MemoryReadStream(std::unique_ptr<byte[]> dataPtr, size_t dataSize) :
+		_ptrOrig(std::move(dataPtr)), _ptr(_ptrOrig.get()), _size(dataSize), _pos(0), _eos(false) {
 	}
 
 	~MemoryReadStream() { }

--- a/src/common/readline.cpp
+++ b/src/common/readline.cpp
@@ -562,7 +562,7 @@ bool ReadLine::isWordCharacter(uint32_t c, bool onlySpace) {
 	if (onlySpace)
 		return c != ' ';
 
-	return !UString::isASCII(c) || UString::isAlNum(c);
+	return !String::isASCII(c) || String::isAlNum(c);
 }
 
 size_t ReadLine::findLastWordStart(bool onlySpace) const {

--- a/src/common/rules.mk
+++ b/src/common/rules.mk
@@ -86,6 +86,7 @@ src_common_libcommon_la_SOURCES += \
     src/common/mutex.h \
     src/common/semaphore.h \
     src/common/serializationstream.h \
+    src/common/string.h \
     $(EMPTY)
 
 src_common_libcommon_la_SOURCES += \
@@ -139,6 +140,7 @@ src_common_libcommon_la_SOURCES += \
     src/common/random.cpp \
     src/common/semaphore.cpp \
     src/common/serializationstream.cpp \
+    src/common/string.cpp \
     $(EMPTY)
 
 lzma_sources = \

--- a/src/common/serializationstream.cpp
+++ b/src/common/serializationstream.cpp
@@ -354,23 +354,23 @@ void SerializationWriteStream::readOrWriteChar(const char &value) {
 }
 
 void SerializationWriteStream::readOrWriteBytePrefixedASCIIString(Common::UString &value) {
-	_stream.writeByte(value.size());
-	Common::writeString(_stream, value, Common::kEncodingASCII, false);
+	readOrWriteBytePrefixedASCIIString(static_cast<const Common::UString &>(value));
 }
 
 void SerializationWriteStream::readOrWriteUint32LEPrefixedASCIIString(Common::UString &value) {
-	_stream.writeUint32LE(value.size());
-	Common::writeString(_stream, value, Common::kEncodingASCII, false);
+	readOrWriteUint32LEPrefixedASCIIString(static_cast<const Common::UString &>(value));
 }
 
 void SerializationWriteStream::readOrWriteBytePrefixedASCIIString(const Common::UString &value) {
-	_stream.writeByte(value.size());
-	Common::writeString(_stream, value, Common::kEncodingASCII, false);
+	std::unique_ptr<SeekableReadStream> encoded = convertString(value, Common::kEncodingASCII, false);
+	_stream.writeByte(encoded->size());
+	_stream.writeStream(*encoded);
 }
 
 void SerializationWriteStream::readOrWriteUint32LEPrefixedASCIIString(const Common::UString &value) {
-	_stream.writeUint32LE(value.size());
-	Common::writeString(_stream, value, Common::kEncodingASCII, false);
+	std::unique_ptr<SeekableReadStream> encoded = convertString(value, Common::kEncodingASCII, false);
+	_stream.writeUint32LE(encoded->size());
+	_stream.writeStream(*encoded);
 }
 
 } // End of namespace Common

--- a/src/common/serializationstream.cpp
+++ b/src/common/serializationstream.cpp
@@ -26,6 +26,7 @@
 
 #include "src/common/serializationstream.h"
 #include "src/common/encoding.h"
+#include "src/common/string.h"
 
 namespace Common {
 
@@ -95,7 +96,7 @@ static UString toHexString(T value) {
 		const uint nV = (v >> (bits - 4)) & 0xF;
 		v <<= 4;
 
-		str += Common::UString::format("%X", nV);
+		str += Common::String::format("%X", nV);
 	}
 
 	return str;

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -29,6 +29,8 @@
 
 #include "src/common/string.h"
 
+#include "external/utf8cpp/utf8.h"
+
 namespace Common {
 namespace String {
 
@@ -64,6 +66,12 @@ std::string formatV(const char *format, va_list args) {
 
 	va_end(copy);
 	return result;
+}
+
+uint32_t fromUTF16(uint16_t c) {
+	std::string utf8result;
+	utf8::utf16to8(&c, &c + 1, std::back_inserter(utf8result));
+	return *utf8::iterator<std::string::const_iterator>(utf8result.begin(), utf8result.begin(), utf8result.end());
 }
 
 } // End of namespace String

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1,0 +1,70 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Utility templates and functions for working with strings.
+ */
+
+#include <cstdarg>
+
+#include <memory>
+#include <system_error>
+
+#include "src/common/string.h"
+
+namespace Common {
+namespace String {
+
+std::string format(const char *format, ...) {
+	va_list va;
+	va_start(va, format);
+	std::string result = formatV(format, va);
+	va_end(va);
+	return result;
+}
+
+std::string formatV(const char *format, va_list args) {
+	std::string result;
+
+	// Allocate a small amount on the stack to avoid using the heap if we can
+	// help it.
+	char stackBuf[1024];
+
+	va_list copy;
+	va_copy(copy, args);
+
+	int size = vsnprintf(stackBuf, sizeof(stackBuf), format, args);
+	if (size < 0) {
+		// FIXME: errno is POSIX-like. Who knows what Windows does.
+		throw std::system_error(errno, std::generic_category(), "Invalid formatting string");
+	} if (static_cast<size_t>(size) >= sizeof(stackBuf)) {
+		std::unique_ptr<char[]> buf = std::make_unique<char[]>(static_cast<unsigned int>(size) + 1);
+		vsnprintf(buf.get(), size, format, copy);
+		result = std::string(buf.get(), size);
+	} else {
+		result = std::string(stackBuf, size);
+	}
+
+	va_end(copy);
+	return result;
+}
+
+} // End of namespace String
+} // End of namespace Common

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <cstdarg>
+#include <cstring>
 
 #include <memory>
 #include <system_error>
@@ -72,6 +73,34 @@ uint32_t fromUTF16(uint16_t c) {
 	std::string utf8result;
 	utf8::utf16to8(&c, &c + 1, std::back_inserter(utf8result));
 	return *utf8::iterator<std::string::const_iterator>(utf8result.begin(), utf8result.begin(), utf8result.end());
+}
+
+int compareIgnoreCase(const std::string &left, const std::string &right) {
+	return compareIgnoreCase(left.c_str(), right.c_str());
+}
+
+int compareIgnoreCase(const char *left, const char *right) {
+#ifdef HAVE_STRCASECMP
+	return strcasecmp(left, right);
+#else
+	const unsigned char *leftPtr = reinterpret_cast<const unsigned char *>(left);
+	const unsigned char *rightPtr = reinterpret_cast<const unsigned char *>(right);
+
+	if (leftPtr == rightPtr)
+		return 0;
+
+	int result;
+	for (;;) {
+		result = toLower(*leftPtr) - toLower(*rightPtr++);
+		if (result != 0)
+			break;
+
+		if (*leftPtr++ == '\0')
+			break;
+	}
+
+	return result;
+#endif
 }
 
 } // End of namespace String

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -25,6 +25,8 @@
 #ifndef XOREOS_COMMON_STRING_H
 #define XOREOS_COMMON_STRING_H
 
+#include <cstdint>
+
 #include <string>
 
 #include <boost/type_traits/make_unsigned.hpp>
@@ -102,6 +104,9 @@ inline T toUpper(T c) {
 	//       characters: http://www.unicode.org/reports/tr21/tr21-5.html
 	return isASCII(c) ? std::toupper(c) : c;
 }
+
+/** Get a UTF-32 codepoint from a UTF-16 character. */
+uint32_t fromUTF16(uint16_t c);
 
 } // End of namespace String
 } // End of namespace Common

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -108,6 +108,12 @@ inline T toUpper(T c) {
 /** Get a UTF-32 codepoint from a UTF-16 character. */
 uint32_t fromUTF16(uint16_t c);
 
+/** Perform a case-insensitive comparison. */
+int compareIgnoreCase(const std::string &left, const std::string &right);
+
+/** Perform a case-insensitive comparison. */
+int compareIgnoreCase(const char *left, const char *right);
+
 } // End of namespace String
 } // End of namespace Common
 

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -27,6 +27,8 @@
 
 #include <string>
 
+#include <boost/type_traits/make_unsigned.hpp>
+
 #include "src/common/system.h"
 
 namespace Common {
@@ -37,6 +39,69 @@ std::string format(const char *format, ...) GCC_PRINTF(1, 2);
 
 /** Print formatted data into a std::string object, similar to vsprintf(). */
 std::string formatV(const char *format, va_list args) GCC_PRINTF(1, 0);
+
+/** The function type used by the ctype class functions. */
+typedef int (*CTypeFunction)(int);
+
+/** Is the character an ASCII character? */
+template<typename T>
+inline bool isASCII(T c) {
+	typedef typename boost::make_unsigned<T>::type UnsignedType;
+	UnsignedType u = static_cast<UnsignedType>(c);
+	return (u & ~static_cast<UnsignedType>(0x7F)) == 0;
+}
+
+/** Internal function for implementing ctype function wrappers. */
+template<typename T, CTypeFunction func>
+inline bool ctypeWrapper(T c) {
+	return isASCII(c) && func(static_cast<unsigned char>(c));
+}
+
+/** Is the character an ASCII space character? */
+template<typename T>
+inline bool isSpace(T c) {
+	return ctypeWrapper<T, std::isspace>(c);
+}
+
+/** Is the character an ASCII digit character? */
+template<typename T>
+inline bool isDigit(T c) {
+	return ctypeWrapper<T, std::isdigit>(c);
+}
+
+/** Is the character an ASCII alphabetic character? */
+template<typename T>
+inline bool isAlpha(T c) {
+	return ctypeWrapper<T, std::isalpha>(c);
+}
+
+/** Is the character an ASCII alphanumeric character? */
+template<typename T>
+inline bool isAlNum(T c) {
+	return ctypeWrapper<T, std::isalnum>(c);
+}
+
+/** Is the character an ASCII control character? */
+template<typename T>
+inline bool isCntrl(T c) {
+	return ctypeWrapper<T, std::iscntrl>(c);
+}
+
+/** Convert an ASCII character to its lowercase equivalent. */
+template<typename T>
+inline T toLower(T c) {
+	// NOTE: If we ever need uppercase<->lowercase mappings for non-ASCII
+	//       characters: http://www.unicode.org/reports/tr21/tr21-5.html
+	return isASCII(c) ? std::tolower(c) : c;
+}
+
+/** Convert an ASCII character to its uppercase equivalent. */
+template<typename T>
+inline T toUpper(T c) {
+	// NOTE: If we ever need uppercase<->lowercase mappings for non-ASCII
+	//       characters: http://www.unicode.org/reports/tr21/tr21-5.html
+	return isASCII(c) ? std::toupper(c) : c;
+}
 
 } // End of namespace String
 } // End of namespace Common

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -112,7 +112,17 @@ uint32_t fromUTF16(uint16_t c);
 int compareIgnoreCase(const std::string &left, const std::string &right);
 
 /** Perform a case-insensitive comparison. */
+inline bool equalsIgnoreCase(const std::string &left, const std::string &right) {
+	return compareIgnoreCase(left, right) == 0;
+}
+
+/** Perform a case-insensitive comparison. */
 int compareIgnoreCase(const char *left, const char *right);
+
+/** Perform a case-insensitive comparison. */
+inline bool equalsIgnoreCase(const char *left, const char *right) {
+	return compareIgnoreCase(left, right) == 0;
+}
 
 } // End of namespace String
 } // End of namespace Common

--- a/src/common/string.h
+++ b/src/common/string.h
@@ -1,0 +1,44 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Utility templates and functions for working with strings.
+ */
+
+#ifndef XOREOS_COMMON_STRING_H
+#define XOREOS_COMMON_STRING_H
+
+#include <string>
+
+#include "src/common/system.h"
+
+namespace Common {
+namespace String {
+
+/** Print formatted data into a std::string object, similar to sprintf(). */
+std::string format(const char *format, ...) GCC_PRINTF(1, 2);
+
+/** Print formatted data into a std::string object, similar to vsprintf(). */
+std::string formatV(const char *format, va_list args) GCC_PRINTF(1, 0);
+
+} // End of namespace String
+} // End of namespace Common
+
+#endif // XOREOS_COMMON_STRING_H

--- a/src/common/strutil.cpp
+++ b/src/common/strutil.cpp
@@ -26,6 +26,7 @@
 #include <cctype>
 #include <climits>
 #include <cerrno>
+#include <cstdarg>
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>

--- a/src/common/strutil.cpp
+++ b/src/common/strutil.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 
 #include "src/common/system.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/util.h"
 #include "src/common/error.h"
@@ -110,7 +111,7 @@ static bool tagToString(uint32_t tag, bool trim, UString &str) {
 	if (!std::isprint(tS[0]) || !std::isprint(tS[1]) || !std::isprint(tS[2]) || !std::isprint(tS[3]))
 		return false;
 
-	str = UString::format("%c%c%c%c", tS[0], tS[1], tS[2], tS[3]);
+	str = String::format("%c%c%c%c", tS[0], tS[1], tS[2], tS[3]);
 	if (trim)
 		str.trim();
 
@@ -120,9 +121,9 @@ static bool tagToString(uint32_t tag, bool trim, UString &str) {
 UString debugTag(uint32_t tag, bool trim) {
 	UString str;
 	if (tagToString(tag, trim, str))
-		return UString::format("0x%08X ('%s')", FROM_BE_32(tag), str.c_str());
+		return String::format("0x%08X ('%s')", FROM_BE_32(tag), str.c_str());
 
-	return UString::format("0x%08X", FROM_BE_32(tag));
+	return String::format("0x%08X", FROM_BE_32(tag));
 }
 
 // Helper functions for parseString()
@@ -331,11 +332,11 @@ template<> UString composeString(bool value) {
 }
 
 template<> UString composeString(float value) {
-	return UString::format("%f", value);
+	return String::format("%f", value);
 }
 
 template<> UString composeString(double value) {
-	return UString::format("%lf", value);
+	return String::format("%lf", value);
 }
 
 template UString composeString<  signed char     >(  signed char      value);

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -259,6 +259,10 @@ const char *UString::c_str() const {
 	return _string.c_str();
 }
 
+const std::string &UString::toString() const {
+	return _string;
+}
+
 UString::iterator UString::begin() const {
 	return iterator(_string.begin(), _string.begin(), _string.end());
 }

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -728,17 +728,6 @@ UString UString::substr(iterator from, iterator to) const {
 	return sub;
 }
 
-UString UString::format(const char *s, ...) {
-	char buf[STRINGBUFLEN];
-	va_list va;
-
-	va_start(va, s);
-	vsnprintf(buf, STRINGBUFLEN, s, va);
-	va_end(va);
-
-	return UString(buf);
-}
-
 size_t UString::split(const UString &text, uint32_t delim, std::vector<UString> &texts) {
 	size_t length = 0;
 

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -765,17 +765,4 @@ void UString::recalculateSize() {
 	}
 }
 
-uint32_t UString::fromUTF16(uint16_t c) {
-	std::string utf8result;
-
-	try {
-		utf8::utf16to8(&c, &c + 1, std::back_inserter(utf8result));
-	} catch (const std::exception &se) {
-		Exception e(se);
-		throw e;
-	}
-
-	return *iterator(utf8result.begin(), utf8result.begin(), utf8result.end());
-}
-
 } // End of namespace Common

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -199,8 +199,8 @@ int UString::stricmp(const UString &str) const {
 		UString::iterator it1 = begin();
 		UString::iterator it2 = str.begin();
 		for (; (it1 != end()) && (it2 != str.end()); ++it1, ++it2) {
-			const uint32_t c1 = toLower(*it1);
-			const uint32_t c2 = toLower(*it2);
+			const uint32_t c1 = String::toLower(*it1);
+			const uint32_t c2 = String::toLower(*it2);
 
 			if (c1 < c2)
 				return -1;
@@ -383,7 +383,7 @@ void UString::trim() {
 	iterator itEnd = --end();
 	for (; itEnd != begin(); --itEnd) {
 		uint32_t c = *itEnd;
-		if (!isSpace(c) && (c != '\0')) {
+		if (!String::isSpace(c) && (c != '\0')) {
 			++itEnd;
 			break;
 		}
@@ -391,14 +391,14 @@ void UString::trim() {
 
 	if (itEnd == begin()) {
 		uint32_t c = *itEnd;
-		if (!isSpace(c) && (c != '\0'))
+		if (!String::isSpace(c) && (c != '\0'))
 			++itEnd;
 	}
 
 	// Find the first non-space
 	iterator itStart = begin();
 	for (; itStart != itEnd; ++itStart)
-		if (!isSpace(*itStart))
+		if (!String::isSpace(*itStart))
 			break;
 
 	_string = std::string(itStart.base(), itEnd.base());
@@ -413,7 +413,7 @@ void UString::trimLeft() {
 	// Find the first non-space
 	iterator itStart = begin();
 	for (; itStart != end(); ++itStart)
-		if (!isSpace(*itStart))
+		if (!String::isSpace(*itStart))
 			break;
 
 	_string = std::string(itStart.base(), end().base());
@@ -429,7 +429,7 @@ void UString::trimRight() {
 	iterator itEnd = --end();
 	for (; itEnd != begin(); --itEnd) {
 		uint32_t c = *itEnd;
-		if (!isSpace(c) && (c != '\0')) {
+		if (!String::isSpace(c) && (c != '\0')) {
 			++itEnd;
 			break;
 		}
@@ -437,7 +437,7 @@ void UString::trimRight() {
 
 	if (itEnd == begin()) {
 		uint32_t c = *itEnd;
-		if (!isSpace(c) && (c != '\0'))
+		if (!String::isSpace(c) && (c != '\0'))
 			++itEnd;
 	}
 
@@ -496,7 +496,7 @@ UString UString::toLower() const {
 
 	str._string.reserve(_string.size());
 	for (iterator it = begin(); it != end(); ++it)
-		str += toLower(*it);
+		str += String::toLower(*it);
 
 	return str;
 }
@@ -506,7 +506,7 @@ UString UString::toUpper() const {
 
 	str._string.reserve(_string.size());
 	for (iterator it = begin(); it != end(); ++it)
-		str += toUpper(*it);
+		str += String::toUpper(*it);
 
 	return str;
 }
@@ -763,49 +763,6 @@ void UString::recalculateSize() {
 		Exception e(se);
 		throw e;
 	}
-}
-
-// NOTE: If we ever need uppercase<->lowercase mappings for non-ASCII
-//       characters: http://www.unicode.org/reports/tr21/tr21-5.html
-
-uint32_t UString::toLower(uint32_t c) {
-	if (!isASCII(c))
-		// We don't know how to lowercase that
-		return c;
-
-	return std::tolower(c);
-}
-
-uint32_t UString::toUpper(uint32_t c) {
-	if (!isASCII(c))
-		// We don't know how to uppercase that
-		return c;
-
-	return std::toupper(c);
-}
-
-bool UString::isASCII(uint32_t c) {
-	return (c & 0xFFFFFF80) == 0;
-}
-
-bool UString::isSpace(uint32_t c) {
-	return isASCII(c) && std::isspace(c);
-}
-
-bool UString::isDigit(uint32_t c) {
-	return isASCII(c) && std::isdigit(c);
-}
-
-bool UString::isAlpha(uint32_t c) {
-	return isASCII(c) && std::isalpha(c);
-}
-
-bool UString::isAlNum(uint32_t c) {
-	return isASCII(c) && std::isalnum(c);
-}
-
-bool UString::isCntrl(uint32_t c) {
-	return isASCII(c) && std::iscntrl(c);
 }
 
 uint32_t UString::fromUTF16(uint16_t c) {

--- a/src/common/ustring.cpp
+++ b/src/common/ustring.cpp
@@ -89,19 +89,19 @@ UString &UString::operator=(const char *str) {
 }
 
 bool UString::operator==(const UString &str) const {
-	return strcmp(str) == 0;
+	return _string == str._string;
 }
 
 bool UString::operator!=(const UString &str) const {
-	return strcmp(str) != 0;
+	return !(*this == str);
 }
 
 bool UString::operator<(const UString &str) const {
-	return strcmp(str) < 0;
+	return _string < str._string;
 }
 
 bool UString::operator>(const UString &str) const {
-	return strcmp(str) > 0;
+	return !(*this < str);
 }
 
 UString UString::operator+(const UString &str) const {
@@ -168,72 +168,20 @@ UString &UString::operator+=(uint32_t c) {
 	return *this;
 }
 
-int UString::strcmp(const UString &str) const {
-	try {
-		UString::iterator it1 = begin();
-		UString::iterator it2 = str.begin();
-		for (; (it1 != end()) && (it2 != str.end()); ++it1, ++it2) {
-			const uint32_t c1 = *it1;
-			const uint32_t c2 = *it2;
-
-			if (c1 < c2)
-				return -1;
-			if (c1 > c2)
-				return  1;
-		}
-
-		if ((it1 == end()) && (it2 == str.end()))
-			return 0;
-
-		if (it1 == end())
-			return -1;
-
-	} catch (...) {
-	}
-
-	return 1;
-}
-
-int UString::stricmp(const UString &str) const {
-	try {
-		UString::iterator it1 = begin();
-		UString::iterator it2 = str.begin();
-		for (; (it1 != end()) && (it2 != str.end()); ++it1, ++it2) {
-			const uint32_t c1 = String::toLower(*it1);
-			const uint32_t c2 = String::toLower(*it2);
-
-			if (c1 < c2)
-				return -1;
-			if (c1 > c2)
-				return  1;
-		}
-
-		if ((it1 == end()) && (it2 == str.end()))
-			return 0;
-
-		if (it1 == end())
-			return -1;
-
-	} catch (...) {
-	}
-
-	return 1;
-}
-
 bool UString::equals(const UString &str) const {
-	return strcmp(str) == 0;
+	return *this == str;
 }
 
 bool UString::equalsIgnoreCase(const UString &str) const {
-	return stricmp(str) == 0;
+	return String::equalsIgnoreCase(_string, str._string);
 }
 
 bool UString::less(const UString &str) const {
-	return strcmp(str) < 0;
+	return *this < str;
 }
 
 bool UString::lessIgnoreCase(const UString &str) const {
-	return stricmp(str) < 0;
+	return String::compareIgnoreCase(_string, str._string) < 0;
 }
 
 void UString::swap(UString &str) {

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -120,6 +120,9 @@ public:
 	/** Return the (utf8 encoded) string data. */
 	const char *c_str() const;
 
+	/** Return the (utf8 encoded) string data. */
+	const std::string &toString() const;
+
 	iterator begin() const;
 	iterator end() const;
 

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -97,9 +97,6 @@ public:
 	UString &operator+=(const char *str);
 	UString &operator+=(uint32_t c);
 
-	int strcmp(const UString &str) const;
-	int stricmp(const UString &str) const;
-
 	bool equals(const UString &str) const;
 	bool equalsIgnoreCase(const UString &str) const;
 

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -180,9 +180,6 @@ public:
 
 	UString substr(iterator from, iterator to) const;
 
-	/** Print formatted data into an UString object, similar to sprintf(). */
-	static UString format(const char *s, ...) GCC_PRINTF(1, 2);
-
 	static size_t split(const UString &text, uint32_t delim, std::vector<UString> &texts);
 
 	static void splitTextTokens(const UString &text, std::vector<UString> &tokens);

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "src/common/types.h"
+#include "src/common/string.h"
 #include "src/common/system.h"
 
 #include "external/utf8cpp/utf8.h"
@@ -184,17 +185,6 @@ public:
 
 	static void splitTextTokens(const UString &text, std::vector<UString> &tokens);
 
-	static uint32_t toLower(uint32_t c);
-	static uint32_t toUpper(uint32_t c);
-
-	static bool isASCII(uint32_t c); ///< Is the character an ASCII character?
-
-	static bool isSpace(uint32_t c); ///< Is the character an ASCII space character?
-	static bool isDigit(uint32_t c); ///< Is the character an ASCII digit character?
-	static bool isAlpha(uint32_t c); ///< Is the character an ASCII alphabetic character?
-	static bool isAlNum(uint32_t c); ///< Is the character an ASCII alphanumeric character?
-	static bool isCntrl(uint32_t c); ///< Is the character an ASCII control character?
-
 	static uint32_t fromUTF16(uint16_t c);
 
 private:
@@ -234,7 +224,7 @@ struct hashUStringCaseInsensitive {
 		size_t seed = 5381;
 
 		for (UString::iterator it = str.begin(); it != str.end(); ++it)
-			seed = ((seed << 5) + seed) + UString::toLower(*it);
+			seed = ((seed << 5) + seed) + String::toLower(*it);
 
 		return seed;
 	}

--- a/src/common/ustring.h
+++ b/src/common/ustring.h
@@ -185,8 +185,6 @@ public:
 
 	static void splitTextTokens(const UString &text, std::vector<UString> &tokens);
 
-	static uint32_t fromUTF16(uint16_t c);
-
 private:
 	std::string _string; ///< Internal string holding the actual data.
 

--- a/src/common/writestream.cpp
+++ b/src/common/writestream.cpp
@@ -92,8 +92,7 @@ size_t WriteStream::writeStream(ReadStream &stream) {
 }
 
 void WriteStream::writeString(const UString &str) {
-	if (write(str.c_str(), std::strlen(str.c_str())) != std::strlen(str.c_str()))
-		throw Exception(kWriteError);
+	writeChecked(str.c_str(), std::strlen(str.c_str()));
 }
 
 SeekableWriteStream::SeekableWriteStream() {

--- a/src/common/writestream.cpp
+++ b/src/common/writestream.cpp
@@ -91,8 +91,8 @@ size_t WriteStream::writeStream(ReadStream &stream) {
 	return writeStream(stream, 0xFFFFFFFF);
 }
 
-void WriteStream::writeString(const UString &str) {
-	writeChecked(str.c_str(), std::strlen(str.c_str()));
+void WriteStream::writeString(const char *str) {
+	writeChecked(str, std::strlen(str));
 }
 
 SeekableWriteStream::SeekableWriteStream() {

--- a/src/common/writestream.h
+++ b/src/common/writestream.h
@@ -77,6 +77,16 @@ public:
 	 */
 	virtual size_t write(const void *dataPtr, size_t dataSize) = 0;
 
+	/** Write data into the stream, throwing on error.
+	 *
+	 *  @param  dataPtr pointer to the data to be written.
+	 *  @param  dataSize number of bytes to be written.
+	 */
+	FORCEINLINE void writeChecked(const void *dataPtr, size_t dataSize) {
+		if (write(dataPtr, dataSize) != dataSize)
+			throw Exception(kWriteError);
+	}
+
 	/** Commit any buffered data to the underlying channel or
 	 *  storage medium; unbuffered streams can use the default
 	 *  implementation.
@@ -88,57 +98,47 @@ public:
 	// --- The following methods should generally not be overloaded ---
 
 	void writeByte(byte value) {
-		if (write(&value, 1) != 1)
-			throw Exception(kWriteError);
+		writeChecked(&value, 1);
 	}
 
 	void writeSByte(int8_t value) {
-		if (write(&value, 1) != 1)
-			throw Exception(kWriteError);
+		writeChecked(&value, 1);
 	}
 
 	void writeUint16LE(uint16_t value) {
 		value = TO_LE_16(value);
-		if (write(&value, 2) != 2)
-			throw Exception(kWriteError);
+		writeChecked(&value, 2);
 	}
 
 	void writeUint32LE(uint32_t value) {
 		value = TO_LE_32(value);
-		if (write(&value, 4) != 4)
-			throw Exception(kWriteError);
+		writeChecked(&value, 4);
 	}
 
 	void writeUint64LE(uint64_t value) {
 		value = TO_LE_64(value);
-		if (write(&value, 8) != 8)
-			throw Exception(kWriteError);
+		writeChecked(&value, 8);
 	}
 
 	void writeUint16BE(uint16_t value) {
 		value = TO_BE_16(value);
-		if (write(&value, 2) != 2)
-			throw Exception(kWriteError);
+		writeChecked(&value, 2);
 	}
 
 	void writeUint32BE(uint32_t value) {
 		value = TO_BE_32(value);
-		if (write(&value, 4) != 4)
-			throw Exception(kWriteError);
+		writeChecked(&value, 4);
 	}
 
 	void writeUint64BE(uint64_t value) {
 		value = TO_BE_64(value);
-		if (write(&value, 8) != 8)
-			throw Exception(kWriteError);
+		writeChecked(&value, 8);
 	}
 
 	/** Write n bytes of value to the stream. */
 	void writeBytes(byte value, size_t n) {
-		for (size_t i = 0; i < n; ++i) {
-			if (write(&value, 1) != 1)
-				throw Exception(kWriteError);
-		}
+		for (size_t i = 0; i < n; ++i)
+			writeChecked(&value, 1);
 	}
 
 	/** Write n zeros to the stream. */

--- a/src/common/writestream.h
+++ b/src/common/writestream.h
@@ -51,6 +51,7 @@
 #define COMMON_WRITESTREAM_H
 
 #include <cstddef>
+#include <string>
 
 #include "src/common/types.h"
 #include "src/common/endianness.h"
@@ -209,9 +210,21 @@ public:
 	 */
 	size_t writeStream(ReadStream &stream);
 
+	/** Write the given string to the stream, encoded as-is.
+	 *  No terminating zero byte is written. */
+	void writeString(const char *str);
+
+	/** Write the given string to the stream, encoded as-is.
+	 *  No terminating zero byte is written. */
+	FORCEINLINE void writeString(const std::string &str) {
+		writeChecked(str.c_str(), str.size());
+	}
+
 	/** Write the given string to the stream, encoded as UTF-8.
 	 *  No terminating zero byte is written. */
-	void writeString(const UString &str);
+	FORCEINLINE void writeString(const UString &str) {
+		writeString(str.c_str());
+	}
 };
 
 class SeekableWriteStream : public WriteStream {

--- a/src/engines/aurora/console.cpp
+++ b/src/engines/aurora/console.cpp
@@ -335,7 +335,7 @@ bool ConsoleWindow::setRedirect(Common::UString redirect) {
 	redirect = Common::FilePath::getUserDataFile(redirect);
 	if (!_redirect.open(redirect)) {
 		Common::UString error =
-			Common::UString::format("Failed opening file \"%s\" for writing.", redirect.c_str());
+			Common::String::format("Failed opening file \"%s\" for writing.", redirect.c_str());
 
 		print(error);
 		return false;
@@ -1560,7 +1560,7 @@ void Console::printList(const std::vector<Common::UString> &list, size_t maxSize
 	// Print a message when we cut items
 	if (linesCut > 0) {
 		Common::UString cutMsg =
-			Common::UString::format("(%u items cut due to history overflow)", (uint)linesCut);
+			Common::String::format("(%u items cut due to history overflow)", (uint)linesCut);
 
 		print(cutMsg);
 	}

--- a/src/engines/aurora/loadprogress.cpp
+++ b/src/engines/aurora/loadprogress.cpp
@@ -24,6 +24,7 @@
 
 #include <cassert>
 
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/graphics/graphics.h"
@@ -91,12 +92,12 @@ void LoadProgress::step(const Common::UString &description) {
 	const int    percentage  = (int) (_currentAmount * 100.0f);
 	const uint32_t timeElapsed = timeNow - _startTime;
 
-	const Common::UString timeStr = Common::UString::format("(%.2fs)", timeElapsed / 1000.0);
+	const Common::UString timeStr = Common::String::format("(%.2fs)", timeElapsed / 1000.0);
 
 	// Update the text
 	{
 		// Create string representing the percentage of done-ness and progress bar
-		const Common::UString percentStr = Common::UString::format("%d%%", percentage);
+		const Common::UString percentStr = Common::String::format("%d%%", percentage);
 		const Common::UString barStr     = createProgressbar(kBarLength, _currentAmount);
 
 		GfxMan.lockFrame();

--- a/src/engines/aurora/util.cpp
+++ b/src/engines/aurora/util.cpp
@@ -65,7 +65,7 @@ void playVideo(const Common::UString &video) {
 	SoundMan.setTypeGain(Sound::kSoundTypeVoice, 0.0f);
 
 	try {
-		Video::Aurora::VideoPlayer videoPlayer(video);
+		Video::Aurora::VideoPlayer videoPlayer(video.toString());
 
 		debugC(Common::kDebugEngineVideo, 1, "Playing video \"%s\"", video.c_str());
 

--- a/src/engines/dragonage/creature.cpp
+++ b/src/engines/dragonage/creature.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/util.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/maths.h"
 #include "src/common/error.h"
@@ -118,7 +119,7 @@ bool Creature::isPC() const {
 
 void Creature::createFakePC() {
 	_name.setString(LangMan.getCurrentLanguageText(), LangMan.getCurrentGender(), "Fakoo McFakeston");
-	_tag = Common::UString::format("[PC: %s]", _name.getString().c_str());
+	_tag = Common::String::format("[PC: %s]", _name.getString().c_str());
 
 	_isPC = true;
 

--- a/src/engines/dragonage/script/functions.cpp
+++ b/src/engines/dragonage/script/functions.cpp
@@ -27,6 +27,7 @@
 
 #include <functional>
 
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/aurora/nwscript/functionman.h"
@@ -95,7 +96,7 @@ void Functions::unimplementedFunction(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/dragonage/script/functions_string.cpp
+++ b/src/engines/dragonage/script/functions_string.cpp
@@ -236,7 +236,7 @@ void Functions::charToInt(Aurora::NWScript::FunctionContext &ctx) {
 	if (!str.empty())
 		c = *str.begin();
 
-	if (!Common::UString::isASCII(c))
+	if (!Common::String::isASCII(c))
 		c = 0;
 
 	ctx.getReturn() = (int32_t) c;

--- a/src/engines/dragonage/script/functions_string.cpp
+++ b/src/engines/dragonage/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -130,7 +131,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -138,7 +139,7 @@ void Functions::vectorToString(Aurora::NWScript::FunctionContext &ctx) {
 	float x, y, z;
 	ctx.getParams()[0].getVector(x, y, z);
 
-	ctx.getReturn() = Common::UString::format("%f %f %f", x, y, z);
+	ctx.getReturn() = Common::String::format("%f %f %f", x, y, z);
 }
 
 void Functions::resourceToString(Aurora::NWScript::FunctionContext &ctx) {
@@ -175,7 +176,7 @@ void Functions::toString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {

--- a/src/engines/dragonage2/creature.cpp
+++ b/src/engines/dragonage2/creature.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/util.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/maths.h"
 #include "src/common/error.h"
@@ -117,7 +118,7 @@ bool Creature::isPC() const {
 
 void Creature::createFakePC() {
 	_name.setString(LangMan.getCurrentLanguageText(), LangMan.getCurrentGender(), "Fakoo McFakeston");
-	_tag = Common::UString::format("[PC: %s]", _name.getString().c_str());
+	_tag = Common::String::format("[PC: %s]", _name.getString().c_str());
 
 	_isPC = true;
 

--- a/src/engines/dragonage2/script/functions.cpp
+++ b/src/engines/dragonage2/script/functions.cpp
@@ -27,6 +27,7 @@
 
 #include <functional>
 
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/aurora/nwscript/functionman.h"
@@ -95,7 +96,7 @@ void Functions::unimplementedFunction(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/dragonage2/script/functions_string.cpp
+++ b/src/engines/dragonage2/script/functions_string.cpp
@@ -236,7 +236,7 @@ void Functions::charToInt(Aurora::NWScript::FunctionContext &ctx) {
 	if (!str.empty())
 		c = *str.begin();
 
-	if (!Common::UString::isASCII(c))
+	if (!Common::String::isASCII(c))
 		c = 0;
 
 	ctx.getReturn() = (int32_t) c;

--- a/src/engines/dragonage2/script/functions_string.cpp
+++ b/src/engines/dragonage2/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -130,7 +131,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -138,7 +139,7 @@ void Functions::vectorToString(Aurora::NWScript::FunctionContext &ctx) {
 	float x, y, z;
 	ctx.getParams()[0].getVector(x, y, z);
 
-	ctx.getReturn() = Common::UString::format("%f %f %f", x, y, z);
+	ctx.getReturn() = Common::String::format("%f %f %f", x, y, z);
 }
 
 void Functions::resourceToString(Aurora::NWScript::FunctionContext &ctx) {
@@ -175,7 +176,7 @@ void Functions::toString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {

--- a/src/engines/jade/arealayout.cpp
+++ b/src/engines/jade/arealayout.cpp
@@ -113,7 +113,7 @@ void AreaLayout::updateCamera() {
 		if (camPointCount > 0) {
 			// Choose one at random.
 			int selectedCamPoint = RNG.getNext(0, camPointCount);
-			Common::UString camPoint = roomProps->getString(Common::UString::format("CamPoint%u", selectedCamPoint), "");
+			Common::UString camPoint = roomProps->getString(Common::String::format("CamPoint%u", selectedCamPoint), "");
 
 			std::vector<Common::UString> camPos;
 			Common::UString::split(camPoint, ' ', camPos);

--- a/src/engines/jade/creature.cpp
+++ b/src/engines/jade/creature.cpp
@@ -25,6 +25,7 @@
 #include "src/common/util.h"
 #include "src/common/maths.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/ustring.h"
 
 #include "src/aurora/2dafile.h"
@@ -194,7 +195,7 @@ void Creature::loadHead() {
 
 void Creature::createFakePC() {
 	_name = "Fakoo McFakeston";
-	_tag  = Common::UString::format("[PC: %s]", _name.c_str());
+	_tag  = Common::String::format("[PC: %s]", _name.c_str());
 
 	_isPC = true;
 }

--- a/src/engines/jade/gui/guibackground.cpp
+++ b/src/engines/jade/gui/guibackground.cpp
@@ -119,7 +119,7 @@ void GUIBackground::update() {
 }
 
 bool GUIBackground::tryBackground(int width, int height) {
-	Common::UString name = Common::UString::format("%ux%u%s", width, height, _type.c_str());
+	Common::UString name = Common::String::format("%ux%u%s", width, height, _type.c_str());
 	if (ResMan.hasResource(name, Aurora::kResourceImage)) {
 		_texture = TextureMan.get(name);
 

--- a/src/engines/jade/placeable.cpp
+++ b/src/engines/jade/placeable.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/aurora/gff3file.h"
@@ -221,10 +222,10 @@ int32_t Placeable::nextState(const Common::UString &input) {
 
 	const Aurora::GFF3Struct &inputs = top.getStruct("InputNames");
 	for (int i = 0;i < inputCount; i++) {
-		const Common::UString &inputKey = Common::UString::format("I%i", i);
+		const Common::UString &inputKey = Common::String::format("I%i", i);
 		const Common::UString &inputValue = inputs.getString(inputKey);
 		if (input == inputValue) {
-			const Common::UString &transKey = Common::UString::format("S%i_I%i", _state, i);
+			const Common::UString &transKey = Common::String::format("S%i_I%i", _state, i);
 			return trans.getSint(transKey);
 		}
 	}

--- a/src/engines/jade/script/functions.cpp
+++ b/src/engines/jade/script/functions.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/random.h"
+#include "src/common/string.h"
 
 #include "src/aurora/nwscript/functionman.h"
 #include "src/aurora/nwscript/util.h"
@@ -113,7 +114,7 @@ int32_t Functions::getRandom(int min, int max, int32_t n) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/jade/script/functions_object.cpp
+++ b/src/engines/jade/script/functions_object.cpp
@@ -23,6 +23,8 @@
  */
 
 #include <memory>
+
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/aurora/nwscript/functioncontext.h"
@@ -65,70 +67,70 @@ void Functions::getIsPC(Aurora::NWScript::FunctionContext &ctx) {
 
 void Functions::getLocalInt(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_INT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_INT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		ctx.getReturn() = object->getVariable(varName, kTypeInt).getInt();
 }
 
 void Functions::getLocalBool(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_BOOL_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_BOOL_%i", ctx.getParams()[1].getInt());
 	if (object)
 		ctx.getReturn() = object->getVariable(varName, kTypeInt).getInt() != 0;
 }
 
 void Functions::getLocalFloat(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_FLOAT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_FLOAT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		ctx.getReturn() = object->getVariable(varName, kTypeFloat).getFloat();
 }
 
 void Functions::getLocalString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_STRING_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_STRING_%i", ctx.getParams()[1].getInt());
 	if (object)
 		ctx.getReturn() = object->getVariable(varName, kTypeString).getString();
 }
 
 void Functions::getLocalObject(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_OBJECT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_OBJECT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		ctx.getReturn() = object->getVariable(varName, kTypeObject).getObject();
 }
 
 void Functions::setLocalInt(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_INT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_INT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		object->setVariable(varName, ctx.getParams()[2].getInt());
 }
 
 void Functions::setLocalBool(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_BOOL_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_BOOL_%i", ctx.getParams()[1].getInt());
 	if (object)
 		object->setVariable(varName, ctx.getParams()[2].getInt() != 0);
 }
 
 void Functions::setLocalFloat(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_FLOAT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_FLOAT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		object->setVariable(varName, ctx.getParams()[2].getFloat());
 }
 
 void Functions::setLocalString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_STRING_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_STRING_%i", ctx.getParams()[1].getInt());
 	if (object)
 		object->setVariable(varName, ctx.getParams()[2].getString());
 }
 
 void Functions::setLocalObject(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = getParamObject(ctx, 0);
-	Common::UString varName = Common::UString::format("LOCAL_OBJECT_%i", ctx.getParams()[1].getInt());
+	Common::UString varName = Common::String::format("LOCAL_OBJECT_%i", ctx.getParams()[1].getInt());
 	if (object)
 		object->setVariable(varName, ctx.getParams()[2].getObject());
 }

--- a/src/engines/jade/script/functions_string.cpp
+++ b/src/engines/jade/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -92,7 +93,7 @@ void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -118,7 +119,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {
@@ -247,7 +248,7 @@ void Functions::setCustomToken(Aurora::NWScript::FunctionContext &ctx) {
 	int32_t tokenNumber = ctx.getParams()[0].getInt();
 	const Common::UString &tokenValue = ctx.getParams()[1].getString();
 
-	const Common::UString tokenName = Common::UString::format("<CUSTOM%d>", tokenNumber);
+	const Common::UString tokenName = Common::String::format("<CUSTOM%d>", tokenNumber);
 
 	TokenMan.set(tokenName, tokenValue);
 }

--- a/src/engines/kotor/creature.cpp
+++ b/src/engines/kotor/creature.cpp
@@ -22,6 +22,7 @@
  *  Creature within an area in Star Wars: Knights of the Old Republic.
  */
 
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 
 #include "src/graphics/aurora/model.h"
@@ -198,7 +199,7 @@ void Creature::getPartModelsPC(PartModels &parts, uint32_t state, uint8_t textur
 
 	parts.portrait = "po_" + parts.head;
 	parts.portrait.replaceAll("0", "");
-	parts.bodyTexture += Common::UString::format("%02u", textureVariation);
+	parts.bodyTexture += Common::String::format("%02u", textureVariation);
 
 	loadMovementRate("PLAYER");
 }

--- a/src/engines/kotor/gui/ingame/container.cpp
+++ b/src/engines/kotor/gui/ingame/container.cpp
@@ -63,7 +63,7 @@ void ContainerMenu::fillFromInventory(const KotORBase::Inventory &inv) {
 			i != invItems.end(); ++i) {
 		try {
 			KotORBase::Item item(i->second.tag);
-			lbItems->addItem(Common::UString::format("%s|%s|%u",
+			lbItems->addItem(Common::String::format("%s|%s|%u",
 			                                         item.getName().c_str(),
 			                                         item.getIcon().c_str(),
 			                                         i->second.count));

--- a/src/engines/kotor/gui/ingame/menu_equ.cpp
+++ b/src/engines/kotor/gui/ingame/menu_equ.cpp
@@ -232,7 +232,7 @@ void MenuEquipment::fillEquipableItemsList() {
 					continue;
 			}
 
-			lbItems->addItem(Common::UString::format("%s|%s|%u",
+			lbItems->addItem(Common::String::format("%s|%s|%u",
 			                                         item.getName().c_str(),
 			                                         item.getIcon().c_str(),
 			                                         i.second.count));

--- a/src/engines/kotor/version.cpp
+++ b/src/engines/kotor/version.cpp
@@ -77,7 +77,7 @@ uint32_t Version::getVersionBuild() const {
 }
 
 Common::UString Version::getVersionString() const {
-	return Common::UString::format("%u.%02u.%u", _versionMajor, _versionMinor, _versionBuild);
+	return Common::String::format("%u.%02u.%u", _versionMajor, _versionMinor, _versionBuild);
 }
 
 uint16_t Version::getOptimumVersionMajor() const {
@@ -111,7 +111,7 @@ uint16_t Version::getOptimumVersionMinor() const {
 }
 
 Common::UString Version::getOptimumVersionString() {
-	return Common::UString::format("%u.%02u",
+	return Common::String::format("%u.%02u",
 			getOptimumVersionMajor(), getOptimumVersionMinor());
 }
 

--- a/src/engines/kotor2/creature.cpp
+++ b/src/engines/kotor2/creature.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 
 #include "src/engines/kotor2/creature.h"
@@ -144,7 +145,7 @@ void Creature::getPartModelsPC(PartModels &parts, uint32_t state, uint8_t textur
 
 	parts.portrait = "po_" + parts.head;
 	parts.portrait.replaceAll("0", "");
-	parts.bodyTexture += Common::UString::format("%02u", textureVariation);
+	parts.bodyTexture += Common::String::format("%02u", textureVariation);
 
 	loadMovementRate("PLAYER");
 }

--- a/src/engines/kotorbase/area.cpp
+++ b/src/engines/kotorbase/area.cpp
@@ -761,7 +761,7 @@ Object *Area::getActiveObject() {
 
 Object *Area::getObjectByTag(const Common::UString &tag) {
 	for (auto &object : _objects)
-		if (object->getTag().stricmp(tag) == 0)
+		if (tag.equalsIgnoreCase(object->getTag()))
 			return object.get();
 
 	return nullptr;

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -414,7 +414,7 @@ void Creature::getPartModels(PartModels &parts, uint32_t state, uint8_t textureV
 void Creature::loadBody(PartModels &parts) {
 	// Model "P_BastilaBB" has broken animations. Replace it with the
 	// correct one.
-	if (parts.body.stricmp("P_BastilaBB") == 0)
+	if (Common::String::equalsIgnoreCase(parts.body.c_str(), "P_BastilaBB"))
 		parts.body = "P_BastilaBB02";
 
 	GfxMan.lockFrame();

--- a/src/engines/kotorbase/creature.cpp
+++ b/src/engines/kotorbase/creature.cpp
@@ -385,7 +385,7 @@ void Creature::getPartModels(PartModels &parts, uint32_t state, uint8_t textureV
 
 	if (_modelType == "B") {
 		parts.body = appearance.getString(Common::UString("model") + state);
-		parts.bodyTexture = appearance.getString(Common::UString("tex") + state) + Common::UString::format("%02u", textureVariation);
+		parts.bodyTexture = appearance.getString(Common::UString("tex") + state) + Common::String::format("%02u", textureVariation);
 
 		// Fall back to a default texture variation
 		if (!ResMan.hasResource(parts.bodyTexture))
@@ -534,7 +534,7 @@ void Creature::attachWeaponModel(InventorySlot slot) {
 
 void Creature::initAsFakePC() {
 	_name = "Fakoo McFakeston";
-	_tag  = Common::UString::format("[PC: %s]", _name.c_str());
+	_tag  = Common::String::format("[PC: %s]", _name.c_str());
 
 	_isPC = true;
 }
@@ -788,7 +788,7 @@ void Creature::playDodgeAnimation() {
 
 	int number = getWeaponAnimationNumber();
 	if (number != -1)
-		_model->playAnimation(Common::UString::format("g%dg1", number));
+		_model->playAnimation(Common::String::format("g%dg1", number));
 }
 
 void Creature::playAnimation(const Common::UString &anim, bool restart, float length, float speed) {

--- a/src/engines/kotorbase/gui/dialog.cpp
+++ b/src/engines/kotorbase/gui/dialog.cpp
@@ -211,7 +211,7 @@ void DialogGUI::refresh() {
 		if (text.empty())
 			text = "[CONTINUE]";
 
-		text = Common::UString::format("%d. %s", index++, text.c_str());
+		text = Common::String::format("%d. %s", index++, text.c_str());
 		lbReplies->addItem(text);
 	}
 	lbReplies->refreshItemWidgets();

--- a/src/engines/kotorbase/gui/guibackground.cpp
+++ b/src/engines/kotorbase/gui/guibackground.cpp
@@ -130,7 +130,7 @@ void GUIBackground::update() {
 }
 
 bool GUIBackground::tryBackground(int width, int height) {
-	Common::UString name = Common::UString::format("%ux%u%s", width, height, _type.c_str());
+	Common::UString name = Common::String::format("%ux%u%s", width, height, _type.c_str());
 	if (ResMan.hasResource(name, Aurora::kResourceImage)) {
 		_texture = TextureMan.get(name);
 

--- a/src/engines/kotorbase/item.cpp
+++ b/src/engines/kotorbase/item.cpp
@@ -22,6 +22,8 @@
  *  Inventory item in KotOR games.
  */
 
+#include "src/common/string.h"
+
 #include "src/aurora/gff3file.h"
 #include "src/aurora/2dafile.h"
 #include "src/aurora/2dareg.h"
@@ -104,11 +106,11 @@ const Common::UString Item::getIcon() const {
 	int variation = (_modelVariation == 0) ? _textureVariation : _modelVariation;
 	if (variation == 0)
 		variation = 1;
-	return Common::UString::format("i%s_%03d", _itemClass.c_str(), variation);
+	return Common::String::format("i%s_%03d", _itemClass.c_str(), variation);
 }
 
 const Common::UString Item::getModelName() const {
-	return Common::UString::format("%s_%03d", _itemClass.c_str(), _modelVariation);
+	return Common::String::format("%s_%03d", _itemClass.c_str(), _modelVariation);
 }
 
 } // End of namespace KotORBase

--- a/src/engines/kotorbase/savedgame.cpp
+++ b/src/engines/kotorbase/savedgame.cpp
@@ -74,7 +74,7 @@ void SavedGame::fillFromSAV(const Aurora::ERFFile &erf, const Common::UString &m
 	for (Aurora::Archive::ResourceList::const_iterator it = resources.begin();
 			it != resources.end(); ++it) {
 		const Aurora::Archive::Resource &res = *it;
-		if (res.name.stricmp(moduleName) == 0 && res.type == Aurora::kFileTypeSAV) {
+		if (res.type == Aurora::kFileTypeSAV && res.name.equalsIgnoreCase(moduleName)) {
 			moduleSavIndex = res.index;
 			break;
 		}

--- a/src/engines/kotorbase/script/functions.cpp
+++ b/src/engines/kotorbase/script/functions.cpp
@@ -85,7 +85,7 @@ int32_t Functions::getRandom(int min, int max, int32_t n) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/kotorbase/script/functions_string.cpp
+++ b/src/engines/kotorbase/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -92,7 +93,7 @@ void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -118,7 +119,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {

--- a/src/engines/nwn/creature.cpp
+++ b/src/engines/nwn/creature.cpp
@@ -437,7 +437,7 @@ void Creature::constructPartName(const Common::UString &type, uint32_t id,
 		const Common::UString &gender, const Common::UString &race,
 		const Common::UString &phenoType, Common::UString &part) {
 
-	part = Common::UString::format("p%s%s%s_%s%03d",
+	part = Common::String::format("p%s%s%s_%s%03d",
 	       gender.c_str(), race.c_str(), phenoType.c_str(), type.c_str(), id);
 }
 
@@ -516,16 +516,16 @@ void Creature::getPartModels() {
 
 	Common::UString genderChar   = gender.getString("GENDER");
 	Common::UString raceChar     = raceAp.getString("RACE");
-	Common::UString phenoChar    = Common::UString::format("%d", _phenotype);
+	Common::UString phenoChar    = Common::String::format("%d", _phenotype);
 	Common::UString phenoAltChar = pheno.getString("DefaultPhenoType");
 
 	// Important to capture the supermodel
-	_partsSuperModelName = Common::UString::format("p%s%s%s",
+	_partsSuperModelName = Common::String::format("p%s%s%s",
 	                       genderChar.c_str(), raceChar.c_str(), phenoChar.c_str());
 
 	// Fall back to the default phenotype if required
 	if (!ResMan.hasResource(_partsSuperModelName, Aurora::kFileTypeMDL))
-		_partsSuperModelName = Common::UString::format("p%s%s%s",
+		_partsSuperModelName = Common::String::format("p%s%s%s",
 		                       genderChar.c_str(), raceChar.c_str(), phenoAltChar.c_str());
 
 	for (size_t i = 0; i < kBodyPartMAX; i++)
@@ -690,7 +690,7 @@ void Creature::loadCharacter(const Common::UString &bic, bool local) {
 	// Set the PC tag to something recognizable for now.
 	// Let's hope no script depends on it being "".
 
-	_tag = Common::UString::format("[PC: %s]", _name.c_str());
+	_tag = Common::String::format("[PC: %s]", _name.c_str());
 
 	_lastChangedGUIDisplay = EventMan.getTimestamp();
 }

--- a/src/engines/nwn/gui/ingame/dialog.cpp
+++ b/src/engines/nwn/gui/ingame/dialog.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/aurora/talkman.h"
 #include "src/aurora/ssffile.h"
@@ -361,7 +362,7 @@ void DialogBox::finishReplies() {
 		_replyLines.push_back(ReplyLine(r));
 
 		_replyLines.back().count =
-			new Graphics::Aurora::Text(_font, Common::UString::format("%d. ", ++_replyCount),
+			new Graphics::Aurora::Text(_font, Common::String::format("%d. ", ++_replyCount),
 			                           kLightBlueR, kLightBlueG, kLightBlueB);
 
 		_replyCountWidth = MAX(_replyCountWidth, _replyLines.back().count->getWidth());

--- a/src/engines/nwn/gui/ingame/partyleader.cpp
+++ b/src/engines/nwn/gui/ingame/partyleader.cpp
@@ -22,6 +22,7 @@
  *  The NWN ingame party leader panel.
  */
 
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/aurora/talkman.h"
@@ -163,7 +164,7 @@ void PartyLeader::callbackActive(Widget &widget) {
 
 void PartyLeader::updatePortraitTooltip() {
 	Common::UString tooltip =
-		Common::UString::format("%s %d/%d\n%s",
+		Common::String::format("%s %d/%d\n%s",
 				_name.c_str(), _currentHP, _maxHP, _area.c_str());
 
 	_portrait->setTooltip(tooltip);

--- a/src/engines/nwn/gui/ingame/quickbar.cpp
+++ b/src/engines/nwn/gui/ingame/quickbar.cpp
@@ -24,6 +24,7 @@
 
 #include "src/common/system.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 
 #include "src/graphics/graphics.h"
 
@@ -64,7 +65,7 @@ QuickbarButton::QuickbarButton(::Engines::GUI &gui, size_t n) : NWNWidget(gui, "
 	if (invisible)
 		invisible->setInvisible(true);
 
-	NWNWidget::setTag(Common::UString::format("Quickbar%u", (uint)_buttonNumber));
+	NWNWidget::setTag(Common::String::format("Quickbar%u", (uint)_buttonNumber));
 	_model->setTag(NWNWidget::getTag());
 
 }

--- a/src/engines/nwn/gui/main/charpremade.cpp
+++ b/src/engines/nwn/gui/main/charpremade.cpp
@@ -26,6 +26,7 @@
 
 #include "src/common/util.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 
 #include "src/events/requests.h"
 
@@ -209,7 +210,7 @@ void CharPremadeMenu::initCharacterList() {
 
 		ch.displayName = ch.name;
 		if (ch.number > 0)
-			ch.displayName += Common::UString::format(" (%u)", ch.number);
+			ch.displayName += Common::String::format(" (%u)", ch.number);
 	}
 
 	std::sort(_characters.begin(), _characters.end());

--- a/src/engines/nwn/gui/main/charpremade.cpp
+++ b/src/engines/nwn/gui/main/charpremade.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <cstdio>
+#include <cstring>
 
 #include "src/common/util.h"
 #include "src/common/error.h"
@@ -97,7 +98,7 @@ void WidgetListItemCharacter::setPosition(float x, float y, float z) {
 }
 
 bool CharPremadeMenu::Character::operator<(const Character &c) const {
-	int cmp = name.strcmp(c.name);
+	int cmp = std::strcmp(name.c_str(), c.name.c_str());
 
 	if (cmp < 0)
 		return true;

--- a/src/engines/nwn/gui/options/feedback.cpp
+++ b/src/engines/nwn/gui/options/feedback.cpp
@@ -24,6 +24,7 @@
 
 #include "src/common/util.h"
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/aurora/talkman.h"
 
@@ -129,7 +130,7 @@ void OptionsFeedbackMenu::updateTooltipDelay(uint32_t UNUSED(tooltipDelay)) {
 
 	const Common::UString secString   = TalkMan.getString(kStringSec);
 	const Common::UString ttDelayText =
-		Common::UString::format("%3.1f %s", ttDelay, secString.c_str());
+		Common::String::format("%3.1f %s", ttDelay, secString.c_str());
 
 	ttDelayLabel.setText(ttDelayText);
 }

--- a/src/engines/nwn/gui/options/resolution.cpp
+++ b/src/engines/nwn/gui/options/resolution.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/configman.h"
+#include "src/common/string.h"
 #include "src/common/util.h"
 
 #include "src/graphics/graphics.h"
@@ -139,7 +140,7 @@ void OptionsResolutionMenu::initResolutionsBox(WidgetListBox &resList) {
 	resList.clear();
 	for (std::vector<Graphics::Resolution>::const_iterator r = _useableResolutions.begin(); r != _useableResolutions.end(); ++r)
 		resList.add(new WidgetListItemTextLine(*this, "fnt_dialog16x16",
-					Common::UString::format("%dx%d", r->width, r->height), 0.0f));
+					Common::String::format("%dx%d", r->width, r->height), 0.0f));
 
 	resList.unlock();
 

--- a/src/engines/nwn/gui/options/sound.cpp
+++ b/src/engines/nwn/gui/options/sound.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/sound/sound.h"
 
@@ -168,7 +169,7 @@ void OptionsSoundMenu::updateVolume(double volume, Sound::SoundType type,
 	SoundMan.setTypeGain(type, volume);
 
 	if (!label.empty())
-		getLabel(label, true)->setText(Common::UString::format("%.0f%%", volume * 100.0f));
+		getLabel(label, true)->setText(Common::String::format("%.0f%%", volume * 100.0f));
 }
 
 void OptionsSoundMenu::adoptChanges() {

--- a/src/engines/nwn/gui/options/videoadv.cpp
+++ b/src/engines/nwn/gui/options/videoadv.cpp
@@ -25,6 +25,7 @@
 #include "src/common/util.h"
 #include "src/common/maths.h"
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/aurora/talkman.h"
 
@@ -155,7 +156,7 @@ void OptionsVideoAdvancedMenu::updateFSAALabel(int n) {
 	else if (n == 2)
 		text = TalkMan.getString(67542);
 	else
-		text = Common::UString::format("%dx %s", 1 << n, TalkMan.getString(67538).c_str());
+		text = Common::String::format("%dx %s", 1 << n, TalkMan.getString(67538).c_str());
 
 	getLabel("AntialiasLabel", true)->setText(text);
 }

--- a/src/engines/nwn/gui/widgets/listbox.cpp
+++ b/src/engines/nwn/gui/widgets/listbox.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/ustring.h"
 
 #include "src/graphics/graphics.h"
@@ -420,7 +421,7 @@ void WidgetListBox::add(WidgetListItem *item, bool noTag) {
 	item->_itemNumber = _items.size();
 
 	if (!noTag)
-		item->setTag(Common::UString::format("%s#Item%d", getTag().c_str(), (int)_items.size()));
+		item->setTag(Common::String::format("%s#Item%d", getTag().c_str(), (int)_items.size()));
 
 	for (std::vector<WidgetListItem *>::iterator i = _items.begin(); i != _items.end(); ++i) {
 		(*i)->addGroupMember(*item);

--- a/src/engines/nwn/gui/widgets/tooltip.cpp
+++ b/src/engines/nwn/gui/widgets/tooltip.cpp
@@ -26,6 +26,7 @@
 
 #include "src/common/util.h"
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/graphics/graphics.h"
 #include "src/graphics/font.h"
@@ -535,7 +536,7 @@ Common::UString Tooltip::getBubbleModel(uint32_t lines, float width) {
 	} else
 		modelWidth = 300;
 
-	return Common::UString::format("pnl_bubble%d_%d", modelLines, modelWidth);
+	return Common::String::format("pnl_bubble%d_%d", modelLines, modelWidth);
 }
 
 uint32_t Tooltip::getDefaultDelay() {

--- a/src/engines/nwn/script/functions.cpp
+++ b/src/engines/nwn/script/functions.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/random.h"
+#include "src/common/string.h"
 
 #include "src/aurora/nwscript/functionman.h"
 #include "src/aurora/nwscript/util.h"
@@ -113,7 +114,7 @@ int32_t Functions::getRandom(int min, int max, int32_t n) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/nwn/script/functions_string.cpp
+++ b/src/engines/nwn/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -92,7 +93,7 @@ void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -118,7 +119,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {
@@ -257,7 +258,7 @@ void Functions::setCustomToken(Aurora::NWScript::FunctionContext &ctx) {
 	int32_t tokenNumber = ctx.getParams()[0].getInt();
 	const Common::UString &tokenValue = ctx.getParams()[1].getString();
 
-	const Common::UString tokenName = Common::UString::format("<CUSTOM%d>", tokenNumber);
+	const Common::UString tokenName = Common::String::format("<CUSTOM%d>", tokenNumber);
 
 	TokenMan.set(tokenName, tokenValue);
 }

--- a/src/engines/nwn/tileset.cpp
+++ b/src/engines/nwn/tileset.cpp
@@ -97,7 +97,7 @@ void Tileset::loadGeneral(const Common::ConfigDomain &general) {
 }
 
 void Tileset::loadTile(const Common::ConfigFile &set, uint i, Tile &tile) {
-	Common::UString domainName = Common::UString::format("TILE%u", i);
+	Common::UString domainName = Common::String::format("TILE%u", i);
 	const Common::ConfigDomain *domain = set.getDomain(domainName);
 	if (!domain)
 		throw Common::Exception("Tileset has no \"%s\" domain", domainName.c_str());

--- a/src/engines/nwn/version.cpp
+++ b/src/engines/nwn/version.cpp
@@ -92,7 +92,7 @@ uint16_t Version::getVersionBuild() const {
 }
 
 Common::UString Version::getVersionString() const {
-	return Common::UString::format("%d.%d.%d", _versionMajor, _versionMinor, _versionBuild);
+	return Common::String::format("%d.%d.%d", _versionMajor, _versionMinor, _versionBuild);
 }
 
 uint64_t Version::getOptimumVersion() {
@@ -112,7 +112,7 @@ uint16_t Version::getOptimumVersionBuild() {
 }
 
 Common::UString Version::getOptimumVersionString() {
-	return Common::UString::format("%d.%d.%d",
+	return Common::String::format("%d.%d.%d",
 			kOptimumVersionMajor, kOptimumVersionMinor, kOptimumVersionBuild);
 }
 

--- a/src/engines/nwn2/area.cpp
+++ b/src/engines/nwn2/area.cpp
@@ -25,6 +25,7 @@
 #include "src/common/util.h"
 #include "src/common/error.h"
 #include "src/common/configman.h"
+#include "src/common/string.h"
 
 #include "src/aurora/gff3file.h"
 #include "src/aurora/2dafile.h"
@@ -440,7 +441,7 @@ void Area::loadTile(const Aurora::GFF3Struct &t, Tile &tile) {
 		Common::UString tileType = tiles.getRow(tile.tileID).getString("Tile_Type");
 		int             tileVar  = t.getUint("Variation") + 1;
 
-		tile.modelName = Common::UString::format("tl_%s_%s_%02d", tileSet.c_str(), tileType.c_str(), tileVar);
+		tile.modelName = Common::String::format("tl_%s_%s_%02d", tileSet.c_str(), tileType.c_str(), tileVar);
 	} else {
 		// "Meta tile". Spreads over the space of several normal tiles
 
@@ -449,7 +450,7 @@ void Area::loadTile(const Aurora::GFF3Struct &t, Tile &tile) {
 		Common::UString tileSet = metatiles.getRow(tile.tileID).getString("TileSet");
 		Common::UString name    = metatiles.getRow(tile.tileID).getString("Name");
 
-		tile.modelName = Common::UString::format("tl_%s_%s", tileSet.c_str(), name.c_str());
+		tile.modelName = Common::String::format("tl_%s_%s", tileSet.c_str(), name.c_str());
 	}
 }
 

--- a/src/engines/nwn2/creature.cpp
+++ b/src/engines/nwn2/creature.cpp
@@ -31,6 +31,7 @@
 #include "src/common/configman.h"
 #include "src/common/readfile.h"
 #include "src/common/random.h"
+#include "src/common/string.h"
 
 #include "src/aurora/types.h"
 #include "src/aurora/gff3file.h"
@@ -377,7 +378,7 @@ bool Creature::loadArmorModel(const Common::UString &body,
 	Common::UString armorPrefix = armorVisual.getString("Prefix");
 
 	Common::UString modelFile;
-	modelFile = Common::UString::format("%s_%s_%s%02d",
+	modelFile = Common::String::format("%s_%s_%s%02d",
 	                                     body.c_str(), armorPrefix.c_str(), armor.c_str(), variation + 1);
 
 	Graphics::Aurora::Model *model = loadModelObject(modelFile);
@@ -396,7 +397,7 @@ bool Creature::loadHeadModel(uint8_t appearance) {
 		return false;
 
 	Common::UString modelFile;
-	modelFile = Common::UString::format("%s%02d", head.c_str(), appearance);
+	modelFile = Common::String::format("%s%02d", head.c_str(), appearance);
 
 	Graphics::Aurora::Model *model = loadModelObject(modelFile);
 	if (model)
@@ -414,7 +415,7 @@ bool Creature::loadHairModel(uint8_t appearance) {
 		return false;
 
 	Common::UString modelFile;
-	modelFile = Common::UString::format("%s%02d", hair.c_str(), appearance);
+	modelFile = Common::String::format("%s%02d", hair.c_str(), appearance);
 
 	Graphics::Aurora::Model *model = loadModelObject(modelFile);
 	if (model)
@@ -500,7 +501,7 @@ void Creature::loadCharacter(const Common::UString &bic, bool local) {
 	// Set the PC tag to something recognizable for now.
 	// Let's hope no script depends on it being "".
 
-	_tag = Common::UString::format("[PC: %s]", _name.c_str());
+	_tag = Common::String::format("[PC: %s]", _name.c_str());
 }
 
 void Creature::load(const Aurora::GFF3Struct &instance, const Aurora::GFF3Struct *blueprint) {

--- a/src/engines/nwn2/script/functions.cpp
+++ b/src/engines/nwn2/script/functions.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/random.h"
+#include "src/common/string.h"
 
 #include "src/aurora/ltrfile.h"
 
@@ -121,7 +122,7 @@ void Functions::randomName(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/nwn2/script/functions_string.cpp
+++ b/src/engines/nwn2/script/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -92,7 +93,7 @@ void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -118,7 +119,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {

--- a/src/engines/nwn2/util.cpp
+++ b/src/engines/nwn2/util.cpp
@@ -22,6 +22,7 @@
  *  Neverwinter Nights 2 utility functions.
  */
 
+#include "src/common/string.h"
 #include "src/common/ustring.h"
 
 #include "src/aurora/gff3file.h"
@@ -43,7 +44,7 @@ bool readTint(const Aurora::GFF3Struct &gff, float t[3][4]) {
 	const Aurora::GFF3Struct &tint = tintable.getStruct("Tint");
 
 	for (int i = 0; i < 3; i++) {
-		Common::UString index = Common::UString::format("%d", i + 1);
+		Common::UString index = Common::String::format("%d", i + 1);
 		if (!tint.hasField(index))
 			continue;
 

--- a/src/engines/odyssey/listbox.cpp
+++ b/src/engines/odyssey/listbox.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "src/common/util.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 
 #include "src/aurora/gff3file.h"
@@ -127,7 +128,7 @@ void WidgetListBox::createItemWidgets(uint32_t count) {
 		return;
 
 	for (uint32_t i = 0; i < count; ++i) {
-		Common::UString tag = Common::UString::format("%s_ITEM_%u", _tag.c_str(), i);
+		Common::UString tag = Common::String::format("%s_ITEM_%u", _tag.c_str(), i);
 		WidgetProtoItem *item = createItemWidget(tag);
 		item->load(*_protoItem);
 

--- a/src/engines/sonic/console.cpp
+++ b/src/engines/sonic/console.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 
 #include "src/common/ustring.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 
 #include "src/aurora/gdafile.h"
@@ -73,7 +74,7 @@ void Console::updateAreas() {
 		if (areas.getInt(i, "Name") > 0) {
 			_areas.insert(i);
 
-			areaIDs.push_back(Common::UString::format("%u", (uint)i));
+			areaIDs.push_back(Common::String::format("%u", (uint)i));
 		}
 	}
 

--- a/src/engines/sonic/sonic.cpp
+++ b/src/engines/sonic/sonic.cpp
@@ -258,7 +258,7 @@ void SonicEngine::unloadLanguageFiles() {
 }
 
 void SonicEngine::loadLanguageFiles(LoadProgress &progress, Aurora::Language language) {
-	progress.step(Common::UString::format("Indexing language files (%s)",
+	progress.step(Common::String::format("Indexing language files (%s)",
 				LangMan.getLanguageName(language).c_str()));
 
 	loadLanguageFiles(language);

--- a/src/engines/witcher/nwscript/functions.cpp
+++ b/src/engines/witcher/nwscript/functions.cpp
@@ -29,6 +29,7 @@
 
 #include "src/common/util.h"
 #include "src/common/random.h"
+#include "src/common/string.h"
 
 #include "src/aurora/nwscript/functionman.h"
 #include "src/aurora/nwscript/util.h"
@@ -119,7 +120,7 @@ int32_t Functions::getRandom(int min, int max, int32_t n) {
 }
 
 Common::UString Functions::formatFloat(float f, int width, int decimals) {
-	return Common::UString::format("%*.*f", width, decimals, f);
+	return Common::String::format("%*.*f", width, decimals, f);
 }
 
 Aurora::NWScript::Object *Functions::getParamObject(const Aurora::NWScript::FunctionContext &ctx, size_t n) {

--- a/src/engines/witcher/nwscript/functions_string.cpp
+++ b/src/engines/witcher/nwscript/functions_string.cpp
@@ -26,6 +26,7 @@
 #include "src/common/ustring.h"
 #include "src/common/debug.h"
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/strutil.h"
 #include "src/common/datetime.h"
 
@@ -86,7 +87,7 @@ void Functions::printString(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 
 	status("Witcher: %s", ctx.getReturn().getString().c_str());
@@ -95,7 +96,7 @@ void Functions::printObject(Aurora::NWScript::FunctionContext &ctx) {
 void Functions::objectToString(Aurora::NWScript::FunctionContext &ctx) {
 	Aurora::NWScript::Object *object = ctx.getParams()[0].getObject();
 
-	ctx.getReturn() = Common::UString::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
+	ctx.getReturn() = Common::String::format("object<%s,%p)", Aurora::NWScript::formatTag(object).c_str(),
 	                                          static_cast<void *>(object));
 }
 
@@ -105,7 +106,7 @@ void Functions::printVector(Aurora::NWScript::FunctionContext &ctx) {
 
 	const bool prepend = ctx.getParams()[1].getInt() != 0;
 
-	ctx.getReturn() = Common::UString::format("%s%f, %f, %f", prepend ? "PRINTVECTOR:" : "", x, y, z);
+	ctx.getReturn() = Common::String::format("%s%f, %f, %f", prepend ? "PRINTVECTOR:" : "", x, y, z);
 
 	status("Witcher: %s", ctx.getReturn().getString().c_str());
 }
@@ -123,7 +124,7 @@ void Functions::floatToString(Aurora::NWScript::FunctionContext &ctx) {
 }
 
 void Functions::intToHexString(Aurora::NWScript::FunctionContext &ctx) {
-	ctx.getReturn() = Common::UString::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
+	ctx.getReturn() = Common::String::format("0x%08x", (uint32_t) ctx.getParams()[0].getInt());
 }
 
 void Functions::stringToInt(Aurora::NWScript::FunctionContext &ctx) {

--- a/src/engines/witcher/witcher.cpp
+++ b/src/engines/witcher/witcher.cpp
@@ -81,8 +81,8 @@ bool WitcherEngine::detectLanguages(Aurora::GameID UNUSED(game), const Common::U
 		for (size_t i = 0; i < Aurora::kLanguageMAX; i++) {
 			const uint32_t langID = LangMan.getLanguageID((Aurora::Language) i);
 
-			const Common::UString voiceKey = Common::UString::format("lang_%d.key"  , langID);
-			const Common::UString textKey  = Common::UString::format("dialog_%d.tlk", langID);
+			const Common::UString voiceKey = Common::String::format("lang_%d.key"  , langID);
+			const Common::UString textKey  = Common::String::format("dialog_%d.tlk", langID);
 
 			if (files.contains(voiceKey, true))
 				languagesVoice.push_back((Aurora::Language) i);
@@ -291,7 +291,7 @@ void WitcherEngine::unloadLanguageFiles() {
 void WitcherEngine::loadLanguageFiles(LoadProgress &progress,
 		Aurora::Language langText, Aurora::Language langVoice) {
 
-	progress.step(Common::UString::format("Indexing language files (%s text + %s voices)",
+	progress.step(Common::String::format("Indexing language files (%s text + %s voices)",
 				LangMan.getLanguageName(langText).c_str(), LangMan.getLanguageName(langVoice).c_str()));
 
 	loadLanguageFiles(langText, langVoice);
@@ -304,20 +304,20 @@ void WitcherEngine::loadLanguageFiles(Aurora::Language langText, Aurora::Languag
 	Common::UString archive;
 
 	_languageResources.push_back(Common::ChangeID());
-	archive = Common::UString::format("lang_%d.key", LangMan.getLanguageID(langVoice));
+	archive = Common::String::format("lang_%d.key", LangMan.getLanguageID(langVoice));
 	indexMandatoryArchive(archive, 100, &_languageResources.back());
 
 	// Voices for the first premium module (The Price of Neutrality)
 	_languageResources.push_back(Common::ChangeID());
-	archive = Common::UString::format("M1_%d.key", LangMan.getLanguageID(langVoice));
+	archive = Common::String::format("M1_%d.key", LangMan.getLanguageID(langVoice));
 	indexOptionalArchive(archive, 101, &_languageResources.back());
 
 	// Voices for the second premium module (Side Effects)
 	_languageResources.push_back(Common::ChangeID());
-	archive = Common::UString::format("M2_%d.key", LangMan.getLanguageID(langVoice));
+	archive = Common::String::format("M2_%d.key", LangMan.getLanguageID(langVoice));
 	indexOptionalArchive(archive, 102, &_languageResources.back());
 
-	archive = Common::UString::format("dialog_%d", LangMan.getLanguageID(langText));
+	archive = Common::String::format("dialog_%d", LangMan.getLanguageID(langText));
 	TalkMan.addTable(archive, "", false, 0, &_languageTLK);
 }
 

--- a/src/events/events.cpp
+++ b/src/events/events.cpp
@@ -324,7 +324,7 @@ Common::UString EventsManager::getTextInput(const Event &event) {
 		uint32_t sym = event.key.keysym.sym;
 
 		// Mask out control characters
-		if ((sym & SDLK_SCANCODE_MASK) || Common::UString::isCntrl(sym))
+		if ((sym & SDLK_SCANCODE_MASK) || Common::String::isCntrl(sym))
 			return "";
 
 		// Interpret this KeySym as an Unicode codepoint

--- a/src/graphics/aurora/abcfont.cpp
+++ b/src/graphics/aurora/abcfont.cpp
@@ -232,7 +232,7 @@ void ABCFont::calcCharVertices(Char &c) {
 }
 
 const ABCFont::Char &ABCFont::findChar(uint32_t c) const {
-	if (Common::UString::isASCII(c))
+	if (Common::String::isASCII(c))
 		return _ascii[c];
 
 	std::map<uint32_t, Char>::const_iterator ch = _extended.find(c);

--- a/src/graphics/aurora/abcfont.cpp
+++ b/src/graphics/aurora/abcfont.cpp
@@ -189,7 +189,7 @@ void ABCFont::load(const Common::UString &name) {
 		}
 
 		calcCharVertices(c);
-		_extended.insert(std::make_pair(Common::UString::fromUTF16((uint16_t) i), c));
+		_extended.insert(std::make_pair(Common::String::fromUTF16((uint16_t) i), c));
 	}
 }
 

--- a/src/graphics/aurora/fontman.cpp
+++ b/src/graphics/aurora/fontman.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "src/common/error.h"
+#include "src/common/string.h"
 #include "src/common/systemfonts.h"
 
 #include "src/graphics/aurora/fontman.h"
@@ -137,7 +138,7 @@ Common::UString FontManager::getIndexName(Common::UString name, int height) {
 		return name;
 
 	// If we have been given a height, the font is indexed with the height
-	return Common::UString::format("%s-%d", name.c_str(), height);
+	return Common::String::format("%s-%d", name.c_str(), height);
 }
 
 void FontManager::assign(FontHandle &font, const FontHandle &from) {

--- a/src/graphics/aurora/fps.cpp
+++ b/src/graphics/aurora/fps.cpp
@@ -22,6 +22,7 @@
  *  A text object displaying the current FPS.
  */
 
+#include "src/common/string.h"
 #include "src/common/system.h"
 #include "src/common/ustring.h"
 
@@ -57,7 +58,7 @@ void FPS::render(RenderPass pass) {
 	if (fps != _fps) {
 		_fps = fps;
 
-		setText(Common::UString::format("%d fps", _fps));
+		setText(Common::String::format("%d fps", _fps));
 	}
 
 	Text::render(pass);
@@ -69,7 +70,7 @@ void FPS::renderImmediate(const glm::mat4 &parentTransform) {
 	if (fps != _fps) {
 		_fps = fps;
 
-		setText(Common::UString::format("%d fps", _fps));
+		setText(Common::String::format("%d fps", _fps));
 	}
 
 	Text::renderImmediate(parentTransform);

--- a/src/graphics/aurora/model_jade.cpp
+++ b/src/graphics/aurora/model_jade.cpp
@@ -705,7 +705,7 @@ void ModelNode_Jade::readMaterialTextures(uint32_t materialID, std::vector<Commo
 		return;
 	}
 
-	Common::UString mabFile = Common::UString::format("%d", materialID);
+	Common::UString mabFile = Common::String::format("%d", materialID);
 	Common::SeekableReadStream *mab = ResMan.getResource(mabFile, ::Aurora::kFileTypeMAB);
 	if (!mab) {
 		textures.clear();

--- a/src/graphics/font.cpp
+++ b/src/graphics/font.cpp
@@ -117,7 +117,7 @@ float Font::split(const Common::UString &line, std::vector<Common::UString> &lin
 			if (c == '\r')
 				continue;
 
-			if (((c == '\n') || Common::UString::isSpace(c)) && !currentWord.empty()) {
+			if (((c == '\n') || Common::String::isSpace(c)) && !currentWord.empty()) {
 				// We can break and there's already something in the word buffer
 
 				if ((lineLength + wordLength) > maxWidth) {

--- a/src/sound/decoders/asf.cpp
+++ b/src/sound/decoders/asf.cpp
@@ -53,6 +53,7 @@
 #include "src/common/util.h"
 #include "src/common/error.h"
 #include "src/common/memreadstream.h"
+#include "src/common/string.h"
 
 #include "src/sound/audiostream.h"
 
@@ -84,7 +85,7 @@ public:
 	}
 
 	Common::UString toString() const {
-		return Common::UString::format("%02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x",
+		return Common::String::format("%02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x, %02x",
 				id[0], id[1], id[2], id[3], id[4], id[5], id[6], id[7], id[8], id[9], id[10], id[11], id[12], id[13], id[14], id[15]);
 	}
 

--- a/src/video/aurora/videoplayer.cpp
+++ b/src/video/aurora/videoplayer.cpp
@@ -26,7 +26,6 @@
 
 #include "src/common/util.h"
 #include "src/common/error.h"
-#include "src/common/ustring.h"
 #include "src/common/readstream.h"
 #include "src/common/debug.h"
 
@@ -48,14 +47,14 @@ namespace Video {
 
 namespace Aurora {
 
-VideoPlayer::VideoPlayer(const Common::UString &video) {
+VideoPlayer::VideoPlayer(const std::string &video) {
 	load(video);
 }
 
 VideoPlayer::~VideoPlayer() {
 }
 
-void VideoPlayer::load(const Common::UString &name) {
+void VideoPlayer::load(const std::string &name) {
 	::Aurora::FileType type;
 
 	std::unique_ptr<Common::SeekableReadStream>

--- a/src/video/aurora/videoplayer.h
+++ b/src/video/aurora/videoplayer.h
@@ -26,10 +26,7 @@
 #define VIDEO_AURORA_VIDEOPLAYER_H
 
 #include <memory>
-
-namespace Common {
-	class UString;
-}
+#include <string>
 
 namespace Video {
 
@@ -40,7 +37,7 @@ namespace Aurora {
 /** A video player. */
 class VideoPlayer {
 public:
-	VideoPlayer(const Common::UString &video);
+	VideoPlayer(const std::string &video);
 	~VideoPlayer();
 
 	void play();
@@ -48,7 +45,7 @@ public:
 private:
 	std::unique_ptr<VideoDecoder> _video;
 
-	void load(const Common::UString &name);
+	void load(const std::string &name);
 };
 
 } // End of namespace Aurora

--- a/src/video/matroska.cpp
+++ b/src/video/matroska.cpp
@@ -178,8 +178,7 @@ void readEBMLEntry(uint64_t &value, Common::SeekableReadStream &stream, uint64_t
 	}
 }
 
-template<typename T>
-void readEBMLString(T &value, Common::SeekableReadStream &stream) {
+void readEBMLEntry(std::string &value, Common::SeekableReadStream &stream, uint64_t UNUSED(filePos)) {
 	// Max 16MB for strings
 	if (stream.size() > 0x1000000)
 		throw Common::Exception("Invalid EBML string size %u", (uint)stream.size());
@@ -189,17 +188,9 @@ void readEBMLString(T &value, Common::SeekableReadStream &stream) {
 	stream.read(array.get(), stream.size());
 
 	// Treat the whole thing as a string
-	value = T(array.get(), stream.size());
+	value = std::string(array.get(), stream.size());
 
 	// TODO: May need to check for NUL character
-}
-
-void readEBMLEntry(std::string &value, Common::SeekableReadStream &stream, uint64_t UNUSED(filePos)) {
-	readEBMLString(value, stream);
-}
-
-void readEBMLEntry(Common::UString &value, Common::SeekableReadStream &stream, uint64_t UNUSED(filePos)) {
-	readEBMLString(value, stream);
 }
 
 void readEBMLEntry(double &value, Common::SeekableReadStream &stream, uint64_t UNUSED(filePos)) {
@@ -431,8 +422,8 @@ void readEBMLEntry(MatroskaSeekHead &seekHead, Common::SeekableReadStream &strea
 struct MatroskaInfo {
 	uint64_t timeCodeScale;
 	double duration;
-	Common::UString muxingApp;
-	Common::UString writingApp;
+	std::string muxingApp;
+	std::string writingApp;
 };
 
 void readEBMLEntry(MatroskaInfo &info, Common::SeekableReadStream &stream, uint64_t filePos) {

--- a/src/video/quicktime.cpp
+++ b/src/video/quicktime.cpp
@@ -718,7 +718,7 @@ bool QuickTimeDecoder::AudioSampleDesc::isAudioCodecSupported() const {
 		return true;
 
 	if (_codecTag == MKTAG('m', 'p', '4', 'a')) {
-		Common::UString audioType;
+		std::string audioType;
 
 		switch (_objectTypeMP4) {
 		case 0x40:
@@ -785,7 +785,7 @@ void QuickTimeDecoder::VideoSampleDesc::initCodec() {
 	_videoCodec.reset();
 
 	if (_codecTag == MKTAG('m', 'p', '4', 'v')) {
-		Common::UString videoType;
+		std::string videoType;
 
 		// Parse the object type
 		switch (_objectTypeMP4) {

--- a/tests/common/encoding_tests.h
+++ b/tests/common/encoding_tests.h
@@ -80,23 +80,17 @@ static void compareData(const byte *data1, const byte *data2, size_t n, size_t t
 GTEST_TEST(XOREOS_ENCODINGNAME, convertString) {
 	testSupport(kEncoding);
 
-	Common::MemoryReadStream *stream = 0;
-
-	stream = convertString(stringUString, kEncoding, false);
-	ASSERT_NE(stream, static_cast<Common::MemoryReadStream *>(0));
+	std::unique_ptr<Common::SeekableReadStream> stream = convertString(stringUString, kEncoding, false);
+	ASSERT_NE(stream.get(), nullptr);
 
 	EXPECT_EQ(stream->size(), stringBytes);
 	compareData(*stream, stringData0, stringBytes, 0);
 
-	delete stream;
-
 	stream = convertString(stringUString, kEncoding, true);
-	ASSERT_NE(stream, static_cast<Common::MemoryReadStream *>(0));
+	ASSERT_NE(stream.get(), nullptr);
 
 	EXPECT_EQ(stream->size(), sizeof(stringData0));
 	compareData(*stream, stringData0, sizeof(stringData0), 1);
-
-	delete stream;
 }
 
 GTEST_TEST(XOREOS_ENCODINGNAME, writeString) {

--- a/tests/common/rules.mk
+++ b/tests/common/rules.mk
@@ -245,3 +245,8 @@ check_PROGRAMS                                += tests/common/test_serialization
 tests_common_test_serializationstream_SOURCES  = tests/common/serializationstream.cpp
 tests_common_test_serializationstream_LDADD    = $(common_LIBS)
 tests_common_test_serializationstream_CXXFLAGS = $(test_CXXFLAGS)
+
+check_PROGRAMS                   += tests/common/test_string
+tests_common_test_string_SOURCES  = tests/common/string.cpp
+tests_common_test_string_LDADD    = $(common_LIBS)
+tests_common_test_string_CXXFLAGS = $(test_CXXFLAGS)

--- a/tests/common/string.cpp
+++ b/tests/common/string.cpp
@@ -53,3 +53,7 @@ GTEST_TEST(String, charClasses) {
 	EXPECT_TRUE (Common::String::isCntrl(0x10));
 	EXPECT_FALSE(Common::String::isCntrl('x'));
 }
+
+GTEST_TEST(String, fromUTF16) {
+	EXPECT_EQ(Common::String::fromUTF16(0x00F6), 0xF6);
+}

--- a/tests/common/string.cpp
+++ b/tests/common/string.cpp
@@ -1,0 +1,33 @@
+/* xoreos - A reimplementation of BioWare's Aurora engine
+ *
+ * xoreos is the legal property of its developers, whose names
+ * can be found in the AUTHORS file distributed with this source
+ * distribution.
+ *
+ * xoreos is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * xoreos is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with xoreos. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  Unit tests for our String functions.
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/common/string.h"
+
+GTEST_TEST(String, format) {
+	const std::string str = Common::String::format("%s|%s|%d", "Foo", "Bar", 23);
+
+	EXPECT_STREQ(str.c_str(), "Foo|Bar|23");
+}

--- a/tests/common/string.cpp
+++ b/tests/common/string.cpp
@@ -31,3 +31,25 @@ GTEST_TEST(String, format) {
 
 	EXPECT_STREQ(str.c_str(), "Foo|Bar|23");
 }
+
+GTEST_TEST(String, charClasses) {
+	EXPECT_TRUE (Common::String::isASCII('F'));
+	EXPECT_FALSE(Common::String::isASCII(0xF6));
+
+	EXPECT_TRUE (Common::String::isSpace(' '));
+	EXPECT_FALSE(Common::String::isSpace('x'));
+
+	EXPECT_TRUE (Common::String::isDigit('0'));
+	EXPECT_FALSE(Common::String::isDigit('x'));
+
+	EXPECT_TRUE (Common::String::isAlpha('x'));
+	EXPECT_FALSE(Common::String::isAlpha('.'));
+	EXPECT_FALSE(Common::String::isAlpha('0'));
+
+	EXPECT_TRUE (Common::String::isAlNum('x'));
+	EXPECT_TRUE (Common::String::isAlNum('0'));
+	EXPECT_FALSE(Common::String::isAlNum('.'));
+
+	EXPECT_TRUE (Common::String::isCntrl(0x10));
+	EXPECT_FALSE(Common::String::isCntrl('x'));
+}

--- a/tests/common/string.cpp
+++ b/tests/common/string.cpp
@@ -57,3 +57,33 @@ GTEST_TEST(String, charClasses) {
 GTEST_TEST(String, fromUTF16) {
 	EXPECT_EQ(Common::String::fromUTF16(0x00F6), 0xF6);
 }
+
+GTEST_TEST(String, compareIgnoreCase) {
+	struct TestCase {
+		const char *left;
+		const char *right;
+		int result;
+	};
+
+	static const TestCase testCases[] = {
+		{ "abc", "def", -1 },
+		{ "def", "abc", 1 },
+		{ "ABC", "def", -1 },
+		{ "abc", "DEF", -1 },
+		{ "QED", "qed", 0 },
+		{ "de", "defg", -1 },
+		{ "defg", "de", 1 }
+	};
+
+	for (const TestCase &testCase : testCases) {
+		int result = Common::String::compareIgnoreCase(testCase.left, testCase.right);
+
+		if (testCase.result == 0) {
+			EXPECT_EQ(result, 0);
+		} else if (testCase.result < 0) {
+			EXPECT_TRUE(result < 0);
+		} else {
+			EXPECT_TRUE(result > 0);
+		}
+	}
+}

--- a/tests/common/string.cpp
+++ b/tests/common/string.cpp
@@ -87,3 +87,27 @@ GTEST_TEST(String, compareIgnoreCase) {
 		}
 	}
 }
+
+GTEST_TEST(String, equalsIgnoreCase) {
+	struct TestCase {
+		const char *left;
+		const char *right;
+		bool isEqual;
+	};
+
+	static const TestCase testCases[] = {
+		{ "abc", "abc", true },
+		{ "abc", "def", false },
+		{ "def", "abc", false },
+		{ "ABC", "def", false },
+		{ "abc", "DEF", false },
+		{ "QED", "qed", true },
+		{ "de", "defg", false },
+		{ "defg", "de", false }
+	};
+
+	for (const TestCase &testCase : testCases) {
+		bool result = Common::String::equalsIgnoreCase(testCase.left, testCase.right);
+		EXPECT_EQ(result, testCase.isEqual);
+	}
+}

--- a/tests/common/ustring.cpp
+++ b/tests/common/ustring.cpp
@@ -520,28 +520,6 @@ GTEST_TEST(UString, splitTextTokens) {
 	EXPECT_STREQ(tokens[8].c_str(), "quux<token5");
 }
 
-GTEST_TEST(UString, charClasses) {
-	EXPECT_TRUE (Common::UString::isASCII('F'));
-	EXPECT_FALSE(Common::UString::isASCII(0xF6));
-
-	EXPECT_TRUE (Common::UString::isSpace(' '));
-	EXPECT_FALSE(Common::UString::isSpace('x'));
-
-	EXPECT_TRUE (Common::UString::isDigit('0'));
-	EXPECT_FALSE(Common::UString::isDigit('x'));
-
-	EXPECT_TRUE (Common::UString::isAlpha('x'));
-	EXPECT_FALSE(Common::UString::isAlpha('.'));
-	EXPECT_FALSE(Common::UString::isAlpha('0'));
-
-	EXPECT_TRUE (Common::UString::isAlNum('x'));
-	EXPECT_TRUE (Common::UString::isAlNum('0'));
-	EXPECT_FALSE(Common::UString::isAlNum('.'));
-
-	EXPECT_TRUE (Common::UString::isCntrl(0x10));
-	EXPECT_FALSE(Common::UString::isCntrl('x'));
-}
-
 GTEST_TEST(UString, fromUTF16) {
 	EXPECT_EQ(Common::UString::fromUTF16(0x00F6), 0xF6);
 }

--- a/tests/common/ustring.cpp
+++ b/tests/common/ustring.cpp
@@ -487,12 +487,6 @@ GTEST_TEST(UString, substr) {
 	EXPECT_STREQ(str.substr(it, str.end()).c_str(), "Barfoo");
 }
 
-GTEST_TEST(UString, format) {
-	const Common::UString str = Common::UString::format("%s|%s|%d", "Foo", "Bar", 23);
-
-	EXPECT_STREQ(str.c_str(), "Foo|Bar|23");
-}
-
 GTEST_TEST(UString, splitVector) {
 	const Common::UString str("Foobar Barfoo Quux");
 

--- a/tests/common/ustring.cpp
+++ b/tests/common/ustring.cpp
@@ -520,10 +520,6 @@ GTEST_TEST(UString, splitTextTokens) {
 	EXPECT_STREQ(tokens[8].c_str(), "quux<token5");
 }
 
-GTEST_TEST(UString, fromUTF16) {
-	EXPECT_EQ(Common::UString::fromUTF16(0x00F6), 0xF6);
-}
-
 GTEST_TEST(UString, append) {
 	Common::UString str("Foobar");
 


### PR DESCRIPTION
As has long been wanted, we want to switch from using `Common::UString` to using `std::string` everywhere. It's saner to do this in a piecemeal fashion rather than attempting to do this all at once.

This starts off some of the work to create a new set of `Common::String` utilities in `common/string.h` while doing a bit of other related cleanup.