### PR TITLE
Fix Race Condition for Animation Thread

### DIFF
--- a/src/graphics/aurora/animationthread.cpp
+++ b/src/graphics/aurora/animationthread.cpp
@@ -63,6 +63,7 @@ void AnimationThread::registerModel(Model *model) {
 }
 
 void AnimationThread::unregisterModel(Model *model) {
+	registerQueuedModels(); // in case the model to be unregistered is queued
 	if (_pause.load(std::memory_order_seq_cst) == kPausePaused) {
 		unregisterModelInternal(model);
 	} else {


### PR DESCRIPTION
This fixes [sigsev in the animation channel](https://github.com/xoreos/xoreos/blob/f36b681b2a38799ddd6fce0f252b6d7fa781dfc2/src/graphics/aurora/animationchannel.cpp#L167) caused by a scenario where a model is deleted while its animation is still in the animationthread queue.

To reproduce, start xoreos with Neverwinter Nights and skip all of the movies and loading screens by rapidly pressing the space bar.