### PR TITLE
Make CMake find SDL2 on Haiku

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -29,7 +29,7 @@ if(WIN32)
   find_library(SDL2_LIBRARY NAMES SDL2 PATHS $ENV{PROGRAMFILES}/SDL2/lib DOC "The SDL2 library")
 
 else(WIN32)
-  find_path(SDL2_INCLUDE_DIR SDL.h HINTS /usr/include/SDL2 /usr/local/include/SDL2 /opt/local/include/SDL2 /opt/homebrew/include/SDL2 DOC "The directory where SDL.h resides")
+  find_path(SDL2_INCLUDE_DIR SDL.h HINTS /usr/include/SDL2 /usr/local/include/SDL2 /opt/local/include/SDL2 /opt/homebrew/include/SDL2 /boot/system/develop/headers/SDL2 /boot/system/develop/headers/x86/SDL2 DOC "The directory where SDL.h resides")
   find_library(SDL2_LIBRARY NAMES SDL2 DOC "The SDL2 library")
 
 endif(WIN32)


### PR DESCRIPTION
A small tweak to the FindSDL2 file so CMake can find SDL2 on Haiku without user input. By @Begasus