### PR TITLE
AURORA: Add support for DA2 PS3 ERF LZMA decompression

### DIFF
--- a/src/aurora/erffile.h
+++ b/src/aurora/erffile.h
@@ -155,6 +155,7 @@ private:
 	enum Compression {
 		kCompressionNone           = 0, ///< No compression as all.
 		kCompressionBioWareZlib    = 1, ///< Compression using DEFLATE with an extra header byte.
+		kCompressionLZMA           = 2, ///< Compression using LZMA.
 		kCompressionHeaderlessZlib = 7, ///< Compression using DEFLATE with default parameters.
 		kCompressionStandardZlib   = 8  ///< Compression using DEFLATE, standard zlib chunk.
 	};
@@ -302,6 +303,9 @@ private:
 
 	Common::SeekableReadStream *decompressZlib(const byte *compressedData, uint32_t packedSize,
 	                                           uint32_t unpackedSize, int windowBits) const;
+
+	std::unique_ptr<Common::SeekableReadStream> decompressLZMA(std::unique_ptr<Common::SeekableReadStream> packedStream,
+	                                                           uint32_t unpackedSize) const;
 	// '---
 
 	const IResource &getIResource(uint32_t index) const;

--- a/src/common/lzma.h
+++ b/src/common/lzma.h
@@ -63,6 +63,18 @@ byte *decompressLZMA1(const byte *data, size_t inputSize, size_t outputSize, boo
  */
 SeekableReadStream *decompressLZMA1(ReadStream &input, size_t inputSize, size_t outputSize, bool noEndMarker = false);
 
+/** Decompress using the ERF LZMA algorithm.
+ *
+ *  @param  input      The compressed input data.
+ *  @param  inputSize  The size of the input data to read in bytes.
+ *  @param  outputSize The size of the decompressed output data.
+ *                     It is assumed that this information is known and that
+ *                     the whole decompressed data will fit into a buffer of
+ *                     this size.
+ *  @return A stream of the decompressed data.
+ */
+std::unique_ptr<SeekableReadStream> decompressERFLZMA(ReadStream &input, size_t inputSize, size_t outputSize);
+
 } // End of namespace Common
 
 #endif // ENABLE_LZMA

--- a/src/common/readstream.h
+++ b/src/common/readstream.h
@@ -88,14 +88,22 @@ public:
 	 */
 	virtual size_t read(void *dataPtr, size_t dataSize) = 0;
 
+	/** Read data from the stream, throwing on error.
+	 *
+	 *  @param  dataPtr pointer to a buffer into which the data is read.
+	 *  @param  dataSize number of bytes to be read.
+	 */
+	FORCEINLINE void readChecked(void *dataPtr, size_t dataSize) {
+		if (read(dataPtr, dataSize) != dataSize)
+			throw Exception(kReadError);
+	}
+
 	// --- The following methods should generally not be overloaded ---
 
 	/** Read an unsigned byte from the stream and return it. */
 	byte readByte() {
 		byte b;
-		if (read(&b, 1) != 1)
-			throw Exception(kReadError);
-
+		readChecked(&b, 1);
 		return b;
 	}
 
@@ -123,9 +131,7 @@ public:
 	 */
 	uint16_t readUint16LE() {
 		uint16_t val;
-		if (read(&val, 2) != 2)
-			throw Exception(kReadError);
-
+		readChecked(&val, 2);
 		return FROM_LE_16(val);
 	}
 
@@ -134,9 +140,7 @@ public:
 	 */
 	uint32_t readUint32LE() {
 		uint32_t val;
-		if (read(&val, 4) != 4)
-			throw Exception(kReadError);
-
+		readChecked(&val, 4);
 		return FROM_LE_32(val);
 	}
 
@@ -145,9 +149,7 @@ public:
 	 */
 	uint64_t readUint64LE() {
 		uint64_t val;
-		if (read(&val, 8) != 8)
-			throw Exception(kReadError);
-
+		readChecked(&val, 8);
 		return FROM_LE_64(val);
 	}
 
@@ -156,9 +158,7 @@ public:
 	 */
 	uint16_t readUint16BE() {
 		uint16_t val;
-		if (read(&val, 2) != 2)
-			throw Exception(kReadError);
-
+		readChecked(&val, 2);
 		return FROM_BE_16(val);
 	}
 
@@ -167,9 +167,7 @@ public:
 	 */
 	uint32_t readUint32BE() {
 		uint32_t val;
-		if (read(&val, 4) != 4)
-			throw Exception(kReadError);
-
+		readChecked(&val, 4);
 		return FROM_BE_32(val);
 	}
 
@@ -178,9 +176,7 @@ public:
 	 */
 	uint64_t readUint64BE() {
 		uint64_t val;
-		if (read(&val, 8) != 8)
-			throw Exception(kReadError);
-
+		readChecked(&val, 8);
 		return FROM_BE_64(val);
 	}
 


### PR DESCRIPTION
BioWare seems to have created their own (?) custom chunked LZMA format here, which at least seems minimal on top of LZMA1. This parses through that.

DA2 PS3 gets further along now, actually able to parse the initial room before failing to load any mesh (new format?).

This should be half of #335.