### PR TITLE
BUILD: Stop using boost::noncopyable

### DIFF
--- a/src/aurora/2dafile.h
+++ b/src/aurora/2dafile.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -58,9 +56,12 @@ class GDAFile;
  *
  *  See also class TwoDAFile.
  */
-class TwoDARow : boost::noncopyable {
+class TwoDARow {
 public:
 	~TwoDARow();
+
+	TwoDARow(const TwoDARow &) = delete;
+	TwoDARow &operator=(const TwoDARow &) = delete;
 
 	/** Return the contents of a cell as a string. */
 	const Common::UString &getString(size_t column) const;
@@ -119,11 +120,14 @@ private:
  *
  *  See also classes TwoDARow and TwoDARegistry.
  */
-class TwoDAFile : boost::noncopyable, public AuroraFile {
+class TwoDAFile : public AuroraFile {
 public:
 	TwoDAFile(Common::SeekableReadStream &twoda);
 	TwoDAFile(const GDAFile &gda);
 	~TwoDAFile();
+
+	TwoDAFile(const TwoDAFile &) = delete;
+	TwoDAFile &operator=(const TwoDAFile &) = delete;
 
 	/** Return the number of rows in the array. */
 	size_t getRowCount() const;

--- a/src/aurora/archive.h
+++ b/src/aurora/archive.h
@@ -27,8 +27,6 @@
 
 #include <list>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 #include "src/common/hash.h"
@@ -42,7 +40,7 @@ namespace Common {
 namespace Aurora {
 
 /** An abstract file archive. */
-class Archive : boost::noncopyable {
+class Archive {
 public:
 	/** A resource within the archive. */
 	struct Resource {
@@ -58,6 +56,9 @@ public:
 
 	Archive();
 	virtual ~Archive();
+
+	Archive(const Archive &) = delete;
+	Archive &operator=(const Archive &) = delete;
 
 	/** Return the list of resources. */
 	virtual const ResourceList &getResources() const = 0;

--- a/src/aurora/dlgfile.h
+++ b/src/aurora/dlgfile.h
@@ -27,8 +27,6 @@
 
 #include <vector>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -55,7 +53,7 @@ namespace NWScript {
 //       - "Emotion", "FacialAnim"
 //       - "Logic"
 
-class DLGFile : boost::noncopyable {
+class DLGFile {
 public:
 	static const uint32_t kEndLine     = 0xFFFFFFFE;
 	static const uint32_t kInvalidLine = 0xFFFFFFFF;
@@ -83,6 +81,9 @@ public:
 	/** Request this resource from the ResourceManager and read a DLG file out of it. */
 	DLGFile(const Common::UString &dlg, NWScript::Object *owner = 0, bool repairNWNPremium = false);
 	~DLGFile();
+
+	DLGFile(const DLGFile &) = delete;
+	DLGFile &operator=(const DLGFile &) = delete;
 
 	/** Does starting the conversation zoom in the camera onto the speaker or not? */
 	bool getNoZoomIn() const;

--- a/src/aurora/gdafile.h
+++ b/src/aurora/gdafile.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 #include "src/aurora/types.h"
@@ -59,7 +57,7 @@ namespace Aurora {
  *  identified by raw row index (since this index is now meaningless),
  *  but by an "ID" column.
  */
-class GDAFile : boost::noncopyable {
+class GDAFile {
 public:
 	static const size_t kInvalidColumn = SIZE_MAX;
 	static const size_t kInvalidRow    = SIZE_MAX;
@@ -87,6 +85,9 @@ public:
 	/** Take over this stream and read a GDA file out of it. */
 	GDAFile(Common::SeekableReadStream *gda);
 	~GDAFile();
+
+	GDAFile(const GDAFile &) = delete;
+	GDAFile &operator=(const GDAFile &) = delete;
 
 	/** Add another GDA with the same column structure to the bottom of this GDA.
 	 *

--- a/src/aurora/gff3file.h
+++ b/src/aurora/gff3file.h
@@ -29,8 +29,6 @@
 #include <map>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -81,13 +79,16 @@ class GFF3Struct;
  *  See also: GFF4File in gff4file.h for the later V4.0/V4.1 versions of
  *  the GFF format.
  */
-class GFF3File : boost::noncopyable, public AuroraFile {
+class GFF3File : public AuroraFile {
 public:
 	/** Take over this stream and read a GFF3 file out of it. */
 	GFF3File(Common::SeekableReadStream *gff3, uint32_t id = 0xFFFFFFFF, bool repairNWNPremium = false);
 	/** Request this resource from the ResourceManager and read a GFF3 file out of it. */
 	GFF3File(const Common::UString &gff3, FileType type, uint32_t id = 0xFFFFFFFF, bool repairNWNPremium = false);
 	virtual ~GFF3File();
+
+	GFF3File(const GFF3File &) = delete;
+	GFF3File &operator=(const GFF3File &) = delete;
 
 	/** Return the GFF3's specific type. */
 	uint32_t getType() const;

--- a/src/aurora/gff3writer.h
+++ b/src/aurora/gff3writer.h
@@ -30,8 +30,6 @@
 #include <memory>
 #include <variant>
 
-#include <boost/noncopyable.hpp>
-
 #ifdef BOOST_COMP_CLANG
 	#define GLM_LANG_STL11_FORCED // Fix clang glm c++11 bug
 #endif // BOOST_COMP_CLANG
@@ -52,10 +50,13 @@ class GFF3WriterList;
 typedef std::shared_ptr<GFF3WriterStruct> GFF3WriterStructPtr;
 typedef std::shared_ptr<GFF3WriterList> GFF3WriterListPtr;
 
-class GFF3Writer : boost::noncopyable {
+class GFF3Writer {
 public:
 	// TODO: Add a constructor consuming a GFF3File object.
 	GFF3Writer(uint32_t id, uint32_t version = MKTAG('V', '3', '.', '2'));
+
+	GFF3Writer(const GFF3Writer &) = delete;
+	GFF3Writer &operator=(const GFF3Writer &) = delete;
 
 	/** Get the top-level struct. */
 	GFF3WriterStructPtr getTopLevel();
@@ -137,7 +138,12 @@ private:
 	};
 
 	/** An implementation for a field. */
-	struct Field : boost::noncopyable {
+	struct Field {
+		Field() = default;
+
+		Field(const Field &) = delete;
+		Field &operator=(const Field &) = delete;
+
 		uint32_t labelIndex;
 		Value value;
 	};
@@ -165,9 +171,12 @@ private:
 };
 
 /** A GFF3 list containing GFF3 structs. */
-class GFF3WriterList : boost::noncopyable {
+class GFF3WriterList {
 public:
 	GFF3WriterList(GFF3Writer *parent);
+
+	GFF3WriterList(const GFF3WriterList &) = delete;
+	GFF3WriterList &operator=(const GFF3WriterList &) = delete;
 
 	/** Add a new struct to the list. */
 	GFF3WriterStructPtr addStruct();
@@ -192,9 +201,12 @@ private:
  *
  *  A field can be of any type, including list and struct.
  */
-class GFF3WriterStruct : boost::noncopyable {
+class GFF3WriterStruct {
 public:
 	GFF3WriterStruct(GFF3Writer *parent, uint32_t id = 0xFFFFFFFF);
+
+	GFF3WriterStruct(const GFF3WriterStruct &) = delete;
+	GFF3WriterStruct &operator=(const GFF3WriterStruct &) = delete;
 
 	/** Get ID of the struct. */
 	uint32_t getID() const;

--- a/src/aurora/gff4file.h
+++ b/src/aurora/gff4file.h
@@ -31,8 +31,6 @@
 
 #include "external/glm/mat4x4.hpp"
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/endianness.h"
 #include "src/common/ustring.h"
@@ -91,7 +89,7 @@ class GFF4Struct;
  *  See also: GFF3File in gff3file.h for the earlier V3.2/V3.3 versions of
  *  the GFF format.
  */
-class GFF4File : boost::noncopyable, public AuroraFile {
+class GFF4File : public AuroraFile {
 public:
 	/** Read a GFF4 file out of the stream. */
 	GFF4File(std::unique_ptr<Common::SeekableReadStream> gff4, uint32_t type = 0xFFFFFFFF);
@@ -100,6 +98,9 @@ public:
 	/** Request this resource from the ResourceManager and read a GFF4 file out of it. */
 	GFF4File(const Common::UString &gff4, FileType fileType, uint32_t type = 0xFFFFFFFF);
 	~GFF4File();
+
+	GFF4File(const GFF4File &) = delete;
+	GFF4File &operator=(const GFF4File &) = delete;
 
 	/** Return the GFF4's specific type. */
 	uint32_t getType() const;

--- a/src/aurora/ifofile.h
+++ b/src/aurora/ifofile.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -66,10 +64,13 @@ class GFF3Struct;
  *  Jade Empire does not use an IFO file. Neither do Sonic Chronicles or
  *  the two Dragon Age games.
  */
-class IFOFile : boost::noncopyable {
+class IFOFile {
 public:
 	IFOFile();
 	~IFOFile();
+
+	IFOFile(const IFOFile &) = delete;
+	IFOFile &operator=(const IFOFile &) = delete;
 
 	/** Take over this stream and load an IFO out of it.
 	 *

--- a/src/aurora/keyfile.h
+++ b/src/aurora/keyfile.h
@@ -27,8 +27,6 @@
 
 #include <vector>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -67,7 +65,7 @@ namespace Aurora {
  *  games (Baldur's Gate et al) are not supported at all, even though
  *  they claim to be V1.
  */
-class KEYFile : boost::noncopyable, public AuroraFile {
+class KEYFile : public AuroraFile {
 public:
 	/** A key resource index. */
 	struct Resource {
@@ -83,6 +81,9 @@ public:
 
 	KEYFile(Common::SeekableReadStream &key);
 	~KEYFile();
+
+	KEYFile(const KEYFile &) = delete;
+	KEYFile &operator=(const KEYFile &) = delete;
 
 	/** Return a list of all managed bifs. */
 	const BIFList &getBIFs() const;

--- a/src/aurora/talktable.h
+++ b/src/aurora/talktable.h
@@ -25,8 +25,6 @@
 #ifndef AURORA_TALKTABLE_H
 #define AURORA_TALKTABLE_H
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/encoding.h"
 
@@ -49,9 +47,12 @@ namespace Aurora {
  *  See classes TalkTable_TLK and TalkTable_GFF for the two main
  *  formats a talk table can be found in.
  */
-class TalkTable : boost::noncopyable {
+class TalkTable {
 public:
 	virtual ~TalkTable();
+
+	TalkTable(const TalkTable &) = delete;
+	TalkTable &operator=(const TalkTable &) = delete;
 
 	virtual bool hasEntry(uint32_t strRef) const = 0;
 

--- a/src/common/bitstream.h
+++ b/src/common/bitstream.h
@@ -27,8 +27,6 @@
 
 #include <cassert>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/disposableptr.h"
 #include "src/common/error.h"
@@ -82,7 +80,7 @@ protected:
  * from the data stream and hands out the bits in the order of LSB to MSB.
  */
 template<int valueBits, bool isLE, bool isMSB2LSB>
-class BitStreamImpl : boost::noncopyable, public BitStream {
+class BitStreamImpl : public BitStream {
 private:
 	DisposablePtr<SeekableReadStream> _stream; ///< The input stream.
 
@@ -146,8 +144,10 @@ public:
 			throw Exception("BitStream: Invalid memory layout %d, %d, %d", valueBits, isLE, isMSB2LSB);
 	}
 
-	~BitStreamImpl() {
-	}
+	~BitStreamImpl() = default;
+
+	BitStreamImpl(const BitStreamImpl &) = delete;
+	BitStreamImpl &operator=(const BitStreamImpl &) = delete;
 
 	/** Read a bit from the bit stream. */
 	uint32_t getBit() {

--- a/src/common/bitstreamwriter.h
+++ b/src/common/bitstreamwriter.h
@@ -27,8 +27,6 @@
 
 #include <cassert>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/disposableptr.h"
 #include "src/common/error.h"
@@ -67,7 +65,7 @@ protected:
  * the data stream, ordering the bits LSB to MSB.
  */
 template<int valueBits, bool isLE, bool isMSB2LSB>
-class BitStreamWriterImpl : boost::noncopyable, public BitStreamWriter {
+class BitStreamWriterImpl : public BitStreamWriter {
 private:
 	DisposablePtr<WriteStream> _stream; ///< The output stream.
 
@@ -127,8 +125,10 @@ public:
 			throw Exception("BitStreamWriter: Invalid memory layout %d, %d, %d", valueBits, isLE, isMSB2LSB);
 	}
 
-	~BitStreamWriterImpl() {
-	}
+	~BitStreamWriterImpl() = default;
+
+	BitStreamWriterImpl(const BitStreamWriterImpl& ) = delete;
+	BitStreamWriterImpl &operator=(const BitStreamWriterImpl &) = delete;
 
 	/** Write a bit to the bit stream. */
 	void putBit(bool bit) {

--- a/src/common/configfile.h
+++ b/src/common/configfile.h
@@ -31,8 +31,6 @@
 #include <list>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 #include "src/common/stringmap.h"
 
@@ -111,12 +109,15 @@ private:
  * Lines starting with a '#' are ignored (i.e. treated as comments).
  * Some effort is made to preserve comments, though.
  */
-class ConfigFile : boost::noncopyable {
+class ConfigFile {
 public:
 	typedef std::list<std::unique_ptr<ConfigDomain>> DomainList;
 
 	ConfigFile();
 	~ConfigFile();
+
+	ConfigFile(const ConfigFile &) = delete;
+	ConfigFile &operator=(const ConfigFile &) = delete;
 
 	/**
 	 * Check whether the given string is a valid section or key name.

--- a/src/common/dct.h
+++ b/src/common/dct.h
@@ -55,8 +55,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 namespace Common {
@@ -64,7 +62,7 @@ namespace Common {
 class RDFT;
 
 /** (Inverse) Discrete Cosine Transforms. */
-class DCT : boost::noncopyable {
+class DCT {
 public:
 	enum TransformType {
 		DCT_II,
@@ -75,6 +73,9 @@ public:
 
 	DCT(int bits, TransformType trans);
 	~DCT();
+
+	DCT(const DCT &) = delete;
+	DCT &operator=(const DCT &) = delete;
 
 	void calc(float *data);
 

--- a/src/common/disposableptr.h
+++ b/src/common/disposableptr.h
@@ -53,8 +53,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/system.h"
 #include "src/common/types.h"
 #include "src/common/deallocator.h"
@@ -67,13 +65,16 @@ namespace Common {
  *  through a deallocator template parameter.
  */
 template<typename T, class Deallocator>
-class DisposablePtrBase : boost::noncopyable {
+class DisposablePtrBase {
 public:
 	typedef T ValueType;
 	typedef T *PointerType;
 	typedef T &ReferenceType;
 
 	explicit DisposablePtrBase(PointerType o, bool d) : _pointer(o), _dispose(d) {}
+
+	DisposablePtrBase(const DisposablePtrBase &) = delete;
+	DisposablePtrBase &operator=(const DisposablePtrBase &) = delete;
 
 	/** Implicit conversion operator to bool for convenience, to make
 	 *  checks like "if (disposablePtr) ..." possible.

--- a/src/common/fft.h
+++ b/src/common/fft.h
@@ -55,8 +55,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 namespace Common {
@@ -64,10 +62,13 @@ namespace Common {
 struct Complex;
 
 /** (Inverse) Fast Fourier Transform. */
-class FFT : boost::noncopyable {
+class FFT {
 public:
 	FFT(int bits, bool inverse);
 	~FFT();
+
+	FFT(const FFT &) = delete;
+	FFT &operator=(const FFT &) = delete;
 
 	const uint16_t *getRevTab() const;
 

--- a/src/common/foxpro.h
+++ b/src/common/foxpro.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -40,7 +38,7 @@ class SeekableReadStream;
 class WriteStream;
 
 /** A database in FoxPro 2.0 format. */
-class FoxPro : boost::noncopyable {
+class FoxPro {
 public:
 	/** A field type. */
 	enum Type {
@@ -81,6 +79,9 @@ public:
 
 	FoxPro();
 	~FoxPro();
+
+	FoxPro(const FoxPro &) = delete;
+	FoxPro &operator=(const FoxPro &) = delete;
 
 	void load(SeekableReadStream *dbf, SeekableReadStream *cdx = 0,
 	          SeekableReadStream *fpt = 0);

--- a/src/common/mdct.h
+++ b/src/common/mdct.h
@@ -53,8 +53,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 namespace Common {
@@ -62,10 +60,13 @@ namespace Common {
 class FFT;
 
 /** (Inverse) Modified Discrete Cosine Transforms. */
-class MDCT : boost::noncopyable {
+class MDCT {
 public:
 	MDCT(int bits, bool inverse, double scale);
 	~MDCT();
+
+	MDCT(const MDCT &) = delete;
+	MDCT &operator=(const MDCT &) = delete;
 
 	/** Compute MDCT of size N = 2^nbits. */
 	void calcMDCT(float *output, const float *input);

--- a/src/common/memreadstream.h
+++ b/src/common/memreadstream.h
@@ -54,8 +54,6 @@
 #include <cstddef>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/disposableptr.h"
 #include "src/common/readstream.h"
@@ -65,7 +63,7 @@ namespace Common {
 /** Simple memory based 'stream', which implements the ReadStream interface for
  *  a plain memory block.
  */
-class MemoryReadStream : boost::noncopyable, public SeekableReadStream {
+class MemoryReadStream : public SeekableReadStream {
 public:
 	/** This constructor takes a pointer to a memory buffer and a length, and
 	 *  wraps it. If disposeMemory is true, the MemoryReadStream takes ownership
@@ -96,7 +94,10 @@ public:
 		_ptrOrig(std::move(dataPtr)), _ptr(_ptrOrig.get()), _size(dataSize), _pos(0), _eos(false) {
 	}
 
-	~MemoryReadStream() { }
+	~MemoryReadStream() = default;
+
+	MemoryReadStream(const MemoryReadStream &) = delete;
+	MemoryReadStream &operator=(const MemoryReadStream &) = delete;
 
 	size_t read(void *dataPtr, size_t dataSize);
 

--- a/src/common/memwritestream.h
+++ b/src/common/memwritestream.h
@@ -52,8 +52,6 @@
 
 #include <cstddef>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/disposableptr.h"
 #include "src/common/writestream.h"
@@ -65,10 +63,13 @@ namespace Common {
  *
  *  Writing past the size of the memory block will fail with an exception.
  */
-class MemoryWriteStream : boost::noncopyable, public SeekableWriteStream {
+class MemoryWriteStream : public SeekableWriteStream {
 public:
 	MemoryWriteStream(byte *buf, size_t len) : _ptr(buf), _bufSize(len), _pos(0) { }
-	~MemoryWriteStream() { }
+	~MemoryWriteStream() = default;
+
+	MemoryWriteStream(const MemoryWriteStream &) = delete;
+	MemoryWriteStream &operator=(const MemoryWriteStream &) = delete;
 
 	/** Template constructor to create a MemoryWriteStream around an array buffer. */
 	template<size_t N>
@@ -95,10 +96,13 @@ private:
  *
  *  As long as more memory can be allocated, writing into the stream won't fail.
  */
-class MemoryWriteStreamDynamic : boost::noncopyable, public SeekableWriteStream {
+class MemoryWriteStreamDynamic : public SeekableWriteStream {
 public:
 	MemoryWriteStreamDynamic(bool disposeMemory = false, size_t capacity = 0);
 	~MemoryWriteStreamDynamic();
+
+	MemoryWriteStreamDynamic(const MemoryWriteStreamDynamic &) = delete;
+	MemoryWriteStreamDynamic &operator=(const MemoryWriteStreamDynamic &) = delete;
 
 	void reserve(size_t s);
 

--- a/src/common/pe_exe.h
+++ b/src/common/pe_exe.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -99,10 +97,13 @@ enum PEResourceType {
  * A class able to load resources from a Windows Portable Executable, such
  * as cursors, bitmaps, and sounds.
  */
-class PEResources : boost::noncopyable {
+class PEResources {
 public:
 	PEResources(SeekableReadStream *exe);
 	~PEResources();
+
+	PEResources(const PEResources &) = delete;
+	PEResources &operator=(const PEResources &) = delete;
 
 	/** Return a list of resource types. */
 	const std::vector<PEResourceID> getTypeList() const;

--- a/src/common/rdft.h
+++ b/src/common/rdft.h
@@ -53,8 +53,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 namespace Common {
@@ -62,7 +60,7 @@ namespace Common {
 class FFT;
 
 /** (Inverse) Real Discrete Fourier Transform. */
-class RDFT : boost::noncopyable {
+class RDFT {
 public:
 	enum TransformType {
 		DFT_R2C,
@@ -73,6 +71,9 @@ public:
 
 	RDFT(int bits, TransformType trans);
 	~RDFT();
+
+	RDFT(const RDFT &) = delete;
+	RDFT &operator=(const RDFT &) = delete;
 
 	void calc(float *data);
 

--- a/src/common/readfile.h
+++ b/src/common/readfile.h
@@ -28,8 +28,6 @@
 #include <cstdio>
 #include <cstddef>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/readstream.h"
 
@@ -38,11 +36,14 @@ namespace Common {
 class UString;
 
 /** A simple streaming file reading class. */
-class ReadFile : boost::noncopyable, public SeekableReadStream {
+class ReadFile : public SeekableReadStream {
 public:
 	ReadFile();
 	ReadFile(const UString &fileName);
 	~ReadFile();
+
+	ReadFile(const ReadFile &) = delete;
+	ReadFile &operator=(const ReadFile &) = delete;
 
 	/** Try to open the file with the given fileName.
 	 *

--- a/src/common/semaphore.h
+++ b/src/common/semaphore.h
@@ -30,17 +30,18 @@ START_IGNORE_IMPLICIT_FALLTHROUGH
 #include <SDL_thread.h>
 STOP_IGNORE_IMPLICIT_FALLTHROUGH
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 namespace Common {
 
 /** A semaphore . */
-class Semaphore : boost::noncopyable {
+class Semaphore {
 public:
 	Semaphore(uint value = 0);
 	~Semaphore();
+
+	Semaphore(const Semaphore &) = delete;
+	Semaphore &operator=(const Semaphore &) = delete;
 
 	bool lock(uint32_t timeout = 0);
 	bool lockTry();

--- a/src/common/singleton.h
+++ b/src/common/singleton.h
@@ -50,18 +50,16 @@
 #ifndef COMMON_SINGLETON_H
 #define COMMON_SINGLETON_H
 
-#include <boost/noncopyable.hpp>
-
 namespace Common {
 
 /**
  * Generic template base class for implementing the singleton design pattern.
  */
 template<class T>
-class Singleton : boost::noncopyable {
+class Singleton {
 private:
-	Singleton<T>(const Singleton<T> &);
-	Singleton<T> &operator=(const Singleton<T> &);
+	Singleton<T>(const Singleton<T> &) = delete;
+	Singleton<T> &operator=(const Singleton<T> &) = delete;
 
 	static T *_singleton;
 

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -35,17 +35,18 @@
 
 #include <atomic>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 namespace Common {
 
 /** A class that creates its own thread. */
-class Thread : boost::noncopyable {
+class Thread {
 public:
 	Thread();
 	virtual ~Thread();
+
+	Thread(const Thread &) = delete;
+	Thread &operator=(const Thread &) = delete;
 
 	bool createThread(const UString &name = "");
 	bool destroyThread();

--- a/src/common/writefile.h
+++ b/src/common/writefile.h
@@ -28,8 +28,6 @@
 #include <cstdio>
 #include <cstddef>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/writestream.h"
 
@@ -38,11 +36,14 @@ namespace Common {
 class UString;
 
 /** A simple streaming file writing class. */
-class WriteFile : boost::noncopyable, public SeekableWriteStream {
+class WriteFile : public SeekableWriteStream {
 public:
 	WriteFile();
 	WriteFile(const UString &fileName);
 	~WriteFile();
+
+	WriteFile(const WriteFile &) = delete;
+	WriteFile &operator=(const WriteFile &) = delete;
 
 	/** Try to open the file with the given fileName.
 	 *

--- a/src/common/xml.h
+++ b/src/common/xml.h
@@ -35,8 +35,6 @@
 #include <map>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 struct _xmlNode;
@@ -53,7 +51,7 @@ void deinitXML();
 class XMLNode;
 
 /** Class to parse a ReadStream into a simple XML tree. */
-class XMLParser : boost::noncopyable {
+class XMLParser {
 public:
 	/** Parse an XML file out of a stream.
 	 *
@@ -64,6 +62,9 @@ public:
 	XMLParser(ReadStream &stream, bool makeLower = false, const UString &fileName = "stream.xml");
 	~XMLParser();
 
+	XMLParser(const XMLParser &) = delete;
+	XMLParser &operator=(const XMLParser &) = delete;
+
 	/** Return the XML root node. */
 	const XMLNode &getRoot() const;
 
@@ -71,9 +72,12 @@ private:
 	std::unique_ptr<XMLNode> _rootNode;
 };
 
-class XMLNode : boost::noncopyable {
+class XMLNode {
 public:
 	~XMLNode();
+
+	XMLNode(const XMLNode &) = delete;
+	XMLNode &operator=(const XMLNode &) = delete;
 
 	typedef std::map<UString, UString> Properties;
 	typedef std::list<std::unique_ptr<const XMLNode>> Children;

--- a/src/common/zipfile.h
+++ b/src/common/zipfile.h
@@ -30,8 +30,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -40,7 +38,7 @@ namespace Common {
 class SeekableReadStream;
 
 /** A class encapsulating ZIP file access. */
-class ZipFile : boost::noncopyable {
+class ZipFile {
 public:
 	/** A file. */
 	struct File {
@@ -52,6 +50,9 @@ public:
 
 	ZipFile(SeekableReadStream *zip);
 	~ZipFile();
+
+	ZipFile(const ZipFile &) = delete;
+	ZipFile &operator=(const ZipFile &) = delete;
 
 	/** Return the list of files. */
 	const FileList &getFiles() const;

--- a/src/engines/aurora/console.h
+++ b/src/engines/aurora/console.h
@@ -33,8 +33,6 @@
 #include <functional>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/error.h"
 #include "src/common/ustring.h"
@@ -196,10 +194,13 @@ private:
 	static size_t findWordEnd  (const Common::UString &line, size_t pos);
 };
 
-class Console : boost::noncopyable {
+class Console {
 public:
 	Console(Engine &engine, const Common::UString &font, int fontHeight = 0);
 	virtual ~Console();
+
+	Console(const Console &) = delete;
+	Console &operator=(const Console &) = delete;
 
 	void show();
 	void hide();

--- a/src/engines/aurora/gui.h
+++ b/src/engines/aurora/gui.h
@@ -28,8 +28,6 @@
 #include <list>
 #include <map>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 #include "src/events/types.h"
@@ -40,7 +38,7 @@ class Widget;
 class Console;
 
 /** A GUI. */
-class GUI : boost::noncopyable {
+class GUI {
 public:
 	static const uint32_t kStartCodeNone   = 0;
 	static const uint32_t kReturnCodeNone  = 0;
@@ -49,6 +47,9 @@ public:
 
 	GUI(Console *console = 0);
 	virtual ~GUI();
+
+	GUI(const GUI &) = delete;
+	GUI &operator=(const GUI &) = delete;
 
 	bool isVisible() const { return _visible; }
 

--- a/src/engines/aurora/loadprogress.h
+++ b/src/engines/aurora/loadprogress.h
@@ -27,8 +27,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 namespace Graphics {
@@ -39,7 +37,7 @@ namespace Graphics {
 
 namespace Engines {
 
-class LoadProgress : boost::noncopyable {
+class LoadProgress {
 public:
 	/** Create a load progress display.
 	 *
@@ -57,6 +55,9 @@ public:
 	 */
 	LoadProgress(size_t steps);
 	~LoadProgress();
+
+	LoadProgress(const LoadProgress &) = delete;
+	LoadProgress &operator=(const LoadProgress &) = delete;
 
 	/** Take a step in advancing the progress. */
 	void step(const Common::UString &description);

--- a/src/engines/aurora/widget.h
+++ b/src/engines/aurora/widget.h
@@ -27,8 +27,6 @@
 
 #include <list>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/ustring.h"
 
@@ -37,10 +35,13 @@ namespace Engines {
 class GUI;
 
 /** A widget in a GUI. */
-class Widget : boost::noncopyable {
+class Widget {
 public:
 	Widget(GUI &gui, const Common::UString &tag);
 	virtual ~Widget();
+
+	Widget(const Widget &) = delete;
+	Widget &operator=(const Widget &) = delete;
 
 	const Common::UString &getTag() const; ///< Get the widget's tag.
 

--- a/src/engines/engine.h
+++ b/src/engines/engine.h
@@ -27,8 +27,6 @@
 
 #include <vector>
 
-#include <boost/noncopyable.hpp>
-
 #include <memory>
 #include "src/common/ustring.h"
 
@@ -46,10 +44,13 @@ namespace Engines {
 class Console;
 
 /** The base class for an engine within BioWare's Aurora family. */
-class Engine : boost::noncopyable {
+class Engine {
 public:
 	Engine();
 	virtual ~Engine();
+
+	Engine(const Engine &) = delete;
+	Engine &operator=(const Engine &) = delete;
 
 	/** Detect which languages this game instance supports. */
 	virtual bool detectLanguages(Aurora::GameID game, const Common::UString &target,

--- a/src/engines/enginemanager.h
+++ b/src/engines/enginemanager.h
@@ -27,8 +27,6 @@
 
 #include <list>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/singleton.h"
 #include "src/common/ustring.h"
 
@@ -41,9 +39,12 @@ namespace Engines {
 
 class EngineProbe;
 
-class GameInstance : boost::noncopyable {
+class GameInstance {
 public:
 	virtual ~GameInstance();
+
+	GameInstance(const GameInstance &) = delete;
+	GameInstance &operator=(const GameInstance &) = delete;
 
 	virtual Common::UString getGameName(bool platform) const = 0;
 

--- a/src/engines/engineprobe.h
+++ b/src/engines/engineprobe.h
@@ -26,8 +26,6 @@
 #ifndef ENGINES_ENGINEPROBE_H
 #define ENGINES_ENGINEPROBE_H
 
-#include <boost/noncopyable.hpp>
-
 #include "src/aurora/types.h"
 
 namespace Common {
@@ -41,9 +39,13 @@ namespace Engines {
 class Engine;
 
 /** A probe able to detect one specific game. */
-class EngineProbe : boost::noncopyable {
+class EngineProbe {
 public:
-	virtual ~EngineProbe() {}
+	EngineProbe() = default;
+	virtual ~EngineProbe() = default;
+
+	EngineProbe(const EngineProbe &) = delete;
+	EngineProbe &operator=(const EngineProbe &) = delete;
 
 	/** Get the GameID that the probe is able to detect. */
 	virtual Aurora::GameID getGameID() const = 0;

--- a/src/events/joystick.h
+++ b/src/events/joystick.h
@@ -30,16 +30,17 @@ START_IGNORE_IMPLICIT_FALLTHROUGH
 #include <SDL_joystick.h>
 STOP_IGNORE_IMPLICIT_FALLTHROUGH
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/ustring.h"
 
 namespace Events {
 
-class Joystick : boost::noncopyable {
+class Joystick {
 public:
 	Joystick(int index);
 	virtual ~Joystick();
+
+	Joystick(const Joystick &) = delete;
+	Joystick &operator=(const Joystick &) = delete;
 
 	/** Return the joystick's name. */
 	const Common::UString &getName() const;

--- a/src/graphics/glcontainer.h
+++ b/src/graphics/glcontainer.h
@@ -25,17 +25,18 @@
 #ifndef GRAPHICS_GLCONTAINER_H
 #define GRAPHICS_GLCONTAINER_H
 
-#include <boost/noncopyable.hpp>
-
 #include "src/graphics/queueable.h"
 
 namespace Graphics {
 
 /** A container of OpenGL elements. */
-class GLContainer : boost::noncopyable, public Queueable {
+class GLContainer : public Queueable {
 public:
 	GLContainer();
 	~GLContainer();
+
+	GLContainer(const GLContainer &) = delete;
+	GLContainer &operator=(const GLContainer &) = delete;
 
 	void rebuild();
 	void destroy();

--- a/src/graphics/images/decoder.h
+++ b/src/graphics/images/decoder.h
@@ -28,8 +28,6 @@
 #include <vector>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 
 #include "src/graphics/types.h"
@@ -44,7 +42,7 @@ namespace Common {
 namespace Graphics {
 
 /** A generic interface for image decoders. */
-class ImageDecoder : boost::noncopyable {
+class ImageDecoder {
 public:
 	/** A mip map. */
 	struct MipMap {

--- a/src/graphics/renderable.h
+++ b/src/graphics/renderable.h
@@ -25,8 +25,6 @@
 #ifndef GRAPHICS_RENDERABLE_H
 #define GRAPHICS_RENDERABLE_H
 
-#include <boost/noncopyable.hpp>
-
 #include "external/glm/mat4x4.hpp"
 
 #include "src/common/ustring.h"
@@ -39,10 +37,13 @@
 namespace Graphics {
 
 /** An object that can be displayed by the graphics manager. */
-class Renderable : boost::noncopyable, public Queueable {
+class Renderable : public Queueable {
 public:
 	Renderable(RenderableType type);
 	~Renderable();
+
+	Renderable(const Renderable &) = delete;
+	Renderable &operator=(const Renderable &) = delete;
 
 	bool operator<(const Queueable &q) const;
 

--- a/src/sound/audiostream.h
+++ b/src/sound/audiostream.h
@@ -52,8 +52,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/util.h"
 #include "src/common/types.h"
 #include "src/common/disposableptr.h"
@@ -68,11 +66,15 @@ namespace Sound {
  * Generic audio input stream. Subclasses of this are used to feed arbitrary
  * sampled audio data into xoreos' SoundManager.
  */
-class AudioStream : boost::noncopyable {
+class AudioStream {
 public:
 	static const size_t kSizeInvalid = SIZE_MAX;
 
-	virtual ~AudioStream() {}
+	AudioStream() = default;
+	virtual ~AudioStream() = default;
+
+	AudioStream(const AudioStream &) = delete;
+	AudioStream &operator=(const AudioStream &) = delete;
 
 	/**
 	 * Fill the given buffer with up to numSamples samples. Returns the actual

--- a/src/sound/decoders/wwriffvorbis.cpp
+++ b/src/sound/decoders/wwriffvorbis.cpp
@@ -56,8 +56,6 @@
 
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include "src/common/types.h"
 #include "src/common/maths.h"
 #include "src/common/error.h"
@@ -78,12 +76,15 @@
 
 namespace Sound {
 
-class CodebookLibrary : boost::noncopyable {
+class CodebookLibrary {
 public:
 	CodebookLibrary(Common::SeekableReadStream &stream);
 	CodebookLibrary();
 
-	~CodebookLibrary() { }
+	~CodebookLibrary() = default;
+
+	CodebookLibrary(const CodebookLibrary &) = delete;
+	CodebookLibrary &operator=(const CodebookLibrary &) = delete;
 
 	void rebuild(size_t i, Common::BitStreamWriter &bos);
 	void rebuild(Common::BitStream &bis, size_t size, Common::BitStreamWriter &bos);

--- a/src/video/codecs/codec.h
+++ b/src/video/codecs/codec.h
@@ -25,8 +25,6 @@
 #ifndef VIDEO_CODECS_CODEC_H
 #define VIDEO_CODECS_CODEC_H
 
-#include <boost/noncopyable.hpp>
-
 namespace Common {
 	class SeekableReadStream;
 }
@@ -37,10 +35,13 @@ namespace Graphics {
 
 namespace Video {
 
-class Codec : boost::noncopyable {
+class Codec {
 public:
 	Codec();
 	virtual ~Codec();
+
+	Codec(const Codec &) = delete;
+	Codec &operator=(const Codec &) = delete;
 
 	virtual void decodeFrame(Graphics::Surface &surface, Common::SeekableReadStream &data) = 0;
 };


### PR DESCRIPTION
Replaces all uses with the `=delete` method of deleting the copy constructor and assignment operator.